### PR TITLE
Use jdecked's Twemoji fork

### DIFF
--- a/src/EmojiList.ts
+++ b/src/EmojiList.ts
@@ -18,7 +18,7 @@ export const brokenImage = broken;
 
 export function getEmojiImage(codepoint: string, twemoji: boolean): string {
     const normalized = normalizeCodepoint(codepoint);
-    if(twemoji) return `https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/${normalized}.svg`;
+    if(twemoji) return `https://raw.githubusercontent.com/jdecked/twemoji/master/assets/svg/${normalized}.svg`;
     else return `https://raw.githubusercontent.com/lopste/forumoji/main/assets/emoji/15x15/${normalized}.png`;
 }
 


### PR DESCRIPTION
The official Twemoji repository hasn't been updated since Elon Musk's acquisition of Twitter, leaving it stuck on version 14.0.2. As a result, emojis added since then (such as Hyacinth) display as ❓ symbols on the website.

[jdecked's fork of Twemoji](https://github.com/jdecked/twemoji) is maintained by former Twitter developers, and fully supports Emoji 15.

This PR changes `EmojiList.ts` to point to the fork, which should enable these emojis to be displayed.