### PR TITLE
Format author names for each emoji as an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,25 @@ If you would like to add your emojis to the website, you should follow this proc
 ```json
 {
   "codepoint": "U+1F63A",
-  "image": "smileycat.png",
-  "url": "https://u.cubeupload.com/zani/smileycat.png",
-  "author": "uwv"
+  "image": "grinning-cat.png",
+  "url": "https://assets.scratch.mit.edu/get_image/.%2E/f67743bb9153bd1b844b2651f6444c9c.svg",
+  "author": [
+    "uwv"
+  ]
 }
 ```
 Here's what you should put in those sections:
 * `codepoint`: Put the unicode codepoint of the emoji; if you can't find this, it's **not** an emoji!
 * `image`: The image path relative to `/resources/forumoji`.
-* `url`: The image path, hosted online on either [Cubeupload](https://cubeupload.com) or assets.scratch.mit.edu
-* `author`: The author(s). If multiple authors, put them after newlines (`\n`). For example:
+* `url`: The image path, hosted online on either [Cubeupload](https://cubeupload.com) or assets.scratch.mit.edu.
+* `author`: The author(s), formatted as an array. If multiple authors, put them on separate lines, and add a comma after all but the last one.
 ```json
-"author": "authorOne\nauthorTwo"
+"author": [
+  "authorOne",
+  "authorTwo"
+]
 ```
-Remember to add a comma after the old last item in the list, and *don't* add one after the new last item.
+Remember to add a comma after the each new item in the list, but *don't* add one after the last new item.
 
 ## Scratch Topic
 Forumoji has a [topic on the Scratch Forums](https://scratch.mit.edu/discuss/topic/557083/); this is where most discussion about the project takes place, including important updates from @lopste. Some contributors may opt to post their emojis on Scratch first before contributing them here.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here's what you should put in those sections:
 * `codepoint`: Put the unicode codepoint of the emoji; if you can't find this, it's **not** an emoji!
 * `image`: The image path relative to `/resources/forumoji`.
 * `url`: The image path, hosted online on either [Cubeupload](https://cubeupload.com) or assets.scratch.mit.edu.
-* `author`: The author(s), formatted as an array. If multiple authors, put them on separate lines, and add a comma after all but the last one.
+* `author`: The author(s), formatted as an array. If multiple authors, put them on separate lines, and add a comma after each one *except* for the last one.
 ```json
 "author": [
   "authorOne",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here's what you should put in those sections:
 * `codepoint`: Put the unicode codepoint of the emoji; if you can't find this, it's **not** an emoji!
 * `image`: The image path relative to `/resources/forumoji`.
 * `url`: The image path, hosted online on either [Cubeupload](https://cubeupload.com) or assets.scratch.mit.edu.
-* `author`: The author(s), formatted as an array. If multiple authors, put them on separate lines, and add a comma after each one *except* for the last one.
+* `author`: The author(s), formatted as an array. If there are multiple authors, put them on separate lines, and add a comma after each name *except* the last one.
 ```json
 "author": [
   "authorOne",

--- a/resources/forumoji.json
+++ b/resources/forumoji.json
@@ -18,6313 +18,8456 @@
       "codepoint": "U+1F170",
       "image": "blood-type-a.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7a4261d4ea09ed457946fe6b319ac89f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F171",
       "image": "blood-type-b.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6ee21d804c29cfcfae230117934b4f18.svg",
-      "author": "lolecksdeehaha\nstickfiregames"
+      "author": [
+        "lolecksdeehaha",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F18E",
       "image": "blood-type-ab.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8433cf8d7e4524d4fbe851b6e002c512.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F17E",
       "image": "blood-type-o.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a5b008c16411781db0a97ccbdabccf02.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F191",
       "image": "button-cl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e64cdb647df17a8dbd48262a04fa574d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4CA",
       "image": "bar-chart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4b209ab7a07fec3ad38ae0ddbf352ea3.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4C8",
       "image": "chart-increasing.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d153e34b9c9b7a75a3b512cade6dd541.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4C9",
       "image": "chart-decreasing.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bde79f3ae5417acfdd9f68152f4ac967.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+2611",
       "image": "checkboxwithcheck.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7e639e6ac1e2264a4fe2142560391b7d.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+2705",
       "image": "checkbutton.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4ebf7dd27947adb97afe67fb19685b8c.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+2714",
       "image": "check.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3b3d810e154d9876718b9937c51df463.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+274C",
       "image": "crossbutton.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3a140e79fe9ce663e9a8dd5255fc0855.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+274E",
       "image": "cross.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bf73558a8e907549278b1799326ab11f.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F611",
       "image": "expressionlessface.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fd11cb3b1a1a9c8b9fd8c3a5a4a26e04.svg",
-      "author": "kccuber"
+      "author": [
+        "kccuber"
+      ]
     },
     {
       "codepoint": "U+1F41F",
       "image": "fish.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c44ef3d0168b0d6f65515df61bcd9ccf.png",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F636",
       "image": "no-mouth.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/98cacd6d8fa9ed4f25e392d01f037676.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F62C",
       "image": "grimacing-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/db8d363f3d9bce06d3454b51daba7eae.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F977",
       "image": "ninja.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7f0116a5f5d3bdd0b91d9ddc063861b2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F614",
       "image": "pensive.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c7669de0a8d11deffb4bdb5ebea74493.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F97A",
       "image": "pleadingface.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4225f13401f3831e499fb2a2ea49adf0.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F914",
       "image": "thinking-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1ebfa724bf2b7fdd81b8878ccf377daf.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F643",
       "image": "upside-down-slightly-smiling-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/31f3ce68ad56a5d7ab71ce026eda1be2.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F92E",
       "image": "vomitingface.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/540a0f42e0408b7dbd122c79f7039abe.svg",
-      "author": "rayli1123"
+      "author": [
+        "rayli1123"
+      ]
     },
     {
       "codepoint": "U+1F910",
       "image": "zipper-mouth-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0ec593cd34156fbae79b7a8466aed924.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F44D",
       "image": "thumbs-up.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/26a731fe60b4825854fb91b3c93632d6.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F44E",
       "image": "thumbs-down.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c26b881dea788cca3142f5a267982df6.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4AF",
       "image": "100-points.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/63193df0977678a98294f8eaf129906e.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+2728",
       "image": "sparkles.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4d5bf5fb890aa1fa3bd68cab28f78d46.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+2600",
       "image": "sun.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ee9ae334837d5babd78ad10803fdd957.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+2601",
       "image": "cloud.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3a94b191a7d981e0b8cbb8485423bae9.svg",
-      "author": "kccuber"
+      "author": [
+        "kccuber"
+      ]
     },
     {
       "codepoint": "U+1F333",
       "image": "deciduoustree.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ab03ffbc5cf2e288f2fbddce696e62f4.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F30D",
       "image": "earth-globe-showing-europe-africa.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b120482e7f4ca1d71036689afb4e45d0.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F30F",
       "image": "earth-globe-showing-asia-australia.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/567587c641abb47a29b0c2d732fb0f3d.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F30E",
       "image": "earth-globe-showing-americas.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/88a94a4d31b7a833d1a30ecfb4615130.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F389",
       "image": "party-popper.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b20db5fa8a40570f586e4f98a3a8fad6.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F967",
       "image": "pie.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/14735b661718a532ee3f693e24f0c0d7.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F357",
       "image": "turkeyleg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c28e1c10706ba5582fc1cf2b8dbaba1e.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F983",
       "image": "turkey.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/69f87156f459aebf4c6fb729c049e762.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+26AB",
       "image": "black-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f48a20c793cde4d303a6cd93d81e54e8.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+2B1B",
       "image": "black-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e61169a8e85c7f35360c1da75482270a.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+25FC",
       "image": "black-medium-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8d1b28d0f74996879225139a8dece5bb.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+25FE",
       "image": "black-medium-small-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/00b79a6f28ba03c599acb32845101322.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+25AA",
       "image": "black-small-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/184948a257dfb1b2273065bff86024a4.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+26AA",
       "image": "white-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3c8a6414c0975f9f0577628921a83307.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+2B1C",
       "image": "white-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4b338eac5cc64ba3a298eeb90be8ed62.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+25FB",
       "image": "white-medium-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7e339e1531cf570b1019ea4ec4a8992d.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+25FD",
       "image": "white-medium-small-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/37a871b9de5d647025532ce0fe187c92.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+25AB",
       "image": "white-small-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6b07502658623a77adce79f417122ccc.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F534",
       "image": "red-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3fbc526179ee046cb66807453932ca1c.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E5",
       "image": "red-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b2568932244ac6fe57b23897afb65052.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E0",
       "image": "orange-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9ea0fe012f7cf0b7475d8f141691c9c4.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E7",
       "image": "orange-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9a0bbe090fefe8df36848e96d1628761.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E1",
       "image": "yellow-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/266127ea5b3463df6e6233bf2a209696.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E8",
       "image": "yellow-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d7a7ee53040e5cae227773a088b83a4d.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E2",
       "image": "green-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bddd41c8f0dd07168d07083cf41883c9.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E9",
       "image": "green-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8caf712c29e7d0d3d579205834213989.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F535",
       "image": "blue-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c94598a40b07c2d623cb3e9f48be907c.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E6",
       "image": "blue-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/94ef146ad4472f8754914d253c416b24.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F7E3",
       "image": "purple-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9e497ad85a14b35c07cc6f6827d94b11.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F7EA",
       "image": "purple-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/61411c4ddede532ef02d83bcb37e616f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F7E4",
       "image": "brown-circle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3645c6f94a63bfdeac3f8938fffbdf73.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F7EB",
       "image": "brown-square.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a6d9fd3a34b3731fc26aa765ecd7defc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F536",
       "image": "large-orange-diamond.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9453a2c38669e101d9e4e8415b50281b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F537",
       "image": "large-blue-diamond.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bdc94c5daa7c4d7a972c6f68dcae662c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F538",
       "image": "small-orange-diamond.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cb9fe769c8fcee8328a855fa784a2047.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F539",
       "image": "small-blue-diamond.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2cd72630a7fed3ca88d431c00f58ecdf.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F53A",
       "image": "red-triangle-pointed-up.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4ec1cc2f99eb7947397091e80d694ba2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F53B",
       "image": "red-triangle-pointed-down.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/13b4aa0cb901e1e555505b54ff4773b2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F916",
       "image": "robotface.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7eb5ffffb625cab5cdb70770e7e86b32.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F34C",
       "image": "banana.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/977f0bfcb8f0b35775f65ca451c61523.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1FAD0",
       "image": "blueberries.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1c8b946eb584e9755a62b1c0b28d569c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F347",
       "image": "grapes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a5652cdb05cf81c23829e3f9dc46ce2c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F34F",
       "image": "green-apple.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6b910d5a3c9458526b92fd0e8692189d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F34E",
       "image": "red-apple.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e69e011da3a2981601cbb0efc3a901f8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F34B",
       "image": "lemon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/128c947fc730d9067e37a9e9decb2df2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F350",
       "image": "pear.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/84dcd9f59f0334e0a1ebaf285306efec.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F353",
       "image": "strawberry.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/95587658be4c1dd52758c8db9f9d22ae.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F34A",
       "image": "tangerine.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c3c6409fa898767055c748d80e74d473.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F349",
       "image": "watermelon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/66bd80d982a4c7e4502500ff06914c4c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F951",
       "image": "avocado.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/71c267e45a4d17d70409a10e03cc6063.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F352",
       "image": "cherries.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/deb610d431c6adfa46cc6db9eaf4c4df.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F965",
       "image": "coconut.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9b2a0e8ae1d206a4106ca8cd392b19b8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F95D",
       "image": "kiwi-fruit.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f1017d02027a74d2f3ec89f85b0c30a6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F96D",
       "image": "mango.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/194ff60e3fac5368a0584835e913b03a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F348",
       "image": "melon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/82f05544bc0c069002777ddc289904ca.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F34D",
       "image": "pineapple.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3ce31a6738fac0cafdb8b948675761a2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F345",
       "image": "tomato.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/763afdacf7992cd4ce53f689dd059ac2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F5D3",
       "image": "spiral-calendar.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d04be77ac5f2a57b68b88900a9869d34.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4C6",
       "image": "tear-off-calendar.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/eabb6473addbca4c69f366f88e366003.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4C5",
       "image": "calendar.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/586e3ce6bf7ab6d86d2430e2df41988a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F574",
       "image": "person-in-suit-levitating.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1ff4405fea9e1c5ef2547b58626a6c56.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F440",
       "image": "eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9455b317d7d5d29cd49b48a034ecaa16.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F332",
       "image": "evergreen-tree.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e4760b328a2e8e106d6fe4bdb352f359.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F384",
       "image": "christmas-tree.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a9c3ca5ab870e3d37f5366797114d925.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F334",
       "image": "palm-tree.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c5083246dc28454120efee4a964f7ab8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F608",
       "image": "smiling-face-with-horns.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/413c83c6e84d791d0cac966e028147d6.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F47F",
       "image": "angry-face-with-horns.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/64891376dad69332d0cedb255cdcf4d7.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F4D8",
       "image": "blue-book.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/15223fb0579b8f3f5fe63220b1672c6c.svg",
-      "author": "Autofirejm\nlolecksdeehaha"
+      "author": [
+        "Autofirejm",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4D9",
       "image": "orange-book.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fcd7de373f7d6cf830681792bcc2f88a.svg",
-      "author": "Autofirejm\nlolecksdeehaha"
+      "author": [
+        "Autofirejm",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4D5",
       "image": "red-book.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/59832e03f0d0d7b083707727c388ef97.svg",
-      "author": "Autofirejm\nlolecksdeehaha"
+      "author": [
+        "Autofirejm",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4D7",
       "image": "green-book.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b64efb6fe8c7adf256cb200ba01c6f8.svg",
-      "author": "Autofirejm\nlolecksdeehaha"
+      "author": [
+        "Autofirejm",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4D2",
       "image": "ledger.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/55dfa18dd5761b2810c6f516d8167ae5.svg",
-      "author": "Autofirejm\nstickfiregames"
+      "author": [
+        "Autofirejm",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4D4",
       "image": "decorated-notebook.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/07329bef78f1350d77bbdbfdefe7136d.svg",
-      "author": "Autofirejm\nlolecksdeehaha"
+      "author": [
+        "Autofirejm",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F50B",
       "image": "battery.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ea29903ac314b4f9bb2a60053de9371a.svg",
-      "author": "Autofirejm\nlolecksdeehaha"
+      "author": [
+        "Autofirejm",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F48A",
       "image": "pill.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/418c9c0a4294621514277edf8f0ef6ef.svg",
-      "author": "PATSATDAT\nlolecksdeehaha"
+      "author": [
+        "PATSATDAT",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F525",
       "image": "fire.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fdb7eeb755ed35753b20b0f85a295c4e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4A7",
       "image": "water-drop.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/04cd26f5708b8ec25505fcc94230d9bb.svg",
-      "author": "Autofirejm"
+      "author": [
+        "Autofirejm"
+      ]
     },
     {
       "codepoint": "U+1F922",
       "image": "nauseated-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e723121805150ebebe1140d9b28d8dd7.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F976",
       "image": "cold-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2efc4a645ff7e4a3b4888dbced8ea4cb.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F3C1",
       "image": "chequered-flag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5aac9bece4f260baf5f50eeb059df648.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6A9",
       "image": "triangular-flag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1738e4c4a67ff3a5b882813de08bf51f.svg",
-      "author": "stickfiregames\nmybearworld"
+      "author": [
+        "stickfiregames",
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F38C",
       "image": "crossed-flags.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/24e85e1f1d4e4dbd549bb5659ed46874.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3F4",
       "image": "black-flag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f3f385b76a1794217b4348673ca2f103.png",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3F3",
       "image": "white-flag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6f8f0ee577a8aec54d6936465826a9a6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3F3 U+FE0F U+200D U+1F308",
       "image": "rainbow-flag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/936ca6a42609f14d6dd0feb89c168abb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3F3 U+FE0F U+200D U+26A7 U+FE0F",
       "image": "transgender-flag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d961fa0bccbd2a8cb2835c767830f578.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3F4 U+200D U+2620 U+FE0F",
       "image": "pirate-flag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/28b764160eedf8dd942122726f5b3f93.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F972",
       "image": "smiling-face-with-tear.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9d9271f8e5f02705e86f28907c41b94e.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F62E U+200D U+1F4A8",
       "image": "face-exhaling.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a7c5be246602a61c7d3c46b10a678dd3.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F92F",
       "image": "face-with-exploding-head.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/30596b451dc93a9389e9c791e707e82a.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F635",
       "image": "dizzy-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/17e309df0b02376a8b1c9e3b2561adfb.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F920",
       "image": "face-with-cowboy-hat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e795b808c39d7a8d99dec761d95f990a.svg",
-      "author": "mybearworld\nstickfiregames"
+      "author": [
+        "mybearworld",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F480",
       "image": "skull.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6485d2e3d45fa0fc7d71f71cefb3e05d.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+2709",
       "image": "envelope.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ca454b15e2237a24b8ce15226d2b7381.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4CB",
       "image": "clipboard.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b2cd01deac7fb65667bba3f055becb3b.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4DD",
       "image": "memo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1c8093c2185792102615dbbecbb7debd.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4C4",
       "image": "pagefacingup.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2a7ffc3e225d7fbb0804af4215f4326b.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4C3",
       "image": "pagewithcurl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/882e3279bce6d1ffa9da8ea5307c5fa5.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F9FE",
       "image": "receipt.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a5854ccfeea8a4e6429c8a33d02dad6a.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F5D2",
       "image": "spiralnotepad.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/567d37aec4012eb1b534b7d455be7ddd.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F63F",
       "image": "crying-cat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/692dce818f9957b33d723ee6b4962b96.svg",
-      "author": "uwv"
+      "author": [
+        "uwv"
+      ]
     },
     {
       "codepoint": "U+1F639",
       "image": "cat-with-tears-of-joy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fafcf0527e98291e7a6731d177f7d750.svg",
-      "author": "uwv"
+      "author": [
+        "uwv"
+      ]
     },
     {
       "codepoint": "U+1F63E",
       "image": "pouting-cat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b3de8c956b48c8ff3e428387686674e9.svg",
-      "author": "uwv"
+      "author": [
+        "uwv"
+      ]
     },
     {
       "codepoint": "U+1F640",
       "image": "weary-cat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/18b6c0ad19d5ad128468d949215301a1.svg",
-      "author": "uwv"
+      "author": [
+        "uwv"
+      ]
     },
     {
       "codepoint": "U+1F63A",
       "image": "grinning-cat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f67743bb9153bd1b844b2651f6444c9c.svg",
-      "author": "uwv"
+      "author": [
+        "uwv"
+      ]
     },
     {
       "codepoint": "U+1F638",
       "image": "grinning-cat-with-smiling-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1cca2b6bbae39951c495066be59e46e9.svg",
-      "author": "uwv"
+      "author": [
+        "uwv"
+      ]
     },
     {
       "codepoint": "U+1F63C",
       "image": "cat-with-wry-smile.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b87da69c610d444dfbe94278db0875be.svg",
-      "author": "uwv"
+      "author": [
+        "uwv"
+      ]
     },
     {
       "codepoint": "U+1F63B",
       "image": "smiling-cat-with-heart-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7795935386cdab93fac4504d423f807e.svg",
-      "author": "uwv"
+      "author": [
+        "uwv"
+      ]
     },
     {
       "codepoint": "U+1F361",
       "image": "dango.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a81dfb2d4e9745ff6f61840d938b14a4.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+2764",
       "image": "red-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9661c9d6f5cbd20397523ebd63bb0362.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F9E1",
       "image": "orange-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4e2c7ce243097e04e602274ee0821747.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F49B",
       "image": "yellow-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fb6d406702b1d7658358a2e9c21534e3.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F49A",
       "image": "green-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/67b1c5bc04245b5468a3f6d283d015ca.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F499",
       "image": "blue-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9c34b26d3e96587cd7e978f5ff836490.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F49C",
       "image": "purple-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/803ba386e73d0ce5153cbef7dc8a0e65.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F90E",
       "image": "brown-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9489e8bcffd5dcc249329db5c1ec6926.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F5A4",
       "image": "black-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cf786c2f0a7d48c7995cf01f17416462.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F90D",
       "image": "white-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0daf32f23ba12b223cc92809298cdb87.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F494",
       "image": "broken-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/10a39a0b5f88e9e90c80f7726043f8f4.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F495",
       "image": "two-hearts.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bf95c5b41df73c5dad1510033e19f095.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+2763",
       "image": "heart-exclamation.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d1950151108430490cf3d13830deb245.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F49E",
       "image": "spinning-hearts.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/45dfe1509f34beb801da4cf387358635.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F496",
       "image": "sparkling-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/122a37258c8b54903476d1423192ba05.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F498",
       "image": "dagger-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/61ec73a4883b0d477178eaa295b76731.svg",
-      "author": "CST1229"
+      "author": [
+        "CST1229"
+      ]
     },
     {
       "codepoint": "U+1F308",
       "image": "rainbow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/96dbcbf198ffce5737a8d51731b87656.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F35B",
       "image": "curry-rice.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7c02b281d212605ccd5157b6dd87492e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F35C",
       "image": "steaming-bowl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/207d8d4dd52a1514884f8e843f42618c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F35D",
       "image": "spaghetti.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/249b6e73cb209e591ad9fdc4b199e10e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F984",
       "image": "unicorn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cce4e6974ff3a796c19fd5f86749a6ac.svg",
-      "author": "cartooney\nlolecksdeehaha"
+      "author": [
+        "cartooney",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F980",
       "image": "crab.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9e50b1e43edac6688777fc72662dcd33.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F99E",
       "image": "lobster.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5ed887265b5b4dcf31c65dba8b006181.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F990",
       "image": "shrimp.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7c2af36734a4fed93eeada4d054e80fa.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1FAE5",
       "image": "dotted-line-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/051e32197c0b0cf02815ce34fb496c72.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1FAE4",
       "image": "face-with-diagonal-mouth.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2b90ee33052e050c40c4a12a52e48a37.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F7F0",
       "image": "heavy-equals-sign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cd99c80bc244d827909296cf333463f1.png",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2795",
       "image": "plus.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7a80489830c24c330bd34f406974ddc1.png",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2796",
       "image": "minus.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/54c2ef795496df2ca2d4ac106a789122.png",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2716",
       "image": "heavy-multiplication-x.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e6a4a24766acf33273673806737681b3.png",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2797",
       "image": "divide.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d6683da3c56a850225cb87f4ba66dfb9.png",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F979",
       "image": "face-holding-back-tears.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4c7938deb31467417695125cee8bfddd.svg",
-      "author": "Scratch137\nlolecksdeehaha"
+      "author": [
+        "Scratch137",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F55B",
       "image": "twelve-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/82ae003b4bde1007fa6a0ced1a76dd3e.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F567",
       "image": "twelve-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6d0d1749e99b4789ea074a1a876b9872.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F550",
       "image": "one-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1a09cdeb2f8a20f40492a3f6e09b216b.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F55C",
       "image": "one-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8765cb3ab26335244d227e31fe340ca4.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F551",
       "image": "two-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/635ff90741deaf9a1cdc68c5b4898639.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F55D",
       "image": "two-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/547e6e2b667d0ab14d30ea478e42536f.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F552",
       "image": "three-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3a7f9ffe11f24f56780ea7078810eebd.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F55E",
       "image": "three-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0295c6b758e3927341e378a7ee26ae77.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F553",
       "image": "four-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/31bccab6d0d3552daf7bfa28249ad339.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F55F",
       "image": "four-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/14cc85a0836964a792ddc76b7a81d099.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F554",
       "image": "five-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/da649d1b133411e11cfe36e84a076e4a.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F560",
       "image": "five-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/05d86a0773c2234432db981cdde4723e.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F555",
       "image": "six-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9b0889c5e7614fdf92895eb1a7f4749c.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F561",
       "image": "six-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9b6ffc50b1516743765d01e11395ffdd.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F556",
       "image": "seven-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/774eb7faf1560966001b6dbe5d647a9d.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F562",
       "image": "seven-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8078a8e227ffad439f4995045ec3d6d5.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F557",
       "image": "eight-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2f5b7ea4067c33bd453b3c783c203e94.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F563",
       "image": "eight-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b033164319b631178e72b46d812256b0.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F558",
       "image": "nine-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d0d87cbc953644aa7ee7dff32ab4c6bd.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F564",
       "image": "nine-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/230826ccbe4df0a6fd6147c886ed0bc3.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F559",
       "image": "ten-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e8b168c3d6ec1e0efbf044841fe48ad7.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F565",
       "image": "ten-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/aeaea675a6327fca00745abb38ab0b55.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F55A",
       "image": "eleven-o-clock.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4c6e09795db579ae06135db777d65f99.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F566",
       "image": "eleven-thirty.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/66003373a4c3584f463f44f1f88f7680.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0030 U+FE0F U+20E3",
       "image": "keycap-digit-zero.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fa850b9120d420cc53ec89fdedd5b15e.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0031 U+FE0F U+20E3",
       "image": "keycap-digit-one.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/68e53f70e725e63707cd2db3f48c2249.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0032 U+FE0F U+20E3",
       "image": "keycap-digit-two.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ca4ca9468fad64a27b1b059188aff06e.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0033 U+FE0F U+20E3",
       "image": "keycap-digit-three.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/89d7b3af861e4ca49741d847059f05b6.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0034 U+FE0F U+20E3",
       "image": "keycap-digit-four.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4cbfa648acfdb17f8671b9d141827cac.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0035 U+FE0F U+20E3",
       "image": "keycap-digit-five.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7c4a989f66ae2e47faad88c66c9f49fc.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0036 U+FE0F U+20E3",
       "image": "keycap-digit-six.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3d3f42cf33acd4ac4bcf3c257041ba98.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0037 U+FE0F U+20E3",
       "image": "keycap-digit-seven.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/465828fef53048831b4ec3f1fa36cc0a.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0038 U+FE0F U+20E3",
       "image": "keycap-digit-eight.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fdd9c0809aa4c9d6b0846aea84a8b75b.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+0039 U+FE0F U+20E3",
       "image": "keycap-digit-nine.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1962efd854839866a30665309f62fa74.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F51F",
       "image": "keycap-digit-ten.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bd9f80f916e990eeafe3d8226eff5f45.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2648",
       "image": "aries.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ce8b5553c4e677a8f61401f0e3295df9.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2649",
       "image": "taurus.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/863c387003863fa2723847735f1912ea.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+264A",
       "image": "gemini.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fd0bdd7f0fa40951e40cc31ae7743f29.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+264B",
       "image": "cancer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9f2cc1e55702263b219d82d34b2f550d.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+264C",
       "image": "leo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5cf495ba0f775cf16040c37d1d31be6d.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+264D",
       "image": "virgo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6700daccb6d235d1b0e1f6cddad074fe.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+264E",
       "image": "libra.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f1417d3e193b2e7a23e69ad7e8791678.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+264F",
       "image": "scorpio.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4f32be663dfb3c56aec06ab323213c61.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2650",
       "image": "sagittarius.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7c39f2ba326cd9d6bb102a20b70c75ab.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2651",
       "image": "capricorn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/aff30939d95101ecc1a4fa8b1bd6b280.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2652",
       "image": "aquarius.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/94d93a5c96061b2da410f0c2c93cda2d.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2653",
       "image": "pisces.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bceaf7a479a92d13b5d45e5125f3a6c0.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+26CE",
       "image": "ophiuchus.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/748e1e008be1cca24f287dc7fc290f76.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2642",
       "image": "male-sign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6e07561c13f4b313fcf0e137e4a6bd8c.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2640",
       "image": "female-sign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/31a5da92076d0883665891d4cebcc0ef.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+26A7",
       "image": "transgender-symbol.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a94bca5d9601acac63272db775bd8f00.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2B06",
       "image": "up-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dbf783fd429e89ef23c1c4861b88b766.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2197",
       "image": "up-right-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/da68a615aade2732b02b3764be2c8043.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+27A1",
       "image": "right-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b1fd53ce5fb6fdb4cbcfa0d0b26b7e3b.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2198",
       "image": "down-right-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5cf03f33598e0308dc6b74d165a63b77.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2B07",
       "image": "down-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/554502b8eee594004fad149398c9175b.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2199",
       "image": "down-left-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a7c8c3785a01c2710e6b8fba2cfc71a3.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2B05",
       "image": "left-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e8e918c1ba43801bed3a959a85d93b21.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2196",
       "image": "up-left-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1a9652a66bcf7e25f6f97c0385787187.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2195",
       "image": "up-down-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/84e270e1fd63be8338e73307d39867a1.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2194",
       "image": "left-right-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6a01dbfb44023d08ef68ed3cc58128ac.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+21A9",
       "image": "right-arrow-curving-left.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/66fcadc7e8be4367b707bb00829a2108.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+21AA",
       "image": "left-arrow-curving-right.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/70160740fcd9d0d05f45957b37517204.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2934",
       "image": "right-arrow-curving-up.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cbb2b1850e9a3e19893b1352b844819e.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+2935",
       "image": "right-arrow-curving-down.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/674f63b53ba60f35a988af3c0c84cf21.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F503",
       "image": "clockwise-vertical-arrows.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8016cde595ce08b28904f8cfbfb318c3.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F504",
       "image": "counterclockwise-arrows-button.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8cef638aa44b954d95035c247d56636d.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F441",
       "image": "eye.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a2caf71ac66266467ba34f90b6659466.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F47E",
       "image": "alien-monster.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/529c6db9ddea497da7249e369a961c6b.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F251",
       "image": "button-acceptable.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bf4dec9defb623e9e4b40ee3cb9a6d64.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F250",
       "image": "button-bargain.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4e6eeb155d9f35e10ffcb1d58ce2da57.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F238",
       "image": "button-application.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/76de0364ebbd6ade277c9c2436a4c721.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F21A",
       "image": "button-free-of-charge.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d1b7e40732d7cf56d7ba4ff190f2177b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F239",
       "image": "button-discount.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/045e012b0b01b9dade9d0dd8ebb9a473.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+3297",
       "image": "button-congratulations.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/10c42fb2ed00c92e7758b304b5d78728.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F237",
       "image": "button-monthly-amount.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3cba1fff11880d6f8ef95f69e7d777dd.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F201",
       "image": "button-here.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/daee92ccc458951099e49096fb9bebbc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F23A",
       "image": "button-open-for-business.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8907d360e0287be6da82c3d79f64f1e0.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F235",
       "image": "button-no-vacancy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c3d648b61141c9499f2ec2ef521ddf37.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F236",
       "image": "button-not-free-of-charge.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fdebe0c9bb4408bf7ecdc97ff6cb5195.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F22F",
       "image": "button-reserved.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a2c90e4a1067e53d06bd68b668c287d3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F232",
       "image": "button-prohibited.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/97f0676f287ebb184c8160a76523ff8e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F234",
       "image": "button-passing-grade.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/807c28c2951a7c8e538a69b8e7474811.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F199",
       "image": "button-up.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/643d8e0e63fe963616ee26567afbc636.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F202",
       "image": "button-service-charge.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d8b2100064fbccaaa4f5a3bd5a34a8f5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+3299",
       "image": "button-secret.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/46fa1ca5b21e560de5fe42bcb5d727a1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F19A",
       "image": "button-vs.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/eda36c887a82e629217d8c0e55bffff5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F233",
       "image": "button-vacancy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/824278e1e42e7af209ca103243c8857e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F523",
       "image": "button-symbols.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e7a40ab6637a822ce306e0499251b621.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2139",
       "image": "button-information.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0603addb84b70f768028bb5de0817fd6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F193",
       "image": "button-free.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f18a841743ddf5aeddc9ba5ac8a22b6e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F192",
       "image": "button-cool.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4ec79bdc55d25522c4cdd8c618c82087.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F521",
       "image": "button-latin-lowercase.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b722556c4ee31fc2526edce6697d1bf.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F524",
       "image": "button-latin-letters.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e766aa1342d66824b70631d3e169ead7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F195",
       "image": "button-new.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/421493bb1c1cd8c9e258a1fc1acfdd18.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F520",
       "image": "button-latin-uppercase.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/39a017dd45df22a2a49e0358deeb1d25.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F522",
       "image": "button-numbers.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/881ace329fad32c2776eff73d97d6276.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F196",
       "image": "button-ng.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9d766ed8755004174f1ca79fcaca8f79.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F197",
       "image": "button-ok.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3a0430647b99d66efd3f3b0dacdf902f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F301",
       "image": "foggy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f0802ab5ffaa2151b088642fd8878307.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F303",
       "image": "night-with-stars.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/46aeece347025205e3f124e093d1147e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3D9",
       "image": "cityscape.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/95ad9427745eff7dab296df6b6337808.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F304",
       "image": "sunrise-over-mountains.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ce28bb1036c135aafeab268cd01c0deb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F305",
       "image": "sunrise.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b10f2acdafb58adb77f452944c8263ca.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F306",
       "image": "cityscape-at-dusk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e9be2f9d9471733b0436964c4270aad2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F307",
       "image": "sunset.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a6fba4c2232e11fced1e3fd84e67d2c1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F309",
       "image": "bridge-at-night.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2f6f52abd5fb8683a914cc69fc4652b3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F9F2",
       "image": "magnet.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2228f91ab575acfa856d9c0729daedf4.svg",
-      "author": "mybearworld\nlolecksdeehaha"
+      "author": [
+        "mybearworld",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F358",
       "image": "rice-cracker.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/14cf55e52c4e36068df3df27e47b43f6.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F517",
       "image": "link.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cbca6ab8a810a75eb32f5fcd32e341f4.svg",
-      "author": "mybearworld\nstickfiregames"
+      "author": [
+        "mybearworld",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+26D4",
       "image": "no-entry.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fb610f2cf304e5aa13fd737cfcd93a49.svg",
-      "author": "Vaibhs11\nstickfiregames"
+      "author": [
+        "Vaibhs11",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F198",
       "image": "sos-button.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9880d0348cf9d4c7241156403472fd0f.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F311",
       "image": "new-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1d24b48c992b71947c0d308f5d646464.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F312",
       "image": "waxing-crescent-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cbe4fd45b79f33f33ccc82b5b9037bac.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F313",
       "image": "first-quarter-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4013fd86783909a7866a4ffbdc01b89b.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F314",
       "image": "waxing-gibbous-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7c6fc9099ad1d0868d71df64541e9f85.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F315",
       "image": "full-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ea097996745fda07c7e9cac01f948ac0.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F316",
       "image": "waning-gibbous-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f036a9427b7cd2290d70051b9b77a017.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F317",
       "image": "last-quarter-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1b4494177cedf87a5311b590a5c1fc6d.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F318",
       "image": "waning-crescent-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/05353aff3d23cc452ff618d880650ac7.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F319",
       "image": "crescent-moon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c7a9946efe0e5dc8205fe567adb4cb52.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F31A",
       "image": "new-moon-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fcc8762b04caa2decf1615711cde1639.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F31B",
       "image": "first-quarter-moon-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/04c24ddefe1e6d5273ff451e21b62459.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F31C",
       "image": "last-quarter-moon-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5087066683eb13d598a3122d1217ed63.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F31D",
       "image": "full-moon-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d7e086fb43b47cfc9cce8a22e59d86f4.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1EB",
       "image": "flag_af.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/29981412bc202b5c9a6303734c68b214.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1FD",
       "image": "flag_ax.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/923b5b7a388ee8eb65fb44ca2c1c5a21.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1F1",
       "image": "flag_al.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/05c20809064c4df042687768ae9e22ab.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E9 U+1F1FF",
       "image": "flag_dz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0c34ce56290409cc91090e4e5d862044.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1F8",
       "image": "flag_as.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/948191f673f79493d9741e8b89acc39c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1E9",
       "image": "flag_ad.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5c790849a27e1b8d8d78692c3bb06e98.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1F4",
       "image": "flag_ao.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9636519152d0b6b1bf8425ef2afb3e65.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1EE",
       "image": "flag_ai.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b6fbd5542c4c45af21e762d3a67e8fad.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1F6",
       "image": "flag_aq.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/043be90e70f027bfe4c6a0c9dc8049ef.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1EC",
       "image": "flag_ag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d1e7cfa2e0fdc6c20d85dab7d12a4647.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1F7",
       "image": "flag_ar.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d74b1a6eea8ce13ed06ce7b98fec58db.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1F2",
       "image": "flag_am.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2a9e492bcd7feabb14df8c914ab62ed8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1FC",
       "image": "flag_aw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b24c150038835345e529a92852eb75ad.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1FA",
       "image": "flag_au.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dc22ef1252f72b3f20b38414a4320b83.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1F9",
       "image": "flag_at.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/784ebeca9cc01151407c09f11ae57660.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1FF",
       "image": "flag_az.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c7dda0ee15edccf95ca9bcd9002fedff.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1F8",
       "image": "flag_bs.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b27f238441305d59ff831626ed365f42.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1ED",
       "image": "flag_bh.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e5f06189342fb3c6b2821a8271002603.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1E9",
       "image": "flag_bd.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3b7ed66a0216a6c3011ac82829b7982b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1E7",
       "image": "flag_bb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/84cf85d1499516b4194534b9294da48f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1FE",
       "image": "flag_by.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8c2755b14927161efbe2724b6922eadf.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1EA",
       "image": "flag_be.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/33c297fd1d2a984bb613bfce1c98c4e4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1FF",
       "image": "flag_bz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1763b91a0cc041c9c28c694b40175f4e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1EF",
       "image": "flag_bj.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/74e934e0f368b780254035dc70f4159e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1F2",
       "image": "flag_bm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9b067b95f4483ccb1efdedd096416557.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1F9",
       "image": "flag_bt.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a309abb14fa1fcfa3c67a2b6ca370665.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1F4",
       "image": "flag_bo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a223597f8bdba15c334fbcc292f664f6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1F6",
       "image": "flag_bq.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6ae3557eeea72c328498b627bd5ca6e4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1E6",
       "image": "flag_ba.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5a318937a7320bb60285ebbd179dddd1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1FC",
       "image": "flag_bw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/89af15804b34d031e6c85848a5548ff3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1FB",
       "image": "flag_bv.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8f6a69035a79b06cb3aeb1f07191c8d4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1F7",
       "image": "flag_br.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/54e1ffd79186ff4ad4309a78b535372e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1F4",
       "image": "flag_io.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0e7a86958ca156cd6a88b82282734055.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1F3",
       "image": "flag_bn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fc4ae937aeadf4c5acb68ef377a3d725.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1EC",
       "image": "flag_bg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/114025deec6090a93aa111fbcc9430de.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1EB",
       "image": "flag_bf.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/53f177e153ac5a15538eb6b1bc9a5422.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1EE",
       "image": "flag_bi.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fb46434b9768635797664052fcd2bab4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1FB",
       "image": "flag_cv.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/67bce35fe915246e8ab99dcf86653f82.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1ED",
       "image": "flag_kh.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f7de448351262f47da46f996cbf924b2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1F2",
       "image": "flag_cm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/84f18d6b8af79608f351b367e9ff178d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1E6",
       "image": "flag_ca.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/46d6114b30c9a6d5c637848febe8c3b5.svg",
-      "author": "stickfiregames\n64lu"
+      "author": [
+        "stickfiregames",
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1FE",
       "image": "flag_ky.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/97117265a8e2971a7c23709672752733.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1EB",
       "image": "flag_cf.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/968864c90a0f9a3a50cacf3f6cc4cb01.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1E9",
       "image": "flag_td.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8dcb972710f79b6b984a97dcb709cdf3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1F1",
       "image": "flag_cl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e9ef3e61d578dab9e0f891661518b303.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1F3",
       "image": "flag_cn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5f333fe10620b0db08e8d379a8cd463f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1FD",
       "image": "flag_cx.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/111edac43b15e3a6352c6d2c8d545408.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1E8",
       "image": "flag_cc.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d694dba03ca75cbe430e0ddbe6cbcdbf.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1F4",
       "image": "flag_co.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/70f201f94617e0249774d316a4a70deb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1F2",
       "image": "flag_km.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1043f1467e11cb3c5dc5175f895727a0.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1EC",
       "image": "flag_cg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2adf147abf0b80b757b9eba9f5923f03.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1E9",
       "image": "flag_cd.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d31765eb4bd4b12610ea23b34b678917.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1F0",
       "image": "flag_ck.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7465f2e2349ee0700054ab2ff7c009f8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1F7",
       "image": "flag_cr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/84e84d0ace1f0980a44d9cc29adf273c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1EE",
       "image": "flag_ci.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b0431b98905ec900e472b5d627b997ff.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1ED U+1F1F7",
       "image": "flag_hr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/829d33a45a1266d9aa44459cd554e7aa.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1FA",
       "image": "flag_cu.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c5d60430e9081bc302b51c94b586a175.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1FC",
       "image": "flag_cw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1365b557131941998c8e8f520d9bdcd5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1FE",
       "image": "flag_cy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a82db76710e2d5cc6517ac998906a050.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1FF",
       "image": "flag_cz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5accd4e25551869bd1cf53279b1c0b6c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E9 U+1F1F0",
       "image": "flag_dk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7156a1832b6e17099d04c151313f5c78.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E9 U+1F1EF",
       "image": "flag_dj.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/77b2beea00952d45ad42d23bb303337e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E9 U+1F1F2",
       "image": "flag_dm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/896e5329d0181e7ec620556e1b9748a0.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E9 U+1F1F4",
       "image": "flag_do.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d507f536a0ac937f9111f91cb2de2577.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1E8",
       "image": "flag_ec.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e39854c1792d69a3b57b252bb3ce1119.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1EC",
       "image": "flag_eg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ca1fc56af63ccab389faa035b0892387.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1FB",
       "image": "flag_sv.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1a6736186e63d24a3a3b884403c67145.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1F6",
       "image": "flag_gq.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9d0a63b443cefad7ccc0e06199874349.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1F7",
       "image": "flag_er.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b2fe0ebe4e3b2b14f514763e1995e400.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1EA",
       "image": "flag_ee.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/247ce36db15ee1e79b1ccc4d9aa72a02.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1FF",
       "image": "flag_sz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/060e858ea83f0d991171ef9c1fde5ea6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1F9",
       "image": "flag_et.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ee328c5f3e99dea6ba5d55a742e2e500.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EB U+1F1F0",
       "image": "flag_fk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/22e3e345905b1b355e74b94171c90e39.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EB U+1F1F4",
       "image": "flag_fo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/54f272e39c8c9ed7e4d7e056a6a51a04.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EB U+1F1EF",
       "image": "flag_fj.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/651afc5320157b782ab057c565b6cef3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EB U+1F1EE",
       "image": "flag_fi.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6a1d4bd3c97752fd608816158432d2e5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EB U+1F1F7",
       "image": "flag_fr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d27cb44ccc271d7c2c5e68a99e9de596.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1EB",
       "image": "flag_gf.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cefc2f9a013139cda2c14830e216406b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1EB",
       "image": "flag_pf.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9f808ab74f8b58f9160a9e6d50dfe5c3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1EB",
       "image": "flag_tf.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/64558c0fc900afdfb0a9de07eedf4614.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1E6",
       "image": "flag_ga.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8da0154e7fbdfa517b55ca634ce975c2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1F2",
       "image": "flag_gm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bdcf428a47de8f8f4c852a03cb959cc1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1EA",
       "image": "flag_ge.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/96d2147fc751e9a7f2cb3c443aaf9d29.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E9 U+1F1EA",
       "image": "flag_de.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/be1fd35565d87d8252f1ff9edada7440.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1ED",
       "image": "flag_gh.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3dffc3addabc4d81834694afa966ae13.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1EE",
       "image": "flag_gi.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/70682a248ddd08c3937b29119d6ebeac.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1F7",
       "image": "flag_gr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d921cad071bdeb4a061e24d67e33c0ca.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1F1",
       "image": "flag_gl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/862fb53d1bb3f6205c04e4763aa1cf59.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1E9",
       "image": "flag_gd.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/81900196d9accadc615c2f2e2fe54ed0.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1F5",
       "image": "flag_gp.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/af9659bba3b2e87c10e8870b4004b0e7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1FA",
       "image": "flag_gu.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/786eed6f670accdeb06c8fb5e19d8ec5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1F9",
       "image": "flag_gt.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a0748a7925e5b8e64484f96f3793074d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1EC",
       "image": "flag_gg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b235461f5453716b0f6ea631f10c409a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1F3",
       "image": "flag_gn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/620ef5e823d15dcbf139c2c6d4aa325d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1FC",
       "image": "flag_gw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/62ae827898965056a17b009f8d299253.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1FE",
       "image": "flag_gy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9bf8860ebca56c10e6af7dbb2aa7a52e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1ED U+1F1F9",
       "image": "flag_ht.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/34b04c6e96b463ecb0460f3b2fc796bc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1ED U+1F1F2",
       "image": "flag_hm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dc22ef1252f72b3f20b38414a4320b83.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FB U+1F1E6",
       "image": "flag_va.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/54b3e162939f79119ca6dd869ca2222f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1ED U+1F1F3",
       "image": "flag_hn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b5385d711b1520fe0f7d68d7c7163e2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1ED U+1F1F0",
       "image": "flag_hk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0cb3cd7150d905c6889842ac0ad952e2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1ED U+1F1FA",
       "image": "flag_hu.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b71ce7e5ac539666ec584e9debbc5cb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1F8",
       "image": "flag_is.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f41bb0ce16d9989dc01fe85f54b655f8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1F3",
       "image": "flag_in.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c6ee90c64557d629368ce967f74061e3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1E9",
       "image": "flag_id.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f5d6581c18741c77104599e40de6fb20.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1F7",
       "image": "flag_ir.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f41f074fa9f41fa8b0ef72afed5fb606.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1F6",
       "image": "flag_iq.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f4ca27b6bedcdcc4f08cdc4dcd5a8294.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1EA",
       "image": "flag_ie.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/70e7ab50b0e92b2f631b2bc2011b1462.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1F2",
       "image": "flag_im.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8f837d0bbb904aaefa57ab18ffdac1a6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1F1",
       "image": "flag_il.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a2da8ea7da4cb251b9020c64629161af.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1F9",
       "image": "flag_it.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/afbb505160be1c25a1e2dd6d068b6503.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EF U+1F1F2",
       "image": "flag_jm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/65c089ddef2ab8611946afee6b7caa5f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EF U+1F1F5",
       "image": "flag_jp.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4cd236cc07d814ca32755fe561254b0c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EF U+1F1EA",
       "image": "flag_je.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b54c4d2d96d2d2d3120b257bf4bbd204.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EF U+1F1F4",
       "image": "flag_jo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e3bca3f983322974c603d3c3a77d6f1d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1FF",
       "image": "flag_kz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3e2fa0fcd4a78de0f9902d73bfcaee0a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1EA",
       "image": "flag_ke.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a296c86b0c80efccbfb946f1f40957a5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1EE",
       "image": "flag_ki.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1199586b749d3ee690e60adf4d0c7960.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1F5",
       "image": "flag_kp.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a9a68450647a21e8785c2255061cee14.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1F7",
       "image": "flag_kr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/42b224638f12b6e37d03ca69639b0dbb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1FC",
       "image": "flag_kw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ec60a07afdde5730a0880049ed6571ea.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1EC",
       "image": "flag_kg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/096365ebd99dc2cde3fc6aa3729f7103.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1E6",
       "image": "flag_la.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c235717014d53847a344ec2be47922ab.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1FB",
       "image": "flag_lv.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0672a3e533f4a1bb15037e205290d25d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1E7",
       "image": "flag_lb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1b8cf3b63fe180cc99143db42ca971ec.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1F8",
       "image": "flag_ls.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7772affde649cf7032e6afc01db81cdb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1F7",
       "image": "flag_lr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d5fee855f8f1d332a8fea12b1619fce9.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1FE",
       "image": "flag_ly.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d6c3448b196fce63efac3ce3d07218ff.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1EE",
       "image": "flag_li.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9001fa627318648caaafc4ae2464f059.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1F9",
       "image": "flag_lt.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a993796bba6ed06089fda1fb7a8e409f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1FA",
       "image": "flag_lu.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/62298a92707eec88845a6e478dcebf3f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F4",
       "image": "flag_mo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ab3486eb8d21fd023872618fad492ab1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1EC",
       "image": "flag_mg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c3239ddf51305453ddbb5615e11de3dc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1FC",
       "image": "flag_mw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3a4af0374138195b4cbd4467a09bb10b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1FE",
       "image": "flag_my.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0591465b625747f523edd985d2fa9a5a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1FB",
       "image": "flag_mv.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4c304d6e6719287f9e0c8118588574df.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F1",
       "image": "flag_ml.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/92f081b9659294f3732af3611d8b7833.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F9",
       "image": "flag_mt.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a597c3a824ccdf656579e9a6417f640d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1ED",
       "image": "flag_mh.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fdd7b2ae147f82884b723b56cf7d016a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F6",
       "image": "flag_mq.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c7e1b2aa34f928ca623f068630e11e8b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F7",
       "image": "flag_mr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/96fe2799fad0ab65a424ac9e956849ae.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1FA",
       "image": "flag_mu.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b92ee6edc3ad0823b99f349bb159795a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FE U+1F1F9",
       "image": "flag_yt.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/197f5fa0eb4b49ad2489334706688478.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1FD",
       "image": "flag_mx.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/67591d554cd343305796855f4894cf03.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EB U+1F1F2",
       "image": "flag_fm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/76c29aca632765539ba7da2990f8d9b9.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1E9",
       "image": "flag_md.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c813fc72de77ef820faea72ef79507c5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1E8",
       "image": "flag_mc.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1b48d319abe14856a8cb915c48f0568f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F3",
       "image": "flag_mn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cbe2330b6d6f90c053cec9bba7591bd7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1EA",
       "image": "flag_me.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/193266e493a2ae39f790976a25f80e47.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F8",
       "image": "flag_ms.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ddfaf707629dfe75404cd172c88e97dd.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1E6",
       "image": "flag_ma.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/40fc105bcaf9d70177e49890985cbb23.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1FF",
       "image": "flag_mz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9876fea2aace1e2030ffb315dbf0aa5d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F2",
       "image": "flag_mm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/78b8c36452fd0f423fe7ef0e08eb50d3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1E6",
       "image": "flag_na.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bce72497f056a0137c1b6b64f2e3e243.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1F7",
       "image": "flag_nr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/625e0cfbb187aa1ce0f414a0a5639f0f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1F5",
       "image": "flag_np.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f63b84349c26fbd8987b863195773c75.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1F1",
       "image": "flag_nl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d7e58360856271c05a34b21b41d158fa.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1E8",
       "image": "flag_nc.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b11bac80d505442d4dc2bf46b2851164.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1FF",
       "image": "flag_nz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d105b71671f2764d7e580ddfa5eab11f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1EE",
       "image": "flag_ni.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ff3666ebb3d67f54cbc800a48f5a3b5a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1EA",
       "image": "flag_ne.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cc264d53cd7195ede2335cbaab9adbe8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1EC",
       "image": "flag_ng.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f86a32ccf595ea9ff6ca021c870e0a8a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1FA",
       "image": "flag_nu.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a0574c62a83ad7f94a1ab26b6470d1cc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1EB",
       "image": "flag_nf.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b6e46b0695cc72355d6db8beb1fda523.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F0",
       "image": "flag_mk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6d7f1c12287a45f67a03c5b8da4a4c36.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1F5",
       "image": "flag_mp.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b678b9f96a4ddfab34853e152a94a9f3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F3 U+1F1F4",
       "image": "flag_no.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8f6a69035a79b06cb3aeb1f07191c8d4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F4 U+1F1F2",
       "image": "flag_om.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2173af4016e998020234e5a9f69e5958.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1F0",
       "image": "flag_pk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5a590d8dcbb294025dc45c5656a5558a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1FC",
       "image": "flag_pw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3070ea2d4948897ac1004413838bc5e3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1F8",
       "image": "flag_ps.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cd4d5cf663b51b609bc53592cd70aafb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1E6",
       "image": "flag_pa.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/11dece23944a738618d6749f63effeea.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1EC",
       "image": "flag_pg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b13e71f42bc495b3730ad779134a8a36.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1FE",
       "image": "flag_py.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/81583da963df413311306338236b98e5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1EA",
       "image": "flag_pe.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/48e675e6d4d4385ef379a968c2441c19.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1ED",
       "image": "flag_ph.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c6079494d87ac05ea90108169b7ee74b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1F3",
       "image": "flag_pn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e7c7224b1893a0ed5d6aca2d5f69f0cc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1F1",
       "image": "flag_pl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c17891f3883703a7921b46393dd343ca.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1F9",
       "image": "flag_pt.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dae1b8f81af83f7fe254ad5e52ae7287.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1F7",
       "image": "flag_pr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fd59664dba7d2bacfa7d66793660a3ee.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F6 U+1F1E6",
       "image": "flag_qa.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5d9f020fa9deef3248a4cd2403a5edde.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F7 U+1F1EA",
       "image": "flag_re.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4378cc8ce7af68fc48a4f233f10f20ad.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F7 U+1F1F4",
       "image": "flag_ro.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e5d3f1b0d3c525737152a94e9b31b441.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F7 U+1F1FA",
       "image": "flag_ru.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/99f8510d422838ed5e9d5f51aa6632d0.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F7 U+1F1FC",
       "image": "flag_rw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/774aa3338e5da5ba0da2b7ea91ab9f40.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E7 U+1F1F1",
       "image": "flag_bl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/08ee5f2058674bda3887c45aa8a7d3f9.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1ED",
       "image": "flag_sh.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7a2349a7b38f79183903e78664e31c8e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F0 U+1F1F3",
       "image": "flag_kn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b21483174c74dc14eb510af4b559374f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1E8",
       "image": "flag_lc.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5ee47616e931ed91371893ebd287e49a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F2 U+1F1EB",
       "image": "flag_mf.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d27cb44ccc271d7c2c5e68a99e9de596.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F5 U+1F1F2",
       "image": "flag_pm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/85ede1423f16aa92663e7fb33bed4eff.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FB U+1F1E8",
       "image": "flag_vc.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/132f8f29b1424c0129b31f4b0ea0c3c7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FC U+1F1F8",
       "image": "flag_ws.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d662374913cf21af04fe0c9c17da621b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1F2",
       "image": "flag_sm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2e5573ca9eb08488013b49e148a4e005.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1F9",
       "image": "flag_st.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dfb9ec7f9be8b6dec77d536b800ef9a8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1E6",
       "image": "flag_sa.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9b5a01c643295e348b5b3bb9ce8e6f40.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1F3",
       "image": "flag_sn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/11ed165c8c66ac09e4a734629baef06b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F7 U+1F1F8",
       "image": "flag_rs.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8854687679a85c1e4ca7fdad4e904257.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1E8",
       "image": "flag_sc.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/02c4c8669ce421442047e98467f0acf7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1F1",
       "image": "flag_sl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/035d97c1035ea276c51f3146aeeeaf8a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1EC",
       "image": "flag_sg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/91eb5784900ec02ae35fcd0b3107988f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1FD",
       "image": "flag_sx.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b1fc32cbc38e074301219c5934025123.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1F0",
       "image": "flag_sk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/eb557b9e77f3ed2c210eb84de226ac27.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1EE",
       "image": "flag_si.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/139042439ea23feeff550a987453958d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1E7",
       "image": "flag_sb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d83f53c7871445dc27c143db76b87f2f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1F4",
       "image": "flag_so.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bfe60baf7164e7374d174922adf6560b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FF U+1F1E6",
       "image": "flag_za.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9b18291c4a6493bd4ce9525c2d443fab.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1F8",
       "image": "flag_gs.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/57009a5c70469ce34eeec6fee1191b9c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1F8",
       "image": "flag_ss.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8ded72b7091246c8e67e62835dc9bd35.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1F8",
       "image": "flag_es.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7e98f0a2ee56a554fd24d6cfc42b77ca.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F1 U+1F1F0",
       "image": "flag_lk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/489c5148b1818fc197ab53dfe3d3d754.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1E9",
       "image": "flag_sd.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fa1d5e3db0322f391b8431dd4aa09277.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1F7",
       "image": "flag_sr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/48e9669adaf763833798c8c6f61aa4d5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1EF",
       "image": "flag_sj.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8f6a69035a79b06cb3aeb1f07191c8d4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1EA",
       "image": "flag_se.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/48d7aa98cb83527a43be3d61abda8a99.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1ED",
       "image": "flag_ch.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/20257b33b3f9c86fa1943db5c4403de4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F8 U+1F1FE",
       "image": "flag_sy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a02e4b0f4de8269df54b6ef3122210a1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1FC",
       "image": "flag_tw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/61817452a02cf56aad347d867db12948.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1EF",
       "image": "flag_tj.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1a73910fa1f34a75440069027e88d483.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1FF",
       "image": "flag_tz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9e5f7c56ed424e656d5c6a2433f7394a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1ED",
       "image": "flag_th.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ac505d97c49d49d80ac19862ad5e5f96.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1F1",
       "image": "flag_tl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4f4c28a27109772ffc0993bf88abba5d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1EC",
       "image": "flag_tg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d5717d29e188a53a1d2e4806d7bbd49a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1F0",
       "image": "flag_tk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3e2f5447b0ab3009c84a5033bcf65734.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1F4",
       "image": "flag_to.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4913d9617fcdbf3525c80224f0bd54bb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1F9",
       "image": "flag_tt.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e96022c337845db0d762e52206719a87.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1F3",
       "image": "flag_tn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2f99fec87b5874469ac3cc56f00432ee.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1F7",
       "image": "flag_tr.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d0f3a933a13e1badfd818de0aafda971.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1F2",
       "image": "flag_tm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5a327524d0a1fe23647d51b4829c18fc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1E8",
       "image": "flag_tc.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4bef226dbf276e49cf162a82610aa4c4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1FB",
       "image": "flag_tv.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1163b68c094cf317030f32bbf8c5d8cf.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FA U+1F1EC",
       "image": "flag_ug.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/383179462fa93d0b7d434de0459ae373.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FA U+1F1E6",
       "image": "flag_ua.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/add4d3dd2e7ea96ab3b0b29a508c9cf7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1EA",
       "image": "flag_ae.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/de1268ae8a4ebe928f344bf93e531f49.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EC U+1F1E7",
       "image": "flag_gb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/043260a6b6def77affcbc4eb2430a2b6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FA U+1F1F2",
       "image": "flag_um.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5bb1f2d9ab4be0e75e98587df7165d3a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FA U+1F1F8",
       "image": "flag_us.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5bb1f2d9ab4be0e75e98587df7165d3a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FA U+1F1FE",
       "image": "flag_uy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1dcc3650fb2a28caec979db3e2fa6ed8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FA U+1F1FF",
       "image": "flag_uz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/98bec6637aa40f12511a4d4b38644b4f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FB U+1F1FA",
       "image": "flag_vu.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/65ccf1fb4d436dc3b0744efbf54e81d7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FB U+1F1EA",
       "image": "flag_ve.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7e696a2c87449cc5d09c16ce194ad177.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FB U+1F1F3",
       "image": "flag_vn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/922c3f43d48a6c1a6719d075281014b2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FB U+1F1EC",
       "image": "flag_vg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5399e9180b4721da43e95c5cb61eaa69.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FB U+1F1EE",
       "image": "flag_vi.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/55851af23219b34855d91599fdfec676.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FC U+1F1EB",
       "image": "flag_wf.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/741b35d9d69e38b0cff0eb32e07aa120.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1ED",
       "image": "flag_eh.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/041d2052d66ebf07741398a3ec4927e8.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FE U+1F1EA",
       "image": "flag_ye.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0fae858f4a49391961679a4f8cc719c2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FF U+1F1F2",
       "image": "flag_zm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/17b5fbd7f2e1f2948535374ec8117c8c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FF U+1F1FC",
       "image": "flag_zw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ee2fed8db57613c0404a07c123479963.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1F9 U+1F1E6",
       "image": "flag_ta.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/313d0a452b9892b89296f7360197d8b1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EE U+1F1E8",
       "image": "flag_ic.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dcab6daa93e53f5da4034a7c75a508b6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1E6",
       "image": "flag_ea.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7e98f0a2ee56a554fd24d6cfc42b77ca.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E8 U+1F1F5",
       "image": "flag_cp.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d27cb44ccc271d7c2c5e68a99e9de596.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E6 U+1F1E8",
       "image": "flag_ac.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/313d0a452b9892b89296f7360197d8b1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1E9 U+1F1EC",
       "image": "flag_dg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0e7a86958ca156cd6a88b82282734055.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FA U+1F1F3",
       "image": "flag_un.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/87295c68d8d4b4b5e77bedd4fff07193.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1EA U+1F1FA",
       "image": "flag_eu.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9d002a8f1dad3b9a060e9d057d525e16.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F1FD U+1F1F0",
       "image": "flag_xk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5e405df26f5118637baae744c7a372ce.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3F4 U+E0067 U+E0062 U+E0065 U+E006E U+E0067 U+E007F",
       "image": "flag_gb_eng.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7aa1507ed0d1ca867547ce6fc24b63a3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3F4 U+E0067 U+E0062 U+E0073 U+E0063 U+E0074 U+E007F",
       "image": "flag_gb_sct.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4231e3ea5a9a56b5d0a5c63084268b2d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3F4 U+E0067 U+E0062 U+E0077 U+E006C U+E0073 U+E007F",
       "image": "flag_gb_wls.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6e77e9a4f64607fa8803374f99b24303.png",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F636 U+200D U+1F32B U+FE0F",
       "image": "face-in-clouds.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/35c33136353f7a9148d1884e09efa2a2.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4D3",
       "image": "notebook.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/96f0e34a8543c91ebfd3a284b67c10f8.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F430",
       "image": "rabbit-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f484ec3bca627d7d3a4ed270500a218f.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F407",
       "image": "rabbit.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5f9b1cfba38b4d0994dcb4a806ebdf99.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F95E",
       "image": "pancakes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c84fa0bd7057a77162839154efdeb9a9.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F929",
       "image": "face-with-star-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c49308fd70bc3919d5176d8b93514959.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F92A",
       "image": "zany-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9a7780190e331e8289f1759e393323e2.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F5A5",
       "image": "desktop-computer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fa9846651c48f157150e2d9d436dae21.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F971",
       "image": "yawning-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/20c50fddabf2a4898463d9f040f60f4f.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F6D1",
       "image": "stopsign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7982eccd112fe77fbbde856c85754a91.svg",
-      "author": "kccuber"
+      "author": [
+        "kccuber"
+      ]
     },
     {
       "codepoint": "U+1F9E7",
       "image": "redenvelope.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1b7afb294f972b54b1ba4902b6aedc3f.svg",
-      "author": "kccuber"
+      "author": [
+        "kccuber"
+      ]
     },
     {
       "codepoint": "U+26BD",
       "image": "soccerball.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/607f5525af9c23ac850359c5813dfde2.svg",
-      "author": "kccuber"
+      "author": [
+        "kccuber"
+      ]
     },
     {
       "codepoint": "U+1F5E8",
       "image": "left-speech-bubble.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c24ebd64c72bbf34efec5f809a51915e.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1FAE0",
       "image": "melting-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8388132608d2d5072bfa60f200f8f4f1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1FAF6",
       "image": "hand-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b8bf202970ee9a895742f2264a4e807f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F600",
       "image": "grinning-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0c15e1baf0ceb7b2cdc8cc81180ab39b.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F603",
       "image": "grinning-face-with-big-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ac8c25025a535cd07c4e8161d0043ef4.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F604",
       "image": "grinning-face-with-smiling-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e5b0c04a1f5858b75e1b51b9a4940b9a.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F601",
       "image": "beaming-face-with-smiling-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b9cf9f4739cde9a3edf6edd9a0f3741e.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F606",
       "image": "grinning-squinting-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1f49ab7f8d956f2f60aa5fbccbb8ab40.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F605",
       "image": "grinning-face-with-sweat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2abbeac9ae59e5a76bea2b71bb9f8d7b.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F602",
       "image": "face-with-tears-of-joy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3bb355d7c0d2ee8f9c70dae145a9605a.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F642",
       "image": "slightly-smiling-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5a5d854c6821690dbff981f3835bdc67.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F609",
       "image": "winking-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fc5acf4e761a96504d7b7af588c7f22c.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F60A",
       "image": "smiling-face-with-smiling-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2054896f2611e4b605e6079d7a31b7e8.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F607",
       "image": "smiling-face-with-halo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/096363982d69663b05722ef195b647f8.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F60D",
       "image": "smiling-face-with-heart-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7ef91f9f5c1bf402d78e555b289be9c0.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F618",
       "image": "face-blowing-a-kiss.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ae942d36f87ea9ab1e5361afbcbded60.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F617",
       "image": "kissing-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b33650bb95edf2bcf025591cbbe8ecdb.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+263A",
       "image": "smiling-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/212fd1f600e9a8c1fa5ab80387399a55.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F61A",
       "image": "kissing-face-with-closed-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b6193dc2a0cb3faa70b36f13b909dd9f.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F619",
       "image": "kissing-face-with-smiling-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1e55cf69d57b95a07e5fb47ff0ac3b54.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F60B",
       "image": "face-savoring-food.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b9a2ca2b12544a87346e057c1a71275.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F61B",
       "image": "face-with-tongue.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0c2e4bb1f58c618cae82606b4a71d700.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F61C",
       "image": "winking-face-with-tongue.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5650b9599f817b2f88652fc9cf713a82.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F61D",
       "image": "squinting-face-with-tongue.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2675f85a4534c1efa5b24d02703298ec.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F911",
       "image": "money-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4e6307b164d86f6429ce620eb07a0c33.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F917",
       "image": "smiling-face-with-open-hands.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0b8d40c8544ae1a2d80d6a69a6dd6293.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F610",
       "image": "neutral-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2bd52a6855b503e46225a3a219f94ae2.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F60F",
       "image": "smirking-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/282b4b13861fff7e20ca92b12e772724.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F612",
       "image": "unamused-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/05a877503ffd503c763b478bf9d1c0da.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F644",
       "image": "face-with-rolling-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ab9a149bb90445c82ae71682b1360012.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F60C",
       "image": "relieved-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dc9572c1f62fc1909c8ff34c04bb7858.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F62A",
       "image": "sleepy-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f472c01d24d4b23600b658cdf1f505ec.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F634",
       "image": "sleeping-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a0b3fd147cb85c4dd1c7b73f29028706.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F637",
       "image": "face-with-medical-mask.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/63514816b45c67f72fcbd3b5c96df496.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F912",
       "image": "face-with-thermometer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b3343c3a67b8356a18f886b40e7c9db9.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F915",
       "image": "face-with-head-bandage.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/93255774227bd7e197d298981b6044bd.svg",
-      "author": "Vaibhs11\nlolecksdeehaha"
+      "author": [
+        "Vaibhs11",
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F60E",
       "image": "smiling-face-with-sunglasses.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d0fa866b29546edff9cf2d885d544a19.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F913",
       "image": "nerd-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6f1db6d65ba7c99e13592de0474a5e2f.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F615",
       "image": "confused-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/edd1777c86366f0e6410e37f4503fb02.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F61F",
       "image": "worried-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b06e7ccc560e96e09117884b08471d0.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F641",
       "image": "slightly-frowning-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/664e3efb97e59d409ea3bfaad8fc1aaa.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+2639",
       "image": "frowning-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/11f22d0b3d1c3c454ae92b4ccda516ff.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F62E",
       "image": "face-with-open-mouth.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a70a885a44f593bc080a4c1db9af75a8.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F62F",
       "image": "hushed-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/deaa0e9ebbb663311a83e460e06b2991.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F632",
       "image": "astonished-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4c882628e9b71e205cdc98ef97af23f5.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F633",
       "image": "flushed-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8e2b4a83330c889c58d2ee82185a621b.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F626",
       "image": "frowning-face-with-open-mouth.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/69bb1a56f70ed13ebe983d6214acb37a.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F627",
       "image": "anguished-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7136f3b857afc1472442a849ea2511f5.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F628",
       "image": "fearful-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f2ed1a97e8ab884283a7b37ee6dd8e91.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F630",
       "image": "anxious-face-with-sweat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/82be531e59151ac9ee493c1de2d295da.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F625",
       "image": "sad-but-relieved-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/75c1834c1fe9fe426c6894cf8d9bc11e.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F622",
       "image": "crying-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dfd4cdfc0355cea968ec5f911e0e5e54.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F62D",
       "image": "loudly-crying-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/afaa9143cf9bdef5453fdc14a9ada391.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F631",
       "image": "face-screaming-in-fear.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/af7d679a929017a6987040878561d142.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F616",
       "image": "confounded-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4b1b506fdcc4ed1fa8bd8822e5d953b0.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F623",
       "image": "persevering-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/36d48b17d14c5344564233724326aa5d.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F61E",
       "image": "disappointed-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6021cf4d184254589450db9f3f457047.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F613",
       "image": "downcast-face-with-sweat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1bd1d67944fe0aab3107d34507a82589.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F629",
       "image": "weary-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3c50e21e2c4011280f814ff507043089.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F62B",
       "image": "tired-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5f60fbdea630ae387112929db7fecb16.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F624",
       "image": "face-with-steam-from-nose.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8e11044af0a887b5b39514022a34a3a5.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F621",
       "image": "enraged-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a12075815be6a61ebe2bb038f79c8381.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F620",
       "image": "angry-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2093b438a6ec70fad74a695ff5de7b5d.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+2620",
       "image": "skull-and-crossbones.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f26e601ba15a0371c055d7aa613d5cb4.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F4A9",
       "image": "pile-of-poo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1c817eaddb0affc4c8150ffffd70b3cd.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F479",
       "image": "ogre.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/53d1ba4c5f5eb98b6265729a4af9a936.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F47A",
       "image": "goblin.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2105a383e16a1dcf07c0b4eca86aaa45.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F47B",
       "image": "ghost.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b7b32dd7014f5caa22ce37e1edc79d9c.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F47D",
       "image": "alien.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/23eade52d4c040c22eebd0c78d4ce3e1.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F648",
       "image": "see-no-evil-monkey.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/595981cd866e36c86208b6ef1842493a.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F649",
       "image": "hear-no-evil-monkey.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/22105251fc3a115ff16e4e8b90599afe.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F64A",
       "image": "speak-no-evil-monkey.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1bbba38221d2d69f2610e274bada8b70.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F30A",
       "image": "water-wave.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e55d2c309585f35c44c34c4c48941c91.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4BB",
       "image": "laptop.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4f118f6a50a6b6cdbcd2c1a867473434.svg",
-      "author": "mybearworld\nstickfiregames"
+      "author": [
+        "mybearworld",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F5E3",
       "image": "speaking-head-in-silhouette.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/526f7faafc293932f3f365cc59a9fb6e.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F464",
       "image": "bust-in-silhouette.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/96dbfbf17e3a74f52c75401a3b51970a.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F465",
       "image": "busts-in-silhouette.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/655018def3d84f5e866443883772d38d.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1FAC2",
       "image": "people-hugging.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6d939016696e1e94e310747cd4d7f861.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F4B4",
       "image": "yen-banknote.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6fea5f173ca9e10dbb40749567cb66ab.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4B5",
       "image": "dollar-banknote.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c7f72b5b8f2e0f9e03922ab9633f0e59.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4B6",
       "image": "euro-banknote.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/be9818d7309f130bccff7512bc6b4f9c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4B7",
       "image": "pound-banknote.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4fa9e483af395723e0cfdfcc7da5963e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2660",
       "image": "spades-suit.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6bdf570551149d578b2713193d0de125.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2665",
       "image": "hearts-suit.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/846e004eb8d1793b4d13ae8e7d7cc704.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2666",
       "image": "diamonds-suit.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1c834287e3ab3fda29f158e5b76eff79.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2663",
       "image": "clubs-suit.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ff5e5bbadadf46762b3b2a5216bef9e3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F500",
       "image": "button-shuffle-tracks.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9841627c0e869427095c9b5e38a6b286.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F501",
       "image": "button-repeat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4ea40c9c56a46db6c4fd60aae68264f0.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F502",
       "image": "button-repeat-single.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/13f96d5e702640bbe564eb7c43761f54.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+25B6",
       "image": "button-play.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2b6c4f080ab326b572b30800e705e2a1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23E9",
       "image": "button-fast-forward.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a1a8a32b3c5e6a1786467a6b3ed9f2a0.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23ED",
       "image": "button-next-track.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/35a00d6771d207a705c1a3ab54e490fc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23EF",
       "image": "button-play-or-pause.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/208e95f94d1bd49b585116ace4d378eb.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+25C0",
       "image": "button-reverse.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fb7e118da70d591fa104adb0b2224e7a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23EA",
       "image": "button-fast-reverse.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a843bac202022bb05cd698c1d39be974.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23EE",
       "image": "button-last-track.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b0667272e8e5593c4e6992657d01e8ec.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F53C",
       "image": "button-upwards.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ff71f76ff1938a060ef4a2f0086a653a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23EB",
       "image": "button-fast-up.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ec73dbed3987b0ce6252780471b8c33f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F53D",
       "image": "button-downwards.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dd03d5c1adf3b2e169e768fd0a53409a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23EC",
       "image": "button-fast-down.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3f8416abc21a955370f73ca76840c7b9.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23F8",
       "image": "button-pause.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d02d335f917551d2a0583c69d9eb7e7f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23F9",
       "image": "button-stop.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4e5d036b0a4c5ac0437dce6c05434816.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23FA",
       "image": "button-record.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/eaaabd276bb149268382fff80b3ac6c9.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+23CF",
       "image": "button-eject.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e4aaa5bac279dd7022fbfae2bc3bfdf1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3A6",
       "image": "button-cinema.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/135b8811e2348ea7e5e7abd0b3d045fc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F505",
       "image": "dim-button.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3345ea275af6b3e34dbd826749d7a62d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F506",
       "image": "bright-button.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b78acbe47c66662d8819cd318a75b9e3.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4F6",
       "image": "button-antenna-bars.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4d6e9b20e5a8708581c97106b0575e4d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4F3",
       "image": "button-vibration-mode.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3057a4609802704c01872f195a410bb2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4F4",
       "image": "button-mobile-phone-off.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/307085fc98db7b92207277d3063eaa5f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F941",
       "image": "drum.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/096dfa5872f6d1d2e2e6150b9ee943fd.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4E5",
       "image": "inbox-tray.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0b71b56be00a55f00a6b3c64c014743d.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F4E4",
       "image": "outbox-tray.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/36aa929c0ef19b0855ef7b8c52cdca05.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1FA7B",
       "image": "x-ray.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c7167b0df1f020c20be9eef74d80c439.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F38A",
       "image": "party-ball.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0afe125130daba3f35dd5388e0e57be0.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+1F973",
       "image": "partying-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/82a301cce03ce09cfb45d278a76e84f8.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+270F",
       "image": "pencil.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/646d71acf00ccae3f099f7281b62ba7b.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F44F",
       "image": "clapping-hands.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/073c2ccf6d7fdee7bdc1fc54648f2659.svg",
-      "author": "mcgoomba\nstickfiregames"
+      "author": [
+        "mcgoomba",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2693",
       "image": "anchor.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/17fbef407cdcf28de64780ffa2c3a4dc.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F6DE",
       "image": "wheel.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c212c5b37b187911a19196a979cf6b62.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F6DD",
       "image": "playground-slide.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/64a1b21c875d6f5d3d2d2c104ad13291.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAD9",
       "image": "jar.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0dabef4c201de04307b18a3a88189607.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAD7",
       "image": "pouring-water.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/da68c2d9605460209163b766f240c84b.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAD8",
       "image": "beans.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/76361bd2ed0e6ef4e3397d4ad9504485.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FABA",
       "image": "bird-nest-with-eggs.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f62a3372cb28ea887b6b45b20b75da44.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAB9",
       "image": "bird-nest.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0f8c4502263e78c31ad9041d03aaf91f.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAC5",
       "image": "person-with-crown.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5506f46ab8d8eb212331cd1f3f11c8d5.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAF5",
       "image": "hand-pointing-towards-viewer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/57267a610807895ef7d4eee60033efb3.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAF0",
       "image": "hand-with-index-finger-and-thumb-crossed.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ec95eb6d62bfa89c56ea7724655cea84.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAF4",
       "image": "palm-up-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b7022faa087a498b8f01ce371c27ad7b.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAF3",
       "image": "palm-down-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dcc59352260dd9dbb3b41778c13601b1.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAF2",
       "image": "leftwards-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/75919ff6b6fa969103cb483fc226df7d.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAF1",
       "image": "rightwards-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7d8110ab9c1f809ce0622daa89cfe14b.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAE1",
       "image": "saluting-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/79080efc3d1d542eecaa97cd9dcf5a55.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1FAE2",
       "image": "face-with-hand-over-mouth-and-open-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/25ce8db4191bb6e8fb2a345f8e9ba7f7.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F3B5",
       "image": "musical-note.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7f7f2fca17e04d038dbb70c34487930b.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F321",
       "image": "thermometer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/37bf2423a05cb828fc970554a7f3c4ac.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F3CA U+200D U+2642 U+FE0F",
       "image": "man-swimmer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1f07277bb90c8550da20e53f936881d3.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F3CA U+200D U+2640 U+FE0F",
       "image": "woman-swimmer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4fed005faa39f3d51ad10c79855b32ef.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F3CA",
       "image": "swimmer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b7b0ca030602980e89365b7db9b6e60d.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F30B",
       "image": "volcano.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/264ff9370f6036f50a6ac2447f991657.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4AC",
       "image": "speech-balloon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cd8bd4b09d2bfe5981bb419a0411ba20.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F6CF",
       "image": "bed.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/60121b973bf2c0086c66cbc043bf6307.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F6CC",
       "image": "person-sleeping-in-bed.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e096e9d64d1411656784aab7bd61cc11.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F355",
       "image": "pizza.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/66164af83a2f733377aaef7a816937d7.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F928",
       "image": "face-with-raised-eyebrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/45d6051579e38447610d3da09ddd7129.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F92C",
       "image": "cursing-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1fe629679cfedf55da6aeda68e4f1691.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F327",
       "image": "rain-cloud.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/79fb3aaa4ebc2627dbe97fde357bc34f.svg",
-      "author": "kccuber\nmcgoomba"
+      "author": [
+        "kccuber",
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F923",
       "image": "rolling-on-floor-laughing.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dc62f7c5afefcf61cf5591039a7ceaa3.svg",
-      "author": "lolecksdeehaha\nstickfiregames"
+      "author": [
+        "lolecksdeehaha",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F36A",
       "image": "cookie.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/91970e88e48d0edc71032443189b7a80.svg",
-      "author": "kccuber"
+      "author": [
+        "kccuber"
+      ]
     },
     {
       "codepoint": "U+2B50",
       "image": "star.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8e0190a1c02c894c2553feb3bd8b23e4.svg",
-      "author": "kccuber"
+      "author": [
+        "kccuber"
+      ]
     },
     {
       "codepoint": "U+1F978",
       "image": "disguised-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7c62fce0e505447b5cf9b4151e923ab2.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F5FF",
       "image": "moai.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d0df2cf429accb8b6b5ef3bb027901f7.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F431",
       "image": "cat-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/318b3ac09d2ffa11df0b7349d74ea28e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F927",
       "image": "sneezing-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6dcdfe617fbad53cf0e1db9017ed944a.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F925",
       "image": "lying-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b5a614bbb74b7a2596170359edb6d705.svg",
-      "author": "DinoMaster20\nstickfiregames"
+      "author": [
+        "DinoMaster20",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F408",
       "image": "cat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/21b8f1c0b86b87d9514e28d19c67df96.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F408 U+200D U+2B1B",
       "image": "black-cat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8bd2be9ae29650d9cf2693cc318179a7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F92D",
       "image": "face-with-hands-over-mouth.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/17c815951ba840dd40df06b165ef17cc.svg",
-      "author": "notwait\nDinoMaster20"
+      "author": [
+        "notwait",
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+2757",
       "image": "exclamation-mark.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b9e32944d36520b058d175191543751b.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+2753",
       "image": "question-mark.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/adea4d3805e20c25de25ff71fbcad480.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+2049",
       "image": "exclamation-question-mark.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/76c156b56e9d99352e003bafd3e9d83e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F481",
       "image": "person-tipping-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b04ddb3ebf63554e0cfecdd8689cf875.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F481 U+200D U+2642 U+FE0F",
       "image": "man-tipping-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/79de9c60e9f3af295e30e81c02771780.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F481 U+200D U+2640 U+FE0F",
       "image": "woman-tipping-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e1d86b780a265a6e86cb015bbcb2848e.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F934",
       "image": "man-with-crown.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2ef6f4888b7078579a430c6fa20ab5e3.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F478",
       "image": "woman-with-crown.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5156de355ce0cf9611cb89fd913353ee.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F9D1 U+200D U+1F3EB",
       "image": "teacher.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a505d37a5c05c038154f8ff24e3cd7ab.svg",
-      "author": "Vaibhs11\nstickfiregames"
+      "author": [
+        "Vaibhs11",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F3EB",
       "image": "man-teacher.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7fdcab2f42920ffde50f7225cb0c2754.svg",
-      "author": "Vaibhs11\nstickfiregames"
+      "author": [
+        "Vaibhs11",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F3EB",
       "image": "woman-teacher.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0c96ce7ec9e2ff157441ea6f1d9f37cb.svg",
-      "author": "Vaibhs11\nstickfiregames"
+      "author": [
+        "Vaibhs11",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F5FA",
       "image": "world-map.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1d3fa8dddb210524f5c39929a0e85212.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F937",
       "image": "person-shrugging.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6f069a06e1a49e0e8c89e9456dc1205e.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F937 U+200D U+2642 U+FE0F",
       "image": "man-shrugging.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fb3f0abe3c8a9162c060ca2e05193e06.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F937 U+200D U+2640 U+FE0F",
       "image": "woman-shrugging.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/820a86223d81243b711c296699ef30ff.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+2764 U+FE0F U+200D U+1FA79",
       "image": "mending-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4153d17889652771d161bc05b88f8b2e.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F926",
       "image": "person-facepalming.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a332633ec7b014edcaa89eda7ba586a3.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F926 U+200D U+2642 U+FE0F",
       "image": "man-facepalming.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b68aaea9f106edc840ffb16726bccf5.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F926 U+200D U+2640 U+FE0F",
       "image": "woman-facepalming.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cc41388423d8da50ba7cafae624d5da3.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F466",
       "image": "family-mwb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/88ca3b45c2549bf6475f1e42d12e3bbf.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F467",
       "image": "family-mwg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5279f555dd727757c3682c898cc6616e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466",
       "image": "family-mwgb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e0fd9a83c94320ca71f0786957173864.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F466 U+200D U+1F466",
       "image": "family-mwbb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2106e36d3f36f175954377d94e3801e9.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F467",
       "image": "family-mwgg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3182e6f1f1c6b1f0e6f7c6ed5498586b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F466",
       "image": "family-mmb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c46f08cf7e352bb5f5399df1f1c68bee.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F467",
       "image": "family-mmg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0bdf603f82f5d714f6082bad1b5ffb72.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F467 U+200D U+1F466",
       "image": "family-mmgb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d9deeaf229509831b31c4556e35b2cef.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F466 U+200D U+1F466",
       "image": "family-mmbb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0fc30f132faed4376825a2270010fe9f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F467 U+200D U+1F467",
       "image": "family-mmgg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/38edcb6425740f9b2cf5b2619bf8f1e1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F466",
       "image": "family-wwb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4b69a89f74daabc60dde82eff20e3e64.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F467",
       "image": "family-wwg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/18c408d4b496ca07e75a5b3acb7ea6c1.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466",
       "image": "family-wwgb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/77f420093a18b95ece027d49ea76227d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F466 U+200D U+1F466",
       "image": "family-wwbb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cf70d41b84c76138d5eb19573a1ff311.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F467 U+200D U+1F467",
       "image": "family-wwgg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8bbf89ba2948734151b0faeb9a44f267.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F466",
       "image": "family-mb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7689f375229a9ae346b34caf8d35ecc2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F467",
       "image": "family-mg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/85f9ea7d0c52b1d44857d318a6d1f423.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F467 U+200D U+1F466",
       "image": "family-mgb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2742f713cdc95940ef61d6e4ace2e1de.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F466 U+200D U+1F466",
       "image": "family-mbb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9eb6ebb2f9f4c9f05734f0b04457afe4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F467 U+200D U+1F467",
       "image": "family-mgg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1c9614ebb204815dde65bd11c66faa34.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F466",
       "image": "family-wb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0e6c7b10cf6595330d35c2e64ced778c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F467",
       "image": "family-wg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/56f97e97f06df08e3db3dd56846cbcf4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F467 U+200D U+1F466",
       "image": "family-wgb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/138510e0b6b126a4149aa2553d272674.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F466 U+200D U+1F466",
       "image": "family-wbb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ee81323f580d8a8d3d2e6e4d32735310.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F467 U+200D U+1F467",
       "image": "family-wgg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c755b9d265c7d68afe866c5c98afb13d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F46A",
       "image": "family.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0cd17602ff5c1d43db54d2982a7f0b07.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F9D1",
       "image": "person.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e5c8bf2d18b1bba5e4e2cac7abf75d53.svg",
-      "author": "Vaibhs11\nstickfiregames"
+      "author": [
+        "Vaibhs11",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468",
       "image": "man.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0a616efe49f81542284f64bc84064416.png",
-      "author": "Vaibhs11\nstickfiregames"
+      "author": [
+        "Vaibhs11",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469",
       "image": "woman.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6907bc0accd130bdbe38e196bbed3652.svg",
-      "author": "Vaibhs11\nstickfiregames"
+      "author": [
+        "Vaibhs11",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+270B",
       "image": "raised-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7935a9864d43799fda43cdb439098311.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F590",
       "image": "hand-with-fingers-splayed.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/688ee0624c1571a457de643e5de805af.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F918",
       "image": "sign-of-the-horns.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3eec837f7bb789c0d8b50b7d2fb55471.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F91F",
       "image": "love-you-gesture.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f1990c98aa90266706d4e86eca9aa8b5.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F596",
       "image": "vulcan-salute.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9413006440046318e0684bf4b7fbedc9.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F91E",
       "image": "crossed-fingers.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9a0dee501d8064f2d36c1d58ad9b803c.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+270C",
       "image": "victory-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4cbac57ed600cffa047d882f47f62b9f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+261D",
       "image": "index-pointing-up.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1c8ac749ca712009e5b42d7303f8676f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F91A",
       "image": "raised-back-of-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b5696143da054d28abe922706b9c197.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F436",
       "image": "dog-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/442cde0850ad5c8132510a716e14ba5f.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F508",
       "image": "speaker.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1710579deab02b54af01249cd583784c.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F509",
       "image": "speaker-with-one-sound-wave.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b8cfe78605144f95d6eaadfbb716f11.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F50A",
       "image": "speaker-with-three-sound-waves.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b1d6daaddfa8a7ceaeb51a2034fc269e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4E2",
       "image": "loudspeaker.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9b1b6a8ae570e7ee6497ba08ee1c60cd.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F921",
       "image": "clown.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b0c670601d2208bb5a503153742d6540.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F975",
       "image": "overheated-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4079900d65ef2ca9bacc9a4714933cd7.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F9D0",
       "image": "face-with-monocle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/804010ce3cb2972bdfef419bcbf5d379.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F533",
       "image": "white-square-button.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b1f90c8e5249d5f158fbba3fa02a9c8c.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+2754",
       "image": "white-question-mark.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/67b2d5ff30c2e4c69ffd6af936b55679.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+2755",
       "image": "white-exclamation-mark.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/53cccf4eb7744d9117abc7991d1a54af.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F49F",
       "image": "heart-decoration.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ef3af31f95a053ce8eea5de820b153f0.png",
-      "author": "mcgoomba\nScratch137"
+      "author": [
+        "mcgoomba",
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F49D",
       "image": "heart-with-ribbon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ca690a9152c1e03cb588a5695743ccbb.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F439",
       "image": "hamster.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f6f749ef8e8c4cf608f7f359eff105bd.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F497",
       "image": "growing-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f59393426e659a079194154f0e0b4a55.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F635 U+200D U+1F4AB",
       "image": "face-with-spiral-eyes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1202e4e772fd47a271c499c2c04a221e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F924",
       "image": "drooling-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/acfb1523633529fb0f5dc8b125cbc35e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+203C",
       "image": "double-exclamation-mark.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8730973189bbf9c5573688f7fd28d462.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F532",
       "image": "black-square-button.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/75924cde24418a1b51f7253b0487b90b.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F493",
       "image": "beating-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bbe7fd9c0975347d6ed73fbc3a71be30.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F6AB",
       "image": "no-sign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f82cf26d852bab88f8a4518aa018db9d.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+2B55",
       "image": "red-o.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/726506e9069460e42403183c680029b0.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+26A0",
       "image": "warning-sign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/735f68fbdb8ed523231761fd08d10c3e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F3B2",
       "image": "dice.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f44a03e271069fed6e333a519e686acb.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F437",
       "image": "pig-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c4c8e982eb3216d9f6ba3d8711f2dc0a.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F9B5",
       "image": "leg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bd1ccd7d382f4e725330e61d4414730d.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4AA",
       "image": "flexed-biceps.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/828e62cb0fc07c19f11532c7dbd312e0.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F48E",
       "image": "gem-stone.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/545f188720c60a809d9c5ae02327fac5.svg",
-      "author": "Andygun11"
+      "author": [
+        "Andygun11"
+      ]
     },
     {
       "codepoint": "U+1F9FF",
       "image": "nazar-amulet.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/05516dd42418f225e507d21817c83a01.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F4CF",
       "image": "ruler.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/77492e0ab518f8da1113eb7691d825bb.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4D0",
       "image": "triangular-ruler.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b3faf66e1d266fb3e3b3d7db0302613d.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F974",
       "image": "woozy-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8a53c79d26d84510cc3768150146e716.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F63D",
       "image": "kissing-cat.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4f0a15a3815916e4fff6ef6d2d92f260.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F383",
       "image": "pumpkin.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e2b8862b7e3ad5bc2aa007c9b5a11be3.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F54E",
       "image": "menorah.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/016f26cdc77bc52d106bbec1a02c1935.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4CD",
       "image": "round-pushpin.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/498a6267d1b43a414c0a2880b82e0b85.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F512",
       "image": "locked.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dfe5a05bdf63550d02184dcda3192037.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F513",
       "image": "unlocked.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cd6806b6e78767253f99418af1aaa6fa.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F31E",
       "image": "sun-with-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fa7913b23b7e9286c4ec4adf02b3073a.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F92B",
       "image": "shushing-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/64ab1dbd2576cc2281609b170ec419e4.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F43D",
       "image": "pig-nose.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/be6f09e75b23d9904bbfc9fa84710c4a.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+24C2",
       "image": "button-m.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4a6f9b48d0cd4e1c79b3aeab4eee1d8e.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F194",
       "image": "button-id.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9b272b968c3629706ea49baf5cf02e6a.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F17F",
       "image": "button-p.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bb2162c8e974057e0440778e3b7ac620.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+002A U+FE0F U+20E3",
       "image": "keycap-star.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3f6c213fd81fce74e28416141bf23bec.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+0023 U+FE0F U+20E3",
       "image": "keycap-hash.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/354d4c25d17b1d1f245fe9aca2d3736f.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F9C5",
       "image": "onion.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d292d5f7a699f8f2f27190d5a572599d.svg",
-      "author": "PoIygon"
+      "author": [
+        "PoIygon"
+      ]
     },
     {
       "codepoint": "U+1F4EE",
       "image": "postbox.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bfafcf5158c6f367508220dc651ba9d6.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1FAAB",
       "image": "low-battery.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/202676a717d04b16ee9a8c393fc016f6.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F4CE",
       "image": "paperclip.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/09e51ed66f67dc678f535b0914ffb94e.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1FAA7",
       "image": "placard.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cd3e9edd2eead957d437d8676a151019.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F50D",
       "image": "left-magnifying-glass.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b85d5401781c5e750811f3c0c299a465.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F50E",
       "image": "right-magnifying-glass.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f405b3e9dbc4b9f6f064798e9b96538a.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F9F7",
       "image": "safety-pin.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6bcc0db9bacf31b9839599bbf4189f71.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F4DC",
       "image": "scroll.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9ed576869b617ec8f52bdf67582bc6dd.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F5BC",
       "image": "framed-picture.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/da3d1159cfc854295c094194d69970a7.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F970",
       "image": "smiling-face-with-hearts.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5ed76f73c6bd2c85207ae2e886e8ab8d.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1FAE3",
       "image": "face-with-peeking-eye.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/adec40410dea2b0d5d099dd34fcb585e.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2764 U+FE0F U+200D U+1F525",
       "image": "heart-on-fire.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/39b25c9960fb843b7bf01bf6eeee9802.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4A3",
       "image": "bomb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6d86d48d89a2327c51bfece8eb906da2.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F445",
       "image": "tongue.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/897b75366d5418c9f048ee04b04a33dc.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F444",
       "image": "mouth.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ff6e60b51763cd2b22dca2ed736871f5.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F441 U+FE0F U+200D U+1F5E8 U+FE0F",
       "image": "eye-in-speech-bubble.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9292757d499d384eb81f956497a62165.svg",
-      "author": "TheTrillion\nScratch137\nstickfiregames"
+      "author": [
+        "TheTrillion\nScratch137",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F645",
       "image": "person-with-crossed-arms.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4c5b2884f811a34f45325f1a9c89ae36.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F645 U+200D U+2642 U+FE0F",
       "image": "man-with-crossed-arms.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4db093d737a521ccc770ce134e07805e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F645 U+200D U+2640 U+FE0F",
       "image": "woman-with-crossed-arms.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/553710386b07f9e0e2df110d655696f6.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4A0",
       "image": "diamond-with-a-dot.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/738d475ad58060d25e372c5937c765d6.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F4B2",
       "image": "heavy-dollar-sign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/26c03ab2b464aac49fbaa4ae34de0785.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F3B6",
       "image": "musical-notes.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/350330f0ae5a00787196d4f6555d2c40.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F3BC",
       "image": "musical-score.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cc4cee834df19902013505100bebef65.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F518",
       "image": "radio-button.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/32e39d236a2267e76a7646aa96884cbc.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F64B",
       "image": "person-raising-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d0c0af511a5509b61732b2331013442a.svg",
-      "author": "DinoMaster20\nstickfiregames"
+      "author": [
+        "DinoMaster20",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F64B U+200D U+2642 U+FE0F",
       "image": "man-raising-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/13d0a1cdf70d4ba94fad50a69ebd6cf0.svg",
-      "author": "DinoMaster20\nstickfiregames"
+      "author": [
+        "DinoMaster20",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F64B U+200D U+2640 U+FE0F",
       "image": "woman-raising-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c39ac29ad79a0b5d597c9ac87092c88d.svg",
-      "author": "DinoMaster20\nstickfiregames"
+      "author": [
+        "DinoMaster20",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F646",
       "image": "person-gesturing-ok.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1bd0dc08c52ec8b42008c73bd03bbc75.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F646 U+200D U+2642 U+FE0F",
       "image": "man-gesturing-ok.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/68fde67c26514d80f9703aafeeadf646.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F646 U+200D U+2640 U+FE0F",
       "image": "woman-gesturing-ok.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5a002b9b34c82cb1f14a99bfd0936b8b.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F9D1 U+200D U+1F373",
       "image": "cook.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/41ffdee43498a8423c42144c4577ee6d.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+1F373",
       "image": "man-cook.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2ba75933107f5994a089551d5b77e451.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+1F373",
       "image": "woman-cook.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b6ba1a0e9ba85fcc9a2df5af173ed4dc.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F514",
       "image": "bell.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5fbc4417475b6143d4bb36a3416312aa.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+27B0",
       "image": "curly-loop.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/778d4c04c543a322ce10cd9b1ad5c9c2.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+27BF",
       "image": "double-curly-loop.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8958047454202e611b90d28dd659ed81.svg",
-      "author": "mcgoomba\nstickfiregames"
+      "author": [
+        "mcgoomba",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2122",
       "image": "tm-sign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b2df63d61249b5bfee0b270b81b7de0e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4A4",
       "image": "zzz.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6c880478a039a01cc14c798d73e7659d.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F58D",
       "image": "crayon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9d5f9772eab5afce9452dc48437bfe4f.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F344",
       "image": "mushroom.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/44e5e91194b73a5bfd71c1cf173c20b0.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F6F8",
       "image": "ufo.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3210ba5c1ce5e2bdb7437f86cb01e3ea.svg",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1F388",
       "image": "balloon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bff58ab589bf62c8cc37d9506a4771ff.svg",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1F3AB",
       "image": "ticket.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d0047ababa5906e2ecc17b0372f5624c.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1F4BE",
       "image": "floppydisk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1fe5a5e7f87d52c61601f69e589fb5f6.svg",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+231B",
       "image": "hourglass.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/93f5f4bc58e5e548e9ec6d8c7bad0ede.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+23F3",
       "image": "hourglass-with-sand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c030fc16f9c46470ce0bc40837501c76.svg",
-      "author": "Scratch137"
+      "author": [
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F9C3",
       "image": "juice.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/52f78e6b8c4d212394c68891299c3a6d.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4BF",
       "image": "optical-disk.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9986346fcc8c057aa0cf59352330c98d.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1F4C0",
       "image": "dvd.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5dafb7fcde8ad6f4f91927adfa5b5e48.png",
-      "author": "-gge\nScratch137"
+      "author": [
+        "-gge",
+        "Scratch137"
+      ]
     },
     {
       "codepoint": "U+1F9BF",
       "image": "mechanical-leg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/072a044a48337b4f3216be64d3ab4b2f.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F9BE",
       "image": "mechanical-arm.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/216e5dca614276a69afed67638a11137.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F4B0",
       "image": "money-bag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/912a5a7fdb5b2a4f859ffa3cd21eba28.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1FA99",
       "image": "coin.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d0e0477edcc844cf742d815acfd3aa9f.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F4B1",
       "image": "currency-exchange.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1018dcad4cc73a25f23e4854b90601e2.svg",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F4AD",
       "image": "thinking-speech-bubble.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8c8bd296ead3b89b39cd074feaa589d2.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F5EF",
       "image": "anger-speech-bubble.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a1ab56d66877a93870c86bdb1904daad.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F9CB",
       "image": "bubble-tea.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c2db8bfade4d55df3d0bc51875b085a6.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F44B",
       "image": "waving-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c0d690680fe83c532b7626a3cf47c6a7.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F354",
       "image": "hamburger.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cce939d625e2a49c0b95081b4a92bb48.svg",
-      "author": "tarsovbak"
+      "author": [
+        "tarsovbak"
+      ]
     },
     {
       "codepoint": "U+1F35F",
       "image": "french-fries.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/409fa0968bc49556c091f91ffa7593ec.svg",
-      "author": "tarsovbak"
+      "author": [
+        "tarsovbak"
+      ]
     },
     {
       "codepoint": "U+1F697",
       "image": "automobile.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8539d483e1ffafea58d8005db3d20d00.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F695",
       "image": "taxi.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d69a0e1e6bc7a0f606ab6601e21758af.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F68C",
       "image": "bus.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e2267c0781cfa93a131a87eabbbb22cd.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F68E",
       "image": "trolleybus.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/265935d3c1c4d2ca5c89b576958abd50.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F69F",
       "image": "suspension-railway.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7d89418e2dc49e10a8015f8d3a653737.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F687",
       "image": "metro.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/01fe3bedb139f79dae81a214da4b86b7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6F5",
       "image": "motor-scooter.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7b0ba1a5ed91ce10aad6c45865590d91.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6FA",
       "image": "auto-rickshaw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7728c212e01b125edff5090f1fbed040.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6B2",
       "image": "bicycle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9c2cf4ab12e5f11210feadd81e723a00.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6B4",
       "image": "person-biking.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c5f6e0347410df60a3db46b2f36cab65.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6B4 U+200D U+2642 U+FE0F",
       "image": "man-biking.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/378c395d1cff8c620dbfc0f7c8544070.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6B4 U+200D U+2640 U+FE0F",
       "image": "woman-biking.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ae48fd2ea0acd4c98ff2c796ad5546b7.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F9B4",
       "image": "bone.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f87e8488cf2453925f59d49c9c858f45.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F9B7",
       "image": "tooth.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2c6f0aa7624d0d4a9be5f1acfb6f1733.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4DA",
       "image": "stack-of-books.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8b406c1ca7b3c928c29f2c28b5166f3e.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F4D6",
       "image": "open-book.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0e20e22c4f3d8a09217dde0f703bd933.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+267E",
       "image": "infinity.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/85a7f7eccd671e2d6a963375c04c2667.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F9CA",
       "image": "ice-cube.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dccb5181295e359265d92479f5cf4a19.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F310",
       "image": "globe-with-meridians.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1bcde767ff437672ed022bcbbb9e9916.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F415",
       "image": "dog.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7fba08ace3c09dd20f1113362cc280b0.svg",
-      "author": "JackyBorderCollie"
+      "author": [
+        "JackyBorderCollie"
+      ]
     },
     {
       "codepoint": "U+3030",
       "image": "wavy-dash.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/eac3c64de1e55fb9415204f1dea5d021.svg",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1F964",
       "image": "cup-with-straw.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/de15df1e4f55274d70cbe79fcf6e4870.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F3B9",
       "image": "musical-keyboard.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/45896a8f21c6031910b1659babc9d3ff.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F530",
       "image": "japanese-symbol-for-beginner.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2ce59abd4c20f5371d71d510048689a7.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F519",
       "image": "back-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/96ea91b2de4a2733ee069bdc6b519c51.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F51A",
       "image": "end-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/be7f4709196fcc85d4a4c14c5fefd489.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F51B",
       "image": "on-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0799d6aeaa6dda99f406615f119bb71d.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F51C",
       "image": "soon-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ebfb4a91fe604fb4d6bedc7d90d78690.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F51D",
       "image": "top-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3759725f0af793b7ae7e3f05acad9599.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+26A1",
       "image": "high-voltage.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1d0de6d0e9cb0ba2d196099bc95cbce1.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F4E7",
       "image": "email.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8950bf4de231cee16e4f35e6250d04e7.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F4E8",
       "image": "incoming-envelope.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/71abd8f459ea499a15a22768a549023d.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F4E9",
       "image": "envelope-with-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4286959ebda08ef53099766eae2329df.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F573",
       "image": "hole.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5747195849d6af1e31d97abd7f9ef287.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FA93",
       "image": "axe.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a00d70285488e79fd91671ddc5c2a194.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F95A",
       "image": "egg.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cac94b36c2ff3d3c68c679cba24c76b3.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F5DD",
       "image": "oldkey.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/da520e6d26d6fcbc5247d51288f82c5b.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F3C6",
       "image": "trophy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f93296a1d8b73fc3d0af57d30a5e28bd.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F486",
       "image": "person-getting-massage.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7675d9da341cbbbe811cd57f950e47f3.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F486 U+200D U+2642 U+FE0F",
       "image": "man-getting-massage.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/30f9c88c9915b3ee05ce66c4b616e894.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F486 U+200D U+2640 U+FE0F",
       "image": "woman-getting-massage.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3d66bc29b89e25f89029343f24b33452.svg",
-      "author": "DinoMaster20"
+      "author": [
+        "DinoMaster20"
+      ]
     },
     {
       "codepoint": "U+1F6B3",
       "image": "no-bicycles.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7869a71304dde61f1c2b9ff1ae9f1026.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6B7",
       "image": "no-pedestrians.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/996e85846f27af64fed6f7073553cd86.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F507",
       "image": "muted-speaker.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e7ddce7f450e1259424064d196802352.svg",
-      "author": "mcgoomba\nstickfiregames"
+      "author": [
+        "mcgoomba",
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F515",
       "image": "bell-with-slash.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3fe087044527d41aec2951b6b1823ee4.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6AF",
       "image": "no-littering.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/c22a41916d8529b6b53dee94d3b65a11.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F4F5",
       "image": "no-mobile-phones.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6a09a09fa09131ff9a59e1ff2fb5c377.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6B1",
       "image": "non-potable-water.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/80442eb47409eedf3b2dd966583e5bb6.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F6B0",
       "image": "potable-water.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8771b8c084f996a573291f0da12c3c0f.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F48C",
       "image": "love-letter.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3e1bc53379fc341a3d3aeddbdb6a69a4.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F576",
       "image": "dark-sunglasses.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/db98e30355b7384ec073448b9a72d25f.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F004",
       "image": "mahjong-tile-red-dragon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8924d824c340743ed0d5cc66f1877dc4.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F337",
       "image": "tulip.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/96b8a6006b33e6cbd534d0c71e8fff8f.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F6D2",
       "image": "shopping-trolley.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2ec29b9a12b9ee9f152253e383fad6f7.svg",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+2602",
       "image": "umbrella.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7d239a445a65b1af107b1e25f069ef65.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F36D",
       "image": "lollipop.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f29e325a9e22ba83e88a9e5179d372a7.svg",
-      "author": "kccuber"
+      "author": [
+        "kccuber"
+      ]
     },
     {
       "codepoint": "U+1F98B",
       "image": "butterfly.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/14804cd0faa5a507081ab020b1af525a.svg",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+2615",
       "image": "hot-beverage.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/775fb98057354f635e52b2e2baa7cac6.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F43E",
       "image": "paw-prints.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/64617d57877539249cd3c6cfcc7ad54d.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F4A5",
       "image": "collision.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ca1561b7c9c545c63146246408279d2a.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F468",
       "image": "kiss-woman-man.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/506b46d40255a6b5c86d92d498504859.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F468 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F468",
       "image": "kiss-man-man.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9ce7d335813801ca9991fef4333fcff9.png",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F469",
       "image": "kiss-woman-woman.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/1606cd15b5d9f88696306161722fbbf1.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F48F",
       "image": "kiss.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ef406366b3e1696164d550f7e444a16e.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F463",
       "image": "footprint.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3f458323bfb9db7c431b38f0651c5deb.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F4A1",
       "image": "light-bulb.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/250f04b785c577de55c520f471160b23.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F56F",
       "image": "candle.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/926fea5bed8d4090cec6d8093f7cb5fc.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F5FE",
       "image": "map-of-japan.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4274bc86d5c067f79146fe224147fd6d.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F511",
       "image": "key.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/146c7f4882c281f41535fc0fc6f1a68b.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F510",
       "image": "locked-with-key.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5872e236c8b5d1cfc9679dea3164e3b7.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F50F",
       "image": "locked-with-pen.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/50cd1b17bdb8d30f3a4c1ca923056e82.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F9EA",
       "image": "test-tube.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7034fe0444bd5de85583bcd0537ea5fe.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F4E3",
       "image": "megaphone.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5a929c94307f80493d96a897e2473fa6.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F4EF",
       "image": "postal-horn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4698ca18bb7b09351867634a919635dc.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F9ED",
       "image": "compass.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/a579f621bf1de8755481ab03e5aec6fb.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F6CE",
       "image": "bellhop-bell.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3277542cf64b289fc41aa2ecc1238d53.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F9F3",
       "image": "luggage.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ea20a60622543e69842b9ed8b991d162.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F438",
       "image": "frog.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/905cd28ec1d1c99cb8637e1a46c630b5.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F36C",
       "image": "candy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/3e27563bb5182735fc2e553bf2615465.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F37F",
       "image": "popcorn.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cda0102157c65a7eb52c148f9681eb17.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F359",
       "image": "rice-ball.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/11046bf3ca26195e85899fba08d79bc6.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F4B9",
       "image": "chart-increasing-with-yen.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4f1494425562f35512a942cffbc4fada.svg",
-      "author": "Vaibhs11"
+      "author": [
+        "Vaibhs11"
+      ]
     },
     {
       "codepoint": "U+1F9B3",
       "image": "white-hair.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/cfb6e41e0b9a0bafba942b00e6146cee.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F9B0",
       "image": "red-hair.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/20ea29372149d3b0dc3fbb7168e38842.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F9B1",
       "image": "curly-hair.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/654122091ad49b774640c7278e85d2c5.svg",
-      "author": "greg1234567890f"
+      "author": [
+        "greg1234567890f"
+      ]
     },
     {
       "codepoint": "U+1F9B2",
       "image": "bald.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/877f789ea61bc2fe177f7ffd39e479db.svg",
-      "author": "lolecksdeehaha"
+      "author": [
+        "lolecksdeehaha"
+      ]
     },
     {
       "codepoint": "U+00A9",
       "image": "copyright.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8b096993f0b5c2ce92f52cd0de8ffed8.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+00AE",
       "image": "registered-trademark.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0ec1e5f76967ebaf646c50ef56da8e4d.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F4AB",
       "image": "dizzy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bb88aedbd2153e5b95bd18025417800e.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1FAD2",
       "image": "olive.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6fbf4fb36d1551aa20015f5008abce4d.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F4EA",
       "image": "closedmailboxwithloweredflag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fada35ae8b657a845d0bf31e137bcd2b.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F4ED",
       "image": "openmailboxwithloweredflag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dec70db1b6aa8b5e499ead8d74a6075f.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F4EB",
       "image": "closedmailboxwithraisedflag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6b8aff0d73c769d90069cf778ec75a9f.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F4EC",
       "image": "openmailboxwithraisedflag.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f8ac6ddd4b57658180a309b5d9aa06b6.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F9E8",
       "image": "firecracker.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e85b0a243dd60892fa1caad7d518b677.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F4A2",
       "image": "anger.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/44aeb33909629401e06b256ccd82bd31.svg",
-      "author": "64lu"
+      "author": [
+        "64lu"
+      ]
     },
     {
       "codepoint": "U+1F381",
       "image": "wrapped-gift.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7ca0d49a41948c7e7e3fb24b64b3d78f.svg",
-      "author": "TheTrillion"
+      "author": [
+        "TheTrillion"
+      ]
     },
     {
       "codepoint": "U+1F336",
       "image": "hot-pepper.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/e6848c33cfd88b8b0151ff2e7d399e95.svg",
-      "author": "TheSmartGuy1234"
+      "author": [
+        "TheSmartGuy1234"
+      ]
     },
     {
       "codepoint": "U+1F33B",
       "image": "sunflower.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/af98a5e6ab389eecbf6ff9f3f074a4f0.png",
-      "author": "greg1234567890f\ntarsovbak"
+      "author": [
+        "greg1234567890f",
+        "tarsovbak"
+      ]
     },
     {
       "codepoint": "U+1F427",
       "image": "penguin.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fc8262c336729bf15823c97a6f9a9419.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F449",
       "image": "backhand-index-pointing-right.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/410591fbc686867752138336a58f7fcc.png",
-      "author": "YtArie5"
+      "author": [
+        "YtArie5"
+      ]
     },
     {
       "codepoint": "U+1F448",
       "image": "backhand-index-pointing-left.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6da085a072a1ea0a715a107cfefbd533.png",
-      "author": "YtArie5"
+      "author": [
+        "YtArie5"
+      ]
     },
     {
       "codepoint": "U+1F46E U+200D U+2642 U+FE0F",
       "image": "man-police-officer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6ff36d17400b30d95e927748d0d11851.png",
-      "author": "YtArie5"
+      "author": [
+        "YtArie5"
+      ]
     },
     {
       "codepoint": "U+1F46E U+200D U+2640 U+FE0F",
       "image": "woman-police-officer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/13f81f4b19d49169ea7106eed0ac9d42.png",
-      "author": "YtArie5"
+      "author": [
+        "YtArie5"
+      ]
     },
     {
       "codepoint": "U+1F46E",
       "image": "police-officer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/731bdadfef355ce20058ada14cf92bdc.png",
-      "author": "YtArie5"
+      "author": [
+        "YtArie5"
+      ]
     },
     {
       "codepoint": "U+1F9C0",
       "image": "cheese-wedge.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ff48a5403399346dd5386350173c80ca.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F4A8",
       "image": "dashing-away.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ec39a106cef3e120b676c5930b3e8739.png",
-      "author": "mcgoomba"
+      "author": [
+        "mcgoomba"
+      ]
     },
     {
       "codepoint": "U+1FA77",
       "image": "pink-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/16926bbb1818ce2c63376c19a642f1bf.png",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1FA75",
       "image": "light-blue-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b40805cb9b0d081c93aec9aba386a54a.png",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1FA76",
       "image": "grey-heart.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8628805eb99bae02d27736ccb86caf3b.png",
-      "author": "stickfiregames"
+      "author": [
+        "stickfiregames"
+      ]
     },
     {
       "codepoint": "U+1F3E7",
       "image": "atm-sign.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b40a33c2a22463ed637cafe798538508.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F549",
       "image": "om.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9e6fba03051f2ea08733e4343fa84f8d.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+2721",
       "image": "star-of-david.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0e49629f5632d99c1e183845686542d0.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+2638",
       "image": "wheel-of-dharma.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2b12c2f3d8f1c4d80aa27f4478dce5bd.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+262F",
       "image": "yin-yang.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8d2355a58a2f030b674464fa096a624f.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+271D",
       "image": "latin-cross.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/00619bd6486c4da0e486f4309daeaa86.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+2626",
       "image": "orthodox-cross.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f6fbdb5a4f05cacf1750f236e511e8a1.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+262A",
       "image": "star-and-crescent.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/4bad0e200ab5222f8b68cfcd1c3fdc34.png",
-      "author": "mybearworld"
+      "author": [
+        "mybearworld"
+      ]
     },
     {
       "codepoint": "U+1F451",
       "image": "crown.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/67123d468f73385450b228b9cf774aa5.png",
-      "author": "YtArie5"
+      "author": [
+        "YtArie5"
+      ]
     },
     {
       "codepoint": "U+1F365",
       "image": "fish-cake-with-swirl.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d1ca8d091096b5a4127720e5170fe8f5.png",
-      "author": "YtArie5"
+      "author": [
+        "YtArie5"
+      ]
     },
     {
       "codepoint": "U+1F6BC",
       "image": "baby-symbol.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/51b8fc62737751da184a036966121f9b.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F6AE",
       "image": "litter-in-bin.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9bfbece7a595fb2d2e3900929879dfcf.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F6B9",
       "image": "man-symbol.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dcb74c31536bd45b0f4bd2e47611324f.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F6BA",
       "image": "woman-symbol.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/d541b3429e88c6cbc4499e88bd1cd9fe.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+267F",
       "image": "wheelchair.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fdb09ccf63ff7ce6f675f3bbb14da8fc.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F6DF",
       "image": "ring-buoy.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2112f108cd860ca998143c2ac768c9bf.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F50C",
       "image": "electric-plug.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f7d97674b96739607c59b8e82d5ac91c.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4F1",
       "image": "mobile-phone.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bd3c865d0178f5869d465ed9d88b475f.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4F2",
       "image": "mobile-phone-with-arrow.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9799590a9040de9f47542814760afc28.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+260E",
       "image": "telephone.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/88c8ba3599377bbbdbffcba368bc0456.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4DE",
       "image": "telephone-receiver.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/9558b58d6772a0a082765a5dbd461775.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4DF",
       "image": "pager.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/bd267b6f610c0374ad59e7f2abb15b74.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F5B1",
       "image": "computer-mouse.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/00e150e27d82e362a3756476e4740168.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F5B2",
       "image": "trackball.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/781f52e72d485a64f9fcaec1e1bf3b3a.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4BD",
       "image": "minidisc.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/56fbf557042ab7a814284a24c304268d.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+2328",
       "image": "keyboard.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/855fe067589bf16085c40922899b6001.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F5A8",
       "image": "printer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5c1770c4be96f00fec207f5b99d249e9.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4C1",
       "image": "folder.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/70bd6f426beb0950af401ff7235dc1a2.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F4C2",
       "image": "open-folder.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/269daaf6def7a4ebe6833582350532a0.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F528",
       "image": "hammer.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/fe866498c94a53235e9b6477c595bdbe.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F944",
       "image": "spoon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/dcb3893a4e23b2afdd09cd5e7462d24d.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F963",
       "image": "bowl-with-spoon.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/03c4f0a93aa6635b0e4f214339963e31.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F302",
       "image": "closed-umbrella.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/db5f50963f5471cd85b239bbc37fd58c.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+2614",
       "image": "umbrella-with-rain.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/525394e3a253284a91e2150ac754a341.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAF7",
       "image": "leftwards-pushing-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/05a3aee4d5fb9306bd1caa3c4286474d.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1FAF8",
       "image": "rightwards-pushing-hand.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7000387b268ff232a9c98833478b2e09.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F451",
       "image": "crown.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/67123d468f73385450b228b9cf774aa5.png",
-      "author": "YtArie5"
+      "author": [
+        "YtArie5"
+      ]
     },
     {
       "codepoint": "U+1F426",
       "image": "bird.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2675658df96c0f7009f80cb15bf3e966.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F414",
       "image": "chicken.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/17c6ad528e4c9a353c6533d3b307a762.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F413",
       "image": "rooster.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f54e6a090279dfa439cdeea036c5c1e3.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F40C",
       "image": "snail.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8456f3f0c0ddddbe1b03e9bd02f2607f.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F41C",
       "image": "ant.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/897186a53059e9528cec80f40b571be2.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+1F41D",
       "image": "honeybee.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/7c545cdc826b2ee0c00cc2f44a0ae092.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     },
     {
       "codepoint": "U+26BE",
       "image": "baseball.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/5333ce7d17f70b36f7f901b643a5cf8c.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1F94E",
       "image": "softball.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/b9e2e5fc423f2a3d9cbf35c2179613a8.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1F3C0",
       "image": "basketball.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/0dfee9e085aded23588c509fac026b03.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1F39F",
       "image": "admission-tickets.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/8f889d5cc32563c08e9d2858bff519b5.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1FAAA",
       "image": "identification-card.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/ce05e1e44401804aae7a2be830208169.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1FAE8",
       "image": "shaking-face.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/f2e327dfa3b4fd4a4d340eabf4e37140.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+26FA",
       "image": "tent.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/767f3a1577cbeaf62d9ab763ab379050.png",
-      "author": "-gge"
+      "author": [
+        "-gge"
+      ]
     },
     {
       "codepoint": "U+1F426 U+200D U+2B1B",
       "image": "black-bird.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/6d80eb4527d980b1a6282c6d5c97f739.png",
-      "author": "notwait"
+      "author": [
+        "notwait"
+      ]
     }
   ]
 }

--- a/resources/list.js
+++ b/resources/list.js
@@ -1,151 +1,150 @@
-window.onload = function() {
-    // do some promise stuff to make this look better
-    $.getJSON('resources/unicode-emoji.json', function(unicodeEmoji) {
-      $.getJSON('resources/forumoji.json', function(forumoji) {
-        $.getJSON('resources/hidden-emoji.json', function(hiddenEmoji) {
-          // add forumoji data to unicode list
-          function addForumoji(item) {
-            if (item.comment) {
-              delete item.comment;
-            }
-  
-            if (item.category) {
-              //remove hidden emojis
-              item.contents = item.contents.filter(e => !hiddenEmoji.codepoints.find(c => c == e.codepoint));
-  
-              $.each(item.contents, function(index, content) {
-                addForumoji(content);
-              });
-            } else if (item.codepoint) {
-              let emoji = forumoji.emoji.filter(e => (e.codepoint.toLowerCase() == item.codepoint.toLowerCase()));
-              emoji.forEach(e => e.used = true);
-              if (emoji.length > 0) {
-                if (emoji.length > 1) {console.log(`duplicate emoji: ${item.codepoint} ${item.name}`)}
-                emoji = emoji.pop();
-                item.image = emoji.image;
-                item.url = emoji.url.replace(/^https:\/\/assets\.scratch\.mit\.edu\/(?=[0-9a-f])/i, 'https://assets.scratch.mit.edu/get_image/.%2E/');
-                item.author = emoji.author;
-              }
+window.onload = function () {
+  // do some promise stuff to make this look better
+  $.getJSON('resources/unicode-emoji.json', function (unicodeEmoji) {
+    $.getJSON('resources/forumoji.json', function (forumoji) {
+      $.getJSON('resources/hidden-emoji.json', function (hiddenEmoji) {
+        // add forumoji data to unicode list
+        function addForumoji(item) {
+          if (item.comment) {
+            delete item.comment;
+          }
+
+          if (item.category) {
+            //remove hidden emojis
+            item.contents = item.contents.filter(e => !hiddenEmoji.codepoints.find(c => c == e.codepoint));
+
+            $.each(item.contents, function (index, content) {
+              addForumoji(content);
+            });
+          } else if (item.codepoint) {
+            let emoji = forumoji.emoji.filter(e => (e.codepoint.toLowerCase() == item.codepoint.toLowerCase()));
+            emoji.forEach(e => e.used = true);
+            if (emoji.length > 0) {
+              if (emoji.length > 1) { console.log(`duplicate emoji: ${item.codepoint} ${item.name}`) }
+              emoji = emoji.pop();
+              item.image = emoji.image;
+              item.url = emoji.url.replace(/^https:\/\/assets\.scratch\.mit\.edu\/(?=[0-9a-f])/i, 'https://assets.scratch.mit.edu/get_image/.%2E/');
+              item.author = emoji.author;
             }
           }
-  
-          addForumoji(unicodeEmoji);
-  
-          forumoji.emoji.filter(e => !e.used).forEach(e => console.log(`invalid codepoint: ${e.codepoint} ${e.image}`));
-  
-          // create tile list
-          function addTiles(item, container, level) {
-            if (item.category) {
-              let categoryContainer = document.createElement('div');
-              $(categoryContainer).attr('id', item.category);
-              $(categoryContainer).addClass('category');
-              $(categoryContainer).addClass(`category-level-${level}`);
-  
-              let categoryHeader = document.createElement('p');
-              $(categoryHeader).text(item.category);
-              $(categoryContainer).append(categoryHeader);
-  
-              $.each(item.contents, function(index, content) {
-                addTiles(content, categoryContainer, level + 1);
+        }
+
+        addForumoji(unicodeEmoji);
+
+        forumoji.emoji.filter(e => !e.used).forEach(e => console.log(`invalid codepoint: ${e.codepoint} ${e.image}`));
+
+        // create tile list
+        function addTiles(item, container, level) {
+          if (item.category) {
+            let categoryContainer = document.createElement('div');
+            $(categoryContainer).attr('id', item.category);
+            $(categoryContainer).addClass('category');
+            $(categoryContainer).addClass(`category-level-${level}`);
+
+            let categoryHeader = document.createElement('p');
+            $(categoryHeader).text(item.category);
+            $(categoryContainer).append(categoryHeader);
+
+            $.each(item.contents, function (index, content) {
+              addTiles(content, categoryContainer, level + 1);
+            });
+
+            $(container).append(categoryContainer);
+          } else if (item.codepoint) {
+            if (item.image) {
+              let tileImage = document.createElement('img');
+              $(tileImage).attr('src', 'resources/forumoji/' + item.image);
+              $(tileImage).attr('alt', item.name);
+              $(tileImage).attr('tabindex', 0);
+              $(tileImage).attr('id', item.codepoint);
+              $(tileImage).addClass('tile');
+              // change the unpacking to support multiple authors
+              $(tileImage).addClass('author-' + item.author.join(' '));
+              $.each(item.keywords, function (index, keyword) {
+                $(tileImage).addClass('keyword-' + keyword.split(' ').join('-'))
               });
-  
-              $(container).append(categoryContainer);
-            } else if (item.codepoint) {
-              if (item.image) {
-                let tileImage = document.createElement('img');
-                $(tileImage).attr('src', 'resources/forumoji/' + item.image);
-                $(tileImage).attr('alt', item.name);
-                $(tileImage).attr('tabindex', 0);
-                $(tileImage).attr('id', item.codepoint);
-                $(tileImage).addClass('tile');
-                // change the unpacking to support multiple authors
-                $(tileImage).addClass('author-' + item.author.join(' '));
-                $.each(item.keywords, function(index, keyword) {
-                  $(tileImage).addClass('keyword-' + keyword.split(' ').join('-'))
-                });
-  
-                $(tileImage).click(function() {select(item)});
-                $(tileImage).keydown(function({ key }) {
-                  if(key == 'Enter' || key == ' ') select(item)
-                });
-  
-                $(container).append(tileImage);
-              }
+
+              $(tileImage).click(function () { select(item) });
+              $(tileImage).keydown(function ({ key }) {
+                if (key == 'Enter' || key == ' ') select(item)
+              });
+
+              $(container).append(tileImage);
             }
           }
-  
-          addTiles(unicodeEmoji, $('#list'), 0);
-          hideEmptyCategories();
-  
-          let tiles = $('.tile');
-          let randomTile = tiles[Math.floor(Math.random() * tiles.length)]
-          $(randomTile).click();
-        });
+        }
+
+        addTiles(unicodeEmoji, $('#list'), 0);
+        hideEmptyCategories();
+
+        let tiles = $('.tile');
+        let randomTile = tiles[Math.floor(Math.random() * tiles.length)]
+        $(randomTile).click();
       });
     });
-  
-    // search bar
-    document.querySelector('#search').addEventListener('input', function(e) {
-      let query = e.srcElement.value;
-      let unicodeRepr = Array.from(query)
-      .map(s => s.codePointAt(0))
-      .map(c => c.toString(16))
-      .map(n => (n.length > 3 ? '' : '0'.repeat(4 - n.length)) + n)
-      .map(h => 'U+' + h.toUpperCase())
-      .join(' ');
-      let notFound;
-      for (let i of document.querySelectorAll('#list img')) {
-        i.removeAttribute('hidden');
-        notFound = unicodeRepr !== i.id;
-        for (let j of Array.from(i.classList).concat(['keyword-'+i.getAttribute('alt')])) {
-          if (!notFound) {break;}
-          if (/^keyword-/.test(j)) {
-            if (j.toLowerCase().slice(8).includes(query.toLowerCase())) {
-              notFound = false;
-            }
+  });
+
+  // search bar
+  document.querySelector('#search').addEventListener('input', function (e) {
+    let query = e.srcElement.value;
+    let unicodeRepr = Array.from(query)
+    .map(s => s.codePointAt(0))
+    .map(c => c.toString(16))
+    .map(n => (n.length > 3 ? '' : '0'.repeat(4 - n.length)) + n)
+    .map(h => 'U+' + h.toUpperCase())
+    .join(' ');
+    let notFound;
+    for (let i of document.querySelectorAll('#list img')) {
+      i.removeAttribute('hidden');
+      notFound = unicodeRepr !== i.id;
+      for (let j of Array.from(i.classList).concat(['keyword-' + i.getAttribute('alt')])) {
+        if (!notFound) { break; }
+        if (/^keyword-/.test(j)) {
+          if (j.toLowerCase().slice(8).includes(query.toLowerCase())) {
+            notFound = false;
           }
         }
-        if (notFound) {
-          i.setAttribute('hidden', '');
-        }
       }
-  
-      hideEmptyCategories();
-    });
-  }
-  
-  // this can be done in CSS once :has() is widely supported
-  function hideEmptyCategories() {
-    $('.category').attr('hidden', true);
-    $('.tile[hidden!="hidden"]').parents('.category').removeAttr('hidden');
-  }
-  
-  function select(emoji) {
-    $('.selected').removeClass('selected');
-    document.getElementById(emoji.codepoint).classList.add('selected');
-  
-    let githubPath = `https://lopste.github.io/forumoji/resources/forumoji/${emoji.image}`;
-    $('img.preview-image').attr('src', 'resources/forumoji/' + emoji.image);
-    $('img.preview-image').attr('alt', emoji.name);
-    $('#emoji-codepoint').text(emoji.codepoint)
-    $('#name').text(emoji.name);
-    $('#contributors').html(emoji.author.join(',<br>'));
-    if(emoji.author.length > 1) {
-      $('#contributors-label').text('Emoji contributors:')
-    } else {
-      $('#contributors-label').text('Emoji contributor:')
+      if (notFound) {
+        i.setAttribute('hidden', '');
+      }
     }
-  
-    $('#keywords').text(emoji.keywords.join(', '));
-    $('#bbcodeScratch').attr('value', `[img=${emoji.url}]`);
-    $('#bbcodeGithub').attr('value', `[img=${githubPath}]`);
+
+    hideEmptyCategories();
+  });
+}
+
+// this can be done in CSS once :has() is widely supported
+function hideEmptyCategories() {
+  $('.category').attr('hidden', true);
+  $('.tile[hidden!="hidden"]').parents('.category').removeAttr('hidden');
+}
+
+function select(emoji) {
+  $('.selected').removeClass('selected');
+  document.getElementById(emoji.codepoint).classList.add('selected');
+
+  let githubPath = `https://lopste.github.io/forumoji/resources/forumoji/${emoji.image}`;
+  $('img.preview-image').attr('src', 'resources/forumoji/' + emoji.image);
+  $('img.preview-image').attr('alt', emoji.name);
+  $('#emoji-codepoint').text(emoji.codepoint)
+  $('#name').text(emoji.name);
+  $('#contributors').html(emoji.author.join(',<br>'));
+  if (emoji.author.length > 1) {
+    $('#contributors-label').text('Emoji contributors:')
+  } else {
+    $('#contributors-label').text('Emoji contributor:')
   }
-  
-  function copyBBCodeScratch() {
-    navigator.clipboard.writeText($('#bbcodeScratch').attr('value'));
-  }
-  
-  function copyBBCodeGithub() {
-    navigator.clipboard.writeText($('#bbcodeGithub').attr('value'));
-  }
-  
+
+  $('#keywords').text(emoji.keywords.join(', '));
+  $('#bbcodeScratch').attr('value', `[img=${emoji.url}]`);
+  $('#bbcodeGithub').attr('value', `[img=${githubPath}]`);
+}
+
+function copyBBCodeScratch() {
+  navigator.clipboard.writeText($('#bbcodeScratch').attr('value'));
+}
+
+function copyBBCodeGithub() {
+  navigator.clipboard.writeText($('#bbcodeGithub').attr('value'));
+}

--- a/resources/list.js
+++ b/resources/list.js
@@ -1,150 +1,151 @@
 window.onload = function() {
-  // do some promise stuff to make this look better
-  $.getJSON('resources/unicode-emoji.json', function(unicodeEmoji) {
-    $.getJSON('resources/forumoji.json', function(forumoji) {
-      $.getJSON('resources/hidden-emoji.json', function(hiddenEmoji) {
-        // add forumoji data to unicode list
-        function addForumoji(item) {
-          if (item.comment) {
-            delete item.comment;
-          }
-
-          if (item.category) {
-            //remove hidden emojis
-            item.contents = item.contents.filter(e => !hiddenEmoji.codepoints.find(c => c == e.codepoint));
-
-            $.each(item.contents, function(index, content) {
-              addForumoji(content);
-            });
-          } else if (item.codepoint) {
-            let emoji = forumoji.emoji.filter(e => (e.codepoint.toLowerCase() == item.codepoint.toLowerCase()));
-            emoji.forEach(e => e.used = true);
-            if (emoji.length > 0) {
-              if (emoji.length > 1) {console.log(`duplicate emoji: ${item.codepoint} ${item.name}`)}
-              emoji = emoji.pop();
-              item.image = emoji.image;
-              item.url = emoji.url.replace(/^https:\/\/assets\.scratch\.mit\.edu\/(?=[0-9a-f])/i, 'https://assets.scratch.mit.edu/get_image/.%2E/');
-              item.author = emoji.author;
+    // do some promise stuff to make this look better
+    $.getJSON('resources/unicode-emoji.json', function(unicodeEmoji) {
+      $.getJSON('resources/forumoji.json', function(forumoji) {
+        $.getJSON('resources/hidden-emoji.json', function(hiddenEmoji) {
+          // add forumoji data to unicode list
+          function addForumoji(item) {
+            if (item.comment) {
+              delete item.comment;
+            }
+  
+            if (item.category) {
+              //remove hidden emojis
+              item.contents = item.contents.filter(e => !hiddenEmoji.codepoints.find(c => c == e.codepoint));
+  
+              $.each(item.contents, function(index, content) {
+                addForumoji(content);
+              });
+            } else if (item.codepoint) {
+              let emoji = forumoji.emoji.filter(e => (e.codepoint.toLowerCase() == item.codepoint.toLowerCase()));
+              emoji.forEach(e => e.used = true);
+              if (emoji.length > 0) {
+                if (emoji.length > 1) {console.log(`duplicate emoji: ${item.codepoint} ${item.name}`)}
+                emoji = emoji.pop();
+                item.image = emoji.image;
+                item.url = emoji.url.replace(/^https:\/\/assets\.scratch\.mit\.edu\/(?=[0-9a-f])/i, 'https://assets.scratch.mit.edu/get_image/.%2E/');
+                item.author = emoji.author;
+              }
             }
           }
-        }
-
-        addForumoji(unicodeEmoji);
-
-        forumoji.emoji.filter(e => !e.used).forEach(e => console.log(`invalid codepoint: ${e.codepoint} ${e.image}`));
-
-        // create tile list
-        function addTiles(item, container, level) {
-          if (item.category) {
-            let categoryContainer = document.createElement('div');
-            $(categoryContainer).attr('id', item.category);
-            $(categoryContainer).addClass('category');
-            $(categoryContainer).addClass(`category-level-${level}`);
-
-            let categoryHeader = document.createElement('p');
-            $(categoryHeader).text(item.category);
-            $(categoryContainer).append(categoryHeader);
-
-            $.each(item.contents, function(index, content) {
-              addTiles(content, categoryContainer, level + 1);
-            });
-
-            $(container).append(categoryContainer);
-          } else if (item.codepoint) {
-            if (item.image) {
-              let tileImage = document.createElement('img');
-              $(tileImage).attr('src', 'resources/forumoji/' + item.image);
-              $(tileImage).attr('alt', item.name);
-              $(tileImage).attr('tabindex', 0);
-              $(tileImage).attr('id', item.codepoint);
-              $(tileImage).addClass('tile');
-              // change the unpacking to support multiple authors
-              $(tileImage).addClass('author-' + item.author.split(' ').join('-'));
-              $.each(item.keywords, function(index, keyword) {
-                $(tileImage).addClass('keyword-' + keyword.split(' ').join('-'))
+  
+          addForumoji(unicodeEmoji);
+  
+          forumoji.emoji.filter(e => !e.used).forEach(e => console.log(`invalid codepoint: ${e.codepoint} ${e.image}`));
+  
+          // create tile list
+          function addTiles(item, container, level) {
+            if (item.category) {
+              let categoryContainer = document.createElement('div');
+              $(categoryContainer).attr('id', item.category);
+              $(categoryContainer).addClass('category');
+              $(categoryContainer).addClass(`category-level-${level}`);
+  
+              let categoryHeader = document.createElement('p');
+              $(categoryHeader).text(item.category);
+              $(categoryContainer).append(categoryHeader);
+  
+              $.each(item.contents, function(index, content) {
+                addTiles(content, categoryContainer, level + 1);
               });
-
-              $(tileImage).click(function() {select(item)});
-              $(tileImage).keydown(function({ key }) {
-                if(key == 'Enter' || key == ' ') select(item)
-              });
-
-              $(container).append(tileImage);
+  
+              $(container).append(categoryContainer);
+            } else if (item.codepoint) {
+              if (item.image) {
+                let tileImage = document.createElement('img');
+                $(tileImage).attr('src', 'resources/forumoji/' + item.image);
+                $(tileImage).attr('alt', item.name);
+                $(tileImage).attr('tabindex', 0);
+                $(tileImage).attr('id', item.codepoint);
+                $(tileImage).addClass('tile');
+                // change the unpacking to support multiple authors
+                $(tileImage).addClass('author-' + item.author.join(' '));
+                $.each(item.keywords, function(index, keyword) {
+                  $(tileImage).addClass('keyword-' + keyword.split(' ').join('-'))
+                });
+  
+                $(tileImage).click(function() {select(item)});
+                $(tileImage).keydown(function({ key }) {
+                  if(key == 'Enter' || key == ' ') select(item)
+                });
+  
+                $(container).append(tileImage);
+              }
             }
           }
-        }
-
-        addTiles(unicodeEmoji, $('#list'), 0);
-        hideEmptyCategories();
-
-        let tiles = $('.tile');
-        let randomTile = tiles[Math.floor(Math.random() * tiles.length)]
-        $(randomTile).click();
+  
+          addTiles(unicodeEmoji, $('#list'), 0);
+          hideEmptyCategories();
+  
+          let tiles = $('.tile');
+          let randomTile = tiles[Math.floor(Math.random() * tiles.length)]
+          $(randomTile).click();
+        });
       });
     });
-  });
-
-  // search bar
-  document.querySelector('#search').addEventListener('input', function(e) {
-    let query = e.srcElement.value;
-    let unicodeRepr = Array.from(query)
-    .map(s => s.codePointAt(0))
-    .map(c => c.toString(16))
-    .map(n => (n.length > 3 ? '' : '0'.repeat(4 - n.length)) + n)
-    .map(h => 'U+' + h.toUpperCase())
-    .join(' ');
-    let notFound;
-    for (let i of document.querySelectorAll('#list img')) {
-      i.removeAttribute('hidden');
-      notFound = unicodeRepr !== i.id;
-      for (let j of Array.from(i.classList).concat(['keyword-'+i.getAttribute('alt')])) {
-        if (!notFound) {break;}
-        if (/^keyword-/.test(j)) {
-          if (j.toLowerCase().slice(8).includes(query.toLowerCase())) {
-            notFound = false;
+  
+    // search bar
+    document.querySelector('#search').addEventListener('input', function(e) {
+      let query = e.srcElement.value;
+      let unicodeRepr = Array.from(query)
+      .map(s => s.codePointAt(0))
+      .map(c => c.toString(16))
+      .map(n => (n.length > 3 ? '' : '0'.repeat(4 - n.length)) + n)
+      .map(h => 'U+' + h.toUpperCase())
+      .join(' ');
+      let notFound;
+      for (let i of document.querySelectorAll('#list img')) {
+        i.removeAttribute('hidden');
+        notFound = unicodeRepr !== i.id;
+        for (let j of Array.from(i.classList).concat(['keyword-'+i.getAttribute('alt')])) {
+          if (!notFound) {break;}
+          if (/^keyword-/.test(j)) {
+            if (j.toLowerCase().slice(8).includes(query.toLowerCase())) {
+              notFound = false;
+            }
           }
         }
+        if (notFound) {
+          i.setAttribute('hidden', '');
+        }
       }
-      if (notFound) {
-        i.setAttribute('hidden', '');
-      }
-    }
-
-    hideEmptyCategories();
-  });
-}
-
-// this can be done in CSS once :has() is widely supported
-function hideEmptyCategories() {
-  $('.category').attr('hidden', true);
-  $('.tile[hidden!="hidden"]').parents('.category').removeAttr('hidden');
-}
-
-function select(emoji) {
-  $('.selected').removeClass('selected');
-  document.getElementById(emoji.codepoint).classList.add('selected');
-
-  let githubPath = `https://lopste.github.io/forumoji/resources/forumoji/${emoji.image}`;
-  $('img.preview-image').attr('src', 'resources/forumoji/' + emoji.image);
-  $('img.preview-image').attr('alt', emoji.name);
-  $('#emoji-codepoint').text(emoji.codepoint)
-  $('#name').text(emoji.name);
-  $('#contributors').html(emoji.author.replace('\n', ',<br>'));
-  if(emoji.author.split('\n').length > 1) {
-    $('#contributors-label').text('Emoji contributors:')
-  } else {
-    $('#contributors-label').text('Emoji contributor:')
+  
+      hideEmptyCategories();
+    });
   }
-
-  $('#keywords').text(emoji.keywords.join(', '));
-  $('#bbcodeScratch').attr('value', `[img=${emoji.url}]`);
-  $('#bbcodeGithub').attr('value', `[img=${githubPath}]`);
-}
-
-function copyBBCodeScratch() {
-  navigator.clipboard.writeText($('#bbcodeScratch').attr('value'));
-}
-
-function copyBBCodeGithub() {
-  navigator.clipboard.writeText($('#bbcodeGithub').attr('value'));
-}
+  
+  // this can be done in CSS once :has() is widely supported
+  function hideEmptyCategories() {
+    $('.category').attr('hidden', true);
+    $('.tile[hidden!="hidden"]').parents('.category').removeAttr('hidden');
+  }
+  
+  function select(emoji) {
+    $('.selected').removeClass('selected');
+    document.getElementById(emoji.codepoint).classList.add('selected');
+  
+    let githubPath = `https://lopste.github.io/forumoji/resources/forumoji/${emoji.image}`;
+    $('img.preview-image').attr('src', 'resources/forumoji/' + emoji.image);
+    $('img.preview-image').attr('alt', emoji.name);
+    $('#emoji-codepoint').text(emoji.codepoint)
+    $('#name').text(emoji.name);
+    $('#contributors').html(emoji.author.join(',<br>'));
+    if(emoji.author.length > 1) {
+      $('#contributors-label').text('Emoji contributors:')
+    } else {
+      $('#contributors-label').text('Emoji contributor:')
+    }
+  
+    $('#keywords').text(emoji.keywords.join(', '));
+    $('#bbcodeScratch').attr('value', `[img=${emoji.url}]`);
+    $('#bbcodeGithub').attr('value', `[img=${githubPath}]`);
+  }
+  
+  function copyBBCodeScratch() {
+    navigator.clipboard.writeText($('#bbcodeScratch').attr('value'));
+  }
+  
+  function copyBBCodeGithub() {
+    navigator.clipboard.writeText($('#bbcodeGithub').attr('value'));
+  }
+  


### PR DESCRIPTION
Based on #42, this changes the formatting of author names in `/resources/forumoji.json` to use arrays of strings, rather a single string.

This allows for better syntax highlighting compared to separating names with `\n`, and makes the file easier to read.

#### Old:
```json
"author": "authorOne\nauthorTwo"
```
#### New:
```json
"author": [
  "authorOne",
  "authorTwo"
]
```

`README.md` has also been updated to reflect the change, and provide instructions on the new format.