### PR TITLE
[A11Y] Remove unneeded "hi" from EmojiCopy.css

### DIFF
--- a/src/css/components/EmojiCopy.css
+++ b/src/css/components/EmojiCopy.css
@@ -31,7 +31,7 @@ div#emoji-copy-options > div::before {
     width: 32pt;
 
     left: 0;
-    content: "hi";
+    content: "";
     color: transparent;
 
     transition: left 0.3s ease-out;


### PR DESCRIPTION
This changes line 34 of [`src/css/components/EmojiCopy.css`](https://github.com/Steve0Greatness/forumoji-dev/commit/ea8a8d6ee3abd6e6a80e474ef8742fd3512deb91#diff-c32ce45305d90cf87135c3e56fda4c7180431544f1a890d7c7afe4ad37873b70) from `content: "hi";` to `content: "";`.

The `hi`, despite not being able to be seen visually, could still be read by assistive technology.

I tested this locally, and it doesn't seem to have an impact on the look of the page.