### PR TITLE
[A11Y] Roles and labels

### DIFF
--- a/src/components/CopyBox.tsx
+++ b/src/components/CopyBox.tsx
@@ -21,8 +21,8 @@ export default function CopyBox(props: CopyBoxProps) {
 
     return (
         <div className="copy-box">
-            <input type="text" value={props.text} readOnly={true} aria-label={props.label} />
-            <button onClick={copyText}>{copied ? "Copied!" : "Copy"}</button>
+            <input type="text" value={props.text} aria-readonly={true} readOnly={true} aria-label={props.label} />
+            <button aria-label="Copy emoji" onClick={copyText}>{copied ? "Copied!" : "Copy"}</button>
         </div>
     );
 }

--- a/src/components/EmojiInfo/EmojiCategories.tsx
+++ b/src/components/EmojiInfo/EmojiCategories.tsx
@@ -9,13 +9,13 @@ interface EmojiNameProps {
 export default function EmojiCategories(props: EmojiNameProps) {
     if(!props.emoji) return (
         <>
-            <div className="emoji-categories">
-                <strong>Category:</strong><br />
-                <span>N/A</span>
+            <div className="emoji-categories" aria-label="Category: N/A">
+                <strong aria-hidden="true">Category:</strong><br aria-hidden="true" />
+                <span aria-hidden="true">N/A</span>
             </div>
 
-            <div className="emoji-keywords">
-                <strong>Keywords:</strong><br />
+            <div className="emoji-keywords" aria-label="Keywords">
+                <strong aria-hidden="true">Keywords:</strong><br aria-hidden="true" />
                 <span>N/A</span>
             </div>
         </>
@@ -23,13 +23,13 @@ export default function EmojiCategories(props: EmojiNameProps) {
 
     return (
         <>
-            <div className="emoji-categories">
-                <strong>Category:</strong><br />
-                <span>{props.emoji.category}</span>
+            <div className="emoji-categories" aria-label={"Category: " + props.emoji.category}>
+                <strong aria-hidden="true">Category:</strong><br aria-hidden="true" />
+                <span aria-hidden="true">{props.emoji.category}</span>
             </div>
 
-            <div className="emoji-keywords">
-                <strong>Keywords:</strong><br />
+            <div className="emoji-keywords" aria-label="Keywords">
+                <strong aria-hidden="true">Keywords:</strong><br aria-hidden="true" />
                 <span>{props.emoji.keywords.join(", ")}</span>
             </div>
         </>

--- a/src/components/EmojiInfo/EmojiCodepoint.tsx
+++ b/src/components/EmojiInfo/EmojiCodepoint.tsx
@@ -6,6 +6,6 @@ export default function EmojiCodepoint(props: { codepoint: string | undefined })
     const codepoint = props.codepoint ? prettyCodepoint(props.codepoint).join(" ") : "N/A";
 
     return (
-        <p className="emoji-codepoint">{codepoint}</p>
+        <p className="emoji-codepoint" aria-label="Codepoint">{codepoint}</p>
     );
 }

--- a/src/components/EmojiInfo/EmojiContributors.tsx
+++ b/src/components/EmojiInfo/EmojiContributors.tsx
@@ -2,15 +2,15 @@ import React from "react";
 
 export default function EmojiContributors(props: { contributors: string[] | undefined }) {
     return (
-        <div className="emoji-contributed">
-            <strong>{props.contributors ? "Contributed by:" : "Not contributed"}</strong>
+        <div className="emoji-contributed" aria-label={props.contributors ? "Contributed by:" : "Not contributed"}>
+            <strong aria-hidden="true">{props.contributors ? "Contributed by:" : "Not contributed"}</strong>
             {
                 props.contributors ? (
-                    <div className="contributors">
+                    <div className="contributors" role="list">
                         {
                             props.contributors.map((contributor, index) => (
-                                <div key={index} className="contributor-name">
-                                    <span>&#x2022; {contributor}</span>
+                                <div key={index} className="contributor-name" role="listitem">
+                                    <span aria-hidden="true">&#x2022; </span><span>{contributor}</span>
                                 </div>
                             ))
                         }

--- a/src/components/EmojiInfo/EmojiCopy.tsx
+++ b/src/components/EmojiInfo/EmojiCopy.tsx
@@ -17,6 +17,8 @@ interface SliderButtonProps {
     title: string;
     setTo: string;
 
+    sliderChoice: string;
+
     id: number;
     idSelected: number;
 
@@ -31,7 +33,7 @@ export function SliderButton(props: SliderButtonProps) {
     };
 
     return (
-        <button className="slider-button" title={props.title} onClick={props.onChange.bind(null, props.setTo, props.id)} data-selected={props.idSelected == props.id}>
+        <button className="slider-button" role="radio" name={props.sliderChoice} title={props.title} onClick={props.onChange.bind(null, props.setTo, props.id)} data-selected={props.idSelected == props.id}>
             <div className="slider-button-icon" style={style}/>
         </button>
     );
@@ -74,27 +76,27 @@ export default function EmojiCopy(props: { emoji?: EmojiData }) {
     };
 
     return (
-        <div id="emoji-copy">
-            <div id="emoji-copy-options">
-                <div id="emoji-copy-host" data-selected={hostSelected}>
-                    <SliderButton title="Cubeupload" setTo="https://u.cubeupload.com/fmji/"
+        <div id="emoji-copy" aria-label="Copy emoji" role="form">
+            <div id="emoji-copy-options" aria-label="Copy options" role="group">
+                <div id="emoji-copy-host" data-selected={hostSelected} aria-label="Emoji host">
+                    <SliderButton sliderChoice="copy-host" title="Cubeupload" setTo="https://u.cubeupload.com/fmji/"
                         id={0} idSelected={hostSelected}
                         image={Cubeupload} onChange={onHostChange} />
-                    <SliderButton title="Github" setTo="https://gh.vercte.net/assets/emoji/15x15/"
+                    <SliderButton sliderChoice="copy-host" title="Github" setTo="https://gh.vercte.net/assets/emoji/15x15/"
                         id={1} idSelected={hostSelected}
                         image={Github} onChange={onHostChange} />
                 </div>
-                <div id="emoji-copy-format" data-selected={formatSelected}>
-                    <SliderButton title="Link" setTo="raw"
+                <div id="emoji-copy-format" data-selected={formatSelected} aria-label="Format">
+                    <SliderButton sliderChoice="copy-format" title="Link" setTo="raw"
                         id={0} idSelected={formatSelected}
                         image={Link} onChange={onFormatChange} />
-                    <SliderButton title="HTML" setTo="html"
+                    <SliderButton sliderChoice="copy-format" title="HTML" setTo="html"
                         id={1} idSelected={formatSelected}
                         image={HTML} onChange={onFormatChange} />
-                    <SliderButton title="BBCode" setTo="bbcode"
+                    <SliderButton sliderChoice="copy-format" title="BBCode" setTo="bbcode"
                         id={2} idSelected={formatSelected}
                         image={BBCode} onChange={onFormatChange} />
-                    <SliderButton title="Markdown" setTo="markdown"
+                    <SliderButton sliderChoice="copy-format" title="Markdown" setTo="markdown"
                         id={3} idSelected={formatSelected}
                         image={Markdown} onChange={onFormatChange} />
                 </div>

--- a/src/components/EmojiInfo/EmojiImage.tsx
+++ b/src/components/EmojiInfo/EmojiImage.tsx
@@ -18,8 +18,8 @@ export default function EmojiImage(props: { emoji?: EmojiData }) {
                     }
                 }/>
             </figure>
-            <strong>Normal Size:</strong>
-            <div id="emoji-preview">
+            <strong aria-hidden="true">Normal Size:</strong>
+            <div id="emoji-preview" aria-label="Normal Sized" role="group">
                 <img className="emoji-image-small" src={imageSrc} alt={name} loading="lazy" onError={
                     (e) => {
                         const img = e.target as HTMLImageElement;

--- a/src/components/EmojiInfo/EmojiInfo.tsx
+++ b/src/components/EmojiInfo/EmojiInfo.tsx
@@ -17,7 +17,7 @@ export default function EmojiInfo(props: EmojiInfoProps) {
     const contributed = props.emoji ? props.emoji.contributed : false;
 
     return (
-        <div id="emoji-info" data-contributed={contributed}>
+        <div id="emoji-info" role="group" data-contributed={contributed}>
             <EmojiImage emoji={props.emoji} />
 
             <EmojiCodepoint codepoint={props.emoji?.codepoint} />

--- a/src/components/EmojiInfo/EmojiName.tsx
+++ b/src/components/EmojiInfo/EmojiName.tsx
@@ -10,6 +10,6 @@ export default function EmojiName(props: EmojiNameProps) {
     const realEmoji = props.emoji ? codepointToEmoji(props.emoji.codepoint) : "\u2753";
 
     return (
-        <figcaption className="emoji-name">{realEmoji} {name}</figcaption>
+        <figcaption aria-hidden="true" className="emoji-name">{realEmoji} {name}</figcaption>
     );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import "css/components/Header.css";
 
 export default function Header() {
     return (
-        <div id="header">
+        <div id="header" role="heading">
             Forumoji
         </div>
     );

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -44,10 +44,14 @@ export default function List(props: ListProps) {
 
     return (
         <div id="list">
-            <ListFilter onCategoryChange={onCategoryChange} barRef={categoryBarRef}
+            <ListFilter
+                onCategoryChange={onCategoryChange}
+                barRef={categoryBarRef}
                 categoryRefs={categoryRefs}
-                searchSelected={searchSelected} setSearchSelected={setSearchSelected}/>
-            <div id="list-items">
+                searchSelected={searchSelected}
+                setSearchSelected={setSearchSelected}
+            />
+            <div id="list-items" aria-label="Emoji list" role="group">
                 {
                     Object.entries(list).map(([category, emojis]) => {
                         if(category === "Component") return null;

--- a/src/components/List/ListCategoryButton.tsx
+++ b/src/components/List/ListCategoryButton.tsx
@@ -38,9 +38,12 @@ export default function ListCategoryButton(props: ListCategoryButtonProps) {
     const className = "filter-button" + (props.category === "Search" ? " search" : "");
 
     return (
-        <button className={className} onClick={props.onCategoryChange.bind(undefined, props.category)}
+        <button
+            className={className}
+            onClick={props.onCategoryChange.bind(undefined, props.category)}
             data-selected={props.selected}
-            aria-label={props.category} title={props.category}
+            aria-label={props.category}
+            title={props.category}
         >
             {
                 icon ? <div className="category-icon" style={style} data-mask={icon}/> : null

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -18,11 +18,19 @@ export default function ListItem(props: ListItemProps) {
             aria-label={props.emoji.name}
             title={props.emoji.name}
             data-selected={props.selected}
+            role="radio"
+            aria-checked={props.selected}
+            name="selected-emoji"
         >
-            <img src={src} onError={(e) => {
-                const img = e.target as HTMLImageElement;
-                img.src = brokenImage;
-            }} loading="lazy"/>
+            <img
+                src={src}
+                onError={(e) => {
+                    const img = e.target as HTMLImageElement;
+                    img.src = brokenImage;
+                }}
+                loading="lazy"
+                aria-hidden="true"
+            />
         </button>
     );
 }


### PR DESCRIPTION
I'm not the best at deciding how sites should do accessibility, so I just did some basic stuff. For one: all selectable elements now have the `radio` role, this means each element in the emoji list is now a radio, as well as the format and host selectors for copying an emoji. The copy `input` element now has `aria-readonly="true"`. There are many more misc. changes.

There was another accessibility issue, however, that one would require visual changes to the site(particularly to the color pallet), so I'll submit it as an issue instead.