### PR TITLE
Remove Duplicated Crown Emoji

### DIFF
--- a/resources/forumoji.json
+++ b/resources/forumoji.json
@@ -8351,14 +8351,6 @@
       ]
     },
     {
-      "codepoint": "U+1F451",
-      "image": "crown.png",
-      "url": "https://assets.scratch.mit.edu/get_image/.%2E/67123d468f73385450b228b9cf774aa5.png",
-      "author": [
-        "YtArie5"
-      ]
-    },
-    {
       "codepoint": "U+1F426",
       "image": "bird.png",
       "url": "https://assets.scratch.mit.edu/get_image/.%2E/2675658df96c0f7009f80cb15bf3e966.png",


### PR DESCRIPTION
There are currently 2 entries within `resources/forumoji.json` for the crown emoji(👑, `U+1F451`). This PR removes it.