### PR TITLE
Update to Emoji 16.0

### DIFF
--- a/assets/unicode-emoji.json
+++ b/assets/unicode-emoji.json
@@ -2,11 +2,11 @@
   "comment": [
     "STOP!",
 
-    "This is the official Emoji 15.0 list from Unicode,",
+    "This is the official Emoji 16.0 list from Unicode,",
     "which can be found at https://unicode.org/emoji/charts/emoji-list.html",
     "It should never be changed unless the official list does,",
     "and even then, only if you know what you're doing.",
-
+    
     "The list of images for Forumoji is kept in forumoji.json"
   ],
   "category": "root",
@@ -15,297 +15,906 @@
       "category": "Smileys & Emotion",
       "contents": [
         {
-          "category": "face_smiling",
+          "category": "face-smiling",
           "contents": [
             {
               "codepoint": "U+1F600",
               "name": "grinning face",
-              "keywords": ["face", "grin", "grinning face"]
+              "keywords": [
+                "cheerful",
+                "cheery",
+                "face",
+                "grin",
+                "grinning",
+                "happy",
+                "laugh",
+                "nice",
+                "smile",
+                "smiling",
+                "teeth"
+              ]
             },
             {
               "codepoint": "U+1F603",
               "name": "grinning face with big eyes",
-              "keywords": ["face", "grinning face with big eyes", "mouth", "open", "smile"]
+              "keywords": [
+                "awesome",
+                "big",
+                "eyes",
+                "face",
+                "grin",
+                "grinning",
+                "happy",
+                "mouth",
+                "open",
+                "smile",
+                "smiling",
+                "teeth",
+                "yay"
+              ]
             },
             {
               "codepoint": "U+1F604",
               "name": "grinning face with smiling eyes",
-              "keywords": ["eye", "face", "grinning face with smiling eyes", "mouth", "open", "smile"]
+              "keywords": [
+                "eye",
+                "eyes",
+                "face",
+                "grin",
+                "grinning",
+                "happy",
+                "laugh",
+                "lol",
+                "mouth",
+                "open",
+                "smile",
+                "smiling"
+              ]
             },
             {
               "codepoint": "U+1F601",
               "name": "beaming face with smiling eyes",
-              "keywords": ["beaming face with smiling eyes", "eye", "face", "grin", "smile"]
+              "keywords": [
+                "beaming",
+                "eye",
+                "eyes",
+                "face",
+                "grin",
+                "grinning",
+                "happy",
+                "nice",
+                "smile",
+                "smiling",
+                "teeth"
+              ]
             },
             {
               "codepoint": "U+1F606",
               "name": "grinning squinting face",
-              "keywords": ["face", "grinning squinting face", "laugh", "mouth", "satisfied", "smile"]
+              "keywords": [
+                "closed",
+                "eyes",
+                "face",
+                "grinning",
+                "haha",
+                "hahaha",
+                "happy",
+                "laugh",
+                "lol",
+                "mouth",
+                "open",
+                "rofl",
+                "smile",
+                "smiling",
+                "squinting"
+              ]
             },
             {
               "codepoint": "U+1F605",
               "name": "grinning face with sweat",
-              "keywords": ["cold", "face", "grinning face with sweat", "open", "smile", "sweat"]
+              "keywords": [
+                "cold",
+                "dejected",
+                "excited",
+                "face",
+                "grinning",
+                "mouth",
+                "nervous",
+                "open",
+                "smile",
+                "smiling",
+                "stress",
+                "stressed",
+                "sweat"
+              ]
             },
             {
               "codepoint": "U+1F923",
               "name": "rolling on the floor laughing",
-              "keywords": ["face", "floor", "laugh", "rofl", "rolling", "rolling on the floor laughing", "rotfl"]
+              "keywords": [
+                "crying",
+                "face",
+                "floor",
+                "funny",
+                "haha",
+                "happy",
+                "hehe",
+                "hilarious",
+                "joy",
+                "laugh",
+                "lmao",
+                "lol",
+                "rofl",
+                "roflmao",
+                "rolling",
+                "tear"
+              ]
             },
             {
               "codepoint": "U+1F602",
               "name": "face with tears of joy",
-              "keywords": ["face", "face with tears of joy", "joy", "laugh", "tear"]
+              "keywords": [
+                "crying",
+                "face",
+                "feels",
+                "funny",
+                "haha",
+                "happy",
+                "hehe",
+                "hilarious",
+                "joy",
+                "laugh",
+                "lmao",
+                "lol",
+                "rofl",
+                "roflmao",
+                "tear"
+              ]
             },
             {
               "codepoint": "U+1F642",
               "name": "slightly smiling face",
-              "keywords": ["face", "slightly smiling face", "smile"]
+              "keywords": ["face", "happy", "slightly", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F643",
               "name": "upside-down face",
-              "keywords": ["face", "upside-down"]
+              "keywords": ["face", "hehe", "smile", "upside-down"]
             },
             {
               "codepoint": "U+1FAE0",
               "name": "melting face",
-              "keywords": ["disappear", "dissolve", "liquid", "melt"]
+              "keywords": [
+                "disappear",
+                "dissolve",
+                "embarrassed",
+                "face",
+                "haha",
+                "heat",
+                "hot",
+                "liquid",
+                "lol",
+                "melt",
+                "melting",
+                "sarcasm",
+                "sarcastic"
+              ]
             },
             {
               "codepoint": "U+1F609",
               "name": "winking face",
-              "keywords": ["face", "wink", "winking face"]
+              "keywords": [
+                "face",
+                "flirt",
+                "heartbreaker",
+                "sexy",
+                "slide",
+                "tease",
+                "wink",
+                "winking",
+                "winks"
+              ]
             },
             {
               "codepoint": "U+1F60A",
               "name": "smiling face with smiling eyes",
-              "keywords": ["blush", "eye", "face", "smile", "smiling face with smiling eyes"]
+              "keywords": [
+                "blush",
+                "eye",
+                "eyes",
+                "face",
+                "glad",
+                "satisfied",
+                "smile",
+                "smiling"
+              ]
             },
             {
               "codepoint": "U+1F607",
               "name": "smiling face with halo",
-              "keywords": ["angel", "face", "fantasy", "halo", "innocent", "smiling face with halo"]
+              "keywords": [
+                "angel",
+                "angelic",
+                "angels",
+                "blessed",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "halo",
+                "happy",
+                "innocent",
+                "peaceful",
+                "smile",
+                "smiling",
+                "spirit",
+                "tale"
+              ]
             }
           ]
         },
         {
-          "category": "face_affection",
+          "category": "face-affection",
           "contents": [
             {
               "codepoint": "U+1F970",
               "name": "smiling face with hearts",
-              "keywords": ["adore", "crush", "hearts", "in love", "smiling face with hearts"]
+              "keywords": [
+                "3",
+                "adore",
+                "crush",
+                "face",
+                "heart",
+                "hearts",
+                "ily",
+                "love",
+                "romance",
+                "smile",
+                "smiling",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F60D",
               "name": "smiling face with heart-eyes",
-              "keywords": ["eye", "face", "love", "smile", "smiling face with heart-eyes"]
+              "keywords": [
+                "143",
+                "bae",
+                "eye",
+                "face",
+                "feels",
+                "heart-eyes",
+                "hearts",
+                "ily",
+                "kisses",
+                "love",
+                "romance",
+                "romantic",
+                "smile",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F929",
               "name": "star-struck",
-              "keywords": ["eyes", "face", "grinning", "star", "star-struck", "starry-eyed"]
+              "keywords": [
+                "excited",
+                "eyes",
+                "face",
+                "grinning",
+                "smile",
+                "star",
+                "star-struck",
+                "starry-eyed",
+                "wow"
+              ]
             },
             {
               "codepoint": "U+1F618",
               "name": "face blowing a kiss",
-              "keywords": ["face", "face blowing a kiss", "kiss"]
+              "keywords": [
+                "adorbs",
+                "bae",
+                "blowing",
+                "face",
+                "flirt",
+                "heart",
+                "ily",
+                "kiss",
+                "love",
+                "lover",
+                "miss",
+                "muah",
+                "romantic",
+                "smooch",
+                "xoxo",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F617",
               "name": "kissing face",
-              "keywords": ["face", "kiss", "kissing face"]
+              "keywords": [
+                "143",
+                "date",
+                "dating",
+                "face",
+                "flirt",
+                "ily",
+                "kiss",
+                "love",
+                "smooch",
+                "smooches",
+                "xoxo",
+                "you"
+              ]
             },
             {
               "codepoint": "U+263A",
               "name": "smiling face",
-              "keywords": ["face", "outlined", "relaxed", "smile", "smiling face"]
+              "keywords": [
+                "face",
+                "happy",
+                "outlined",
+                "relaxed",
+                "smile",
+                "smiling"
+              ]
             },
             {
               "codepoint": "U+1F61A",
               "name": "kissing face with closed eyes",
-              "keywords": ["closed", "eye", "face", "kiss", "kissing face with closed eyes"]
+              "keywords": [
+                "143",
+                "bae",
+                "blush",
+                "closed",
+                "date",
+                "dating",
+                "eye",
+                "eyes",
+                "face",
+                "flirt",
+                "ily",
+                "kisses",
+                "kissing",
+                "smooches",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F619",
               "name": "kissing face with smiling eyes",
-              "keywords": ["eye", "face", "kiss", "kissing face with smiling eyes", "smile"]
+              "keywords": [
+                "143",
+                "closed",
+                "date",
+                "dating",
+                "eye",
+                "eyes",
+                "face",
+                "flirt",
+                "ily",
+                "kiss",
+                "kisses",
+                "kissing",
+                "love",
+                "night",
+                "smile",
+                "smiling"
+              ]
             },
             {
               "codepoint": "U+1F972",
               "name": "smiling face with tear",
-              "keywords": ["grateful", "proud", "relieved", "smiling", "smiling face with tear", "tear", "touched"]
+              "keywords": [
+                "face",
+                "glad",
+                "grateful",
+                "happy",
+                "joy",
+                "pain",
+                "proud",
+                "relieved",
+                "smile",
+                "smiley",
+                "smiling",
+                "tear",
+                "touched"
+              ]
             }
           ]
         },
         {
-          "category": "face_tongue",
+          "category": "face-tongue",
           "contents": [
             {
               "codepoint": "U+1F60B",
               "name": "face savoring food",
-              "keywords": ["delicious", "face", "face savoring food", "savouring", "smile", "yum"]
+              "keywords": [
+                "delicious",
+                "eat",
+                "face",
+                "food",
+                "full",
+                "hungry",
+                "savor",
+                "smile",
+                "smiling",
+                "tasty",
+                "um",
+                "yum",
+                "yummy"
+              ]
             },
             {
               "codepoint": "U+1F61B",
               "name": "face with tongue",
-              "keywords": ["face", "face with tongue", "tongue"]
+              "keywords": [
+                "awesome",
+                "cool",
+                "face",
+                "nice",
+                "party",
+                "stuck-out",
+                "sweet",
+                "tongue"
+              ]
             },
             {
               "codepoint": "U+1F61C",
               "name": "winking face with tongue",
-              "keywords": ["eye", "face", "joke", "tongue", "wink", "winking face with tongue"]
+              "keywords": [
+                "crazy",
+                "epic",
+                "eye",
+                "face",
+                "funny",
+                "joke",
+                "loopy",
+                "nutty",
+                "party",
+                "stuck-out",
+                "tongue",
+                "wacky",
+                "weirdo",
+                "wink",
+                "winking",
+                "yolo"
+              ]
             },
             {
               "codepoint": "U+1F92A",
               "name": "zany face",
-              "keywords": ["eye", "goofy", "large", "small", "zany face"]
+              "keywords": [
+                "crazy",
+                "eye",
+                "eyes",
+                "face",
+                "goofy",
+                "large",
+                "small",
+                "zany"
+              ]
             },
             {
               "codepoint": "U+1F61D",
               "name": "squinting face with tongue",
-              "keywords": ["eye", "face", "horrible", "squinting face with tongue", "taste", "tongue"]
+              "keywords": [
+                "closed",
+                "eye",
+                "eyes",
+                "face",
+                "gross",
+                "horrible",
+                "omg",
+                "squinting",
+                "stuck-out",
+                "taste",
+                "tongue",
+                "whatever",
+                "yolo"
+              ]
             },
             {
               "codepoint": "U+1F911",
               "name": "money-mouth face",
-              "keywords": ["face", "money", "money-mouth face", "mouth"]
+              "keywords": ["face", "money", "money-mouth", "mouth", "paid"]
             }
           ]
         },
         {
-          "category": "face_hand",
+          "category": "face-hand",
           "contents": [
             {
               "codepoint": "U+1F917",
               "name": "smiling face with open hands",
-              "keywords": ["face", "hug", "hugging", "open hands", "smiling face", "smiling face with open hands"]
+              "keywords": ["face", "hands", "hug", "hugging", "open", "smiling"]
             },
             {
               "codepoint": "U+1F92D",
               "name": "face with hand over mouth",
-              "keywords": ["face with hand over mouth", "whoops", "shock", "sudden realization", "surprise"]
+              "keywords": [
+                "face",
+                "giggle",
+                "giggling",
+                "hand",
+                "mouth",
+                "oops",
+                "realization",
+                "secret",
+                "shock",
+                "sudden",
+                "surprise",
+                "whoops"
+              ]
             },
             {
               "codepoint": "U+1FAE2",
               "name": "face with open eyes and hand over mouth",
-              "keywords": ["amazement", "awe", "disbelief", "embarrass", "scared", "surprise"]
+              "keywords": [
+                "amazement",
+                "awe",
+                "disbelief",
+                "embarrass",
+                "eyes",
+                "face",
+                "gasp",
+                "hand",
+                "mouth",
+                "omg",
+                "open",
+                "over",
+                "quiet",
+                "scared",
+                "shock",
+                "surprise"
+              ]
             },
             {
               "codepoint": "U+1FAE3",
               "name": "face with peeking eye",
-              "keywords": ["captivated", "peep", "stare"]
+              "keywords": [
+                "captivated",
+                "embarrass",
+                "eye",
+                "face",
+                "hide",
+                "hiding",
+                "peek",
+                "peeking",
+                "peep",
+                "scared",
+                "shy",
+                "stare"
+              ]
             },
             {
               "codepoint": "U+1F92B",
               "name": "shushing face",
-              "keywords": ["quiet", "shush", "shushing face"]
+              "keywords": ["face", "quiet", "shh", "shush", "shushing"]
             },
             {
               "codepoint": "U+1F914",
               "name": "thinking face",
-              "keywords": ["face", "thinking"]
+              "keywords": [
+                "chin",
+                "consider",
+                "face",
+                "hmm",
+                "ponder",
+                "pondering",
+                "thinking",
+                "wondering"
+              ]
             },
             {
               "codepoint": "U+1FAE1",
               "name": "saluting face",
-              "keywords": ["ok", "salute", "sunny", "troops", "yes"]
+              "keywords": [
+                "face",
+                "good",
+                "luck",
+                "ma’am",
+                "OK",
+                "respect",
+                "salute",
+                "saluting",
+                "sir",
+                "troops",
+                "yes"
+              ]
             }
           ]
         },
         {
-          "category": "face_neutral_skeptical",
+          "category": "face-neutral-skeptical",
           "contents": [
             {
               "codepoint": "U+1F910",
               "name": "zipper-mouth face",
-              "keywords": ["face", "mouth", "zipper", "zipper-mouth face"]
+              "keywords": [
+                "face",
+                "keep",
+                "mouth",
+                "quiet",
+                "secret",
+                "shut",
+                "zip",
+                "zipper",
+                "zipper-mouth"
+              ]
             },
             {
               "codepoint": "U+1F928",
               "name": "face with raised eyebrow",
-              "keywords": ["distrust", "face with raised eyebrow", "skeptic", "disapproval", "disbelief", "mild surprise", "scepticism"]
+              "keywords": [
+                "disapproval",
+                "disbelief",
+                "distrust",
+                "emoji",
+                "eyebrow",
+                "face",
+                "hmm",
+                "mild",
+                "raised",
+                "skeptic",
+                "skeptical",
+                "skepticism",
+                "surprise",
+                "what"
+              ]
             },
             {
               "codepoint": "U+1F610",
               "name": "neutral face",
-              "keywords": ["deadpan", "face", "meh", "neutral"]
+              "keywords": [
+                "awkward",
+                "blank",
+                "deadpan",
+                "expressionless",
+                "face",
+                "fine",
+                "jealous",
+                "meh",
+                "neutral",
+                "oh",
+                "shade",
+                "straight",
+                "unamused",
+                "unhappy",
+                "unimpressed",
+                "whatever"
+              ]
             },
             {
               "codepoint": "U+1F611",
               "name": "expressionless face",
-              "keywords": ["expressionless", "face", "inexpressive", "meh", "unexpressive"]
+              "keywords": [
+                "awkward",
+                "dead",
+                "expressionless",
+                "face",
+                "fine",
+                "inexpressive",
+                "jealous",
+                "meh",
+                "not",
+                "oh",
+                "omg",
+                "straight",
+                "uh",
+                "unhappy",
+                "unimpressed",
+                "whatever"
+              ]
             },
             {
               "codepoint": "U+1F636",
               "name": "face without mouth",
-              "keywords": ["face", "face without mouth", "mouth", "quiet", "silent"]
+              "keywords": [
+                "awkward",
+                "blank",
+                "expressionless",
+                "face",
+                "mouth",
+                "mouthless",
+                "mute",
+                "quiet",
+                "secret",
+                "silence",
+                "silent",
+                "speechless"
+              ]
             },
             {
               "codepoint": "U+1FAE5",
               "name": "dotted line face",
-              "keywords": ["depressed", "disappear", "hide", "introvert", "invisible"]
+              "keywords": [
+                "depressed",
+                "disappear",
+                "dotted",
+                "face",
+                "hidden",
+                "hide",
+                "introvert",
+                "invisible",
+                "line",
+                "meh",
+                "whatever",
+                "wtv"
+              ]
             },
             {
               "codepoint": "U+1F636 U+200D U+1F32B U+FE0F",
               "name": "face in clouds",
-              "keywords": ["absentminded", "face in clouds", "face in the fog", "head in clouds"]
+              "keywords": ["absentminded", "clouds", "face", "fog", "head"]
             },
             {
               "codepoint": "U+1F60F",
               "name": "smirking face",
-              "keywords": ["face", "smirk", "smirking face"]
+              "keywords": [
+                "boss",
+                "dapper",
+                "face",
+                "flirt",
+                "homie",
+                "kidding",
+                "leer",
+                "shade",
+                "slick",
+                "sly",
+                "smirk",
+                "smug",
+                "snicker",
+                "suave",
+                "suspicious",
+                "swag"
+              ]
             },
             {
               "codepoint": "U+1F612",
               "name": "unamused face",
-              "keywords": ["face", "unamused", "unhappy"]
+              "keywords": [
+                "...",
+                "bored",
+                "face",
+                "fine",
+                "jealous",
+                "jel",
+                "jelly",
+                "pissed",
+                "smh",
+                "ugh",
+                "uhh",
+                "unamused",
+                "unhappy",
+                "weird",
+                "whatever"
+              ]
             },
             {
               "codepoint": "U+1F644",
               "name": "face with rolling eyes",
-              "keywords": ["eyeroll", "eyes", "face", "face with rolling eyes", "rolling"]
+              "keywords": [
+                "eyeroll",
+                "eyes",
+                "face",
+                "rolling",
+                "shade",
+                "ugh",
+                "whatever"
+              ]
             },
             {
               "codepoint": "U+1F62C",
               "name": "grimacing face",
-              "keywords": ["face", "grimace", "grimacing face"]
+              "keywords": [
+                "awk",
+                "awkward",
+                "dentist",
+                "face",
+                "grimace",
+                "grimacing",
+                "grinning",
+                "smile",
+                "smiling"
+              ]
             },
             {
               "codepoint": "U+1F62E U+200D U+1F4A8",
               "name": "face exhaling",
-              "keywords": ["exhale", "face exhaling", "gasp", "groan", "relief", "whisper", "whistle"]
+              "keywords": [
+                "blow",
+                "blowing",
+                "exhale",
+                "exhaling",
+                "exhausted",
+                "face",
+                "gasp",
+                "groan",
+                "relief",
+                "sigh",
+                "smiley",
+                "smoke",
+                "whisper",
+                "whistle"
+              ]
             },
             {
               "codepoint": "U+1F925",
               "name": "lying face",
-              "keywords": ["face", "lie", "lying face", "pinocchio"]
+              "keywords": ["face", "liar", "lie", "lying", "pinocchio"]
             },
             {
               "codepoint": "U+1FAE8",
               "name": "shaking face",
-              "keywords": ["earthquake", "face", "shaking", "shock", "vibrate"]
+              "keywords": [
+                "crazy",
+                "daze",
+                "earthquake",
+                "face",
+                "omg",
+                "panic",
+                "shaking",
+                "shock",
+                "surprise",
+                "vibrate",
+                "whoa",
+                "wow"
+              ]
+            },
+            {
+              "codepoint": "U+1F642 U+200D U+2194 U+FE0F",
+              "name": "head shaking horizontally",
+              "keywords": ["head", "horizontally", "no", "shake", "shaking"]
+            },
+            {
+              "codepoint": "U+1F642 U+200D U+2195 U+FE0F",
+              "name": "head shaking vertically",
+              "keywords": ["head", "nod", "shaking", "vertically", "yes"]
             }
           ]
         },
         {
-          "category": "face_sleepy",
+          "category": "face-sleepy",
           "contents": [
             {
               "codepoint": "U+1F60C",
               "name": "relieved face",
-              "keywords": ["face", "relieved"]
+              "keywords": ["calm", "face", "peace", "relief", "relieved", "zen"]
             },
             {
               "codepoint": "U+1F614",
               "name": "pensive face",
-              "keywords": ["dejected", "face", "pensive"]
+              "keywords": [
+                "awful",
+                "bored",
+                "dejected",
+                "died",
+                "disappointed",
+                "face",
+                "losing",
+                "lost",
+                "pensive",
+                "sad",
+                "sucks"
+              ]
             },
             {
               "codepoint": "U+1F62A",
               "name": "sleepy face",
-              "keywords": ["face", "sleep", "sleepy face"]
+              "keywords": [
+                "crying",
+                "face",
+                "good",
+                "night",
+                "sad",
+                "sleep",
+                "sleeping",
+                "sleepy",
+                "tired"
+              ]
             },
             {
               "codepoint": "U+1F924",
@@ -315,77 +924,219 @@
             {
               "codepoint": "U+1F634",
               "name": "sleeping face",
-              "keywords": ["face", "sleep", "sleeping face", "zzz"]
+              "keywords": [
+                "bed",
+                "bedtime",
+                "face",
+                "good",
+                "goodnight",
+                "nap",
+                "night",
+                "sleep",
+                "sleeping",
+                "tired",
+                "whatever",
+                "yawn",
+                "zzz"
+              ]
+            },
+            {
+              "codepoint": "U+1FAE9",
+              "name": "face with bags under eyes",
+              "keywords": [
+                "bags",
+                "bored",
+                "exhausted",
+                "eyes",
+                "face",
+                "fatigued",
+                "late",
+                "sleepy",
+                "tired",
+                "weary"
+              ]
             }
           ]
         },
         {
-          "category": "face_unwell",
+          "category": "face-unwell",
           "contents": [
             {
               "codepoint": "U+1F637",
               "name": "face with medical mask",
-              "keywords": ["cold", "doctor", "face", "face with medical mask", "mask", "sick"]
+              "keywords": [
+                "cold",
+                "dentist",
+                "dermatologist",
+                "doctor",
+                "dr",
+                "face",
+                "germs",
+                "mask",
+                "medical",
+                "medicine",
+                "sick"
+              ]
             },
             {
               "codepoint": "U+1F912",
               "name": "face with thermometer",
-              "keywords": ["face", "face with thermometer", "ill", "sick", "thermometer"]
+              "keywords": ["face", "ill", "sick", "thermometer"]
             },
             {
               "codepoint": "U+1F915",
               "name": "face with head-bandage",
-              "keywords": ["bandage", "face", "face with head-bandage", "hurt", "injury"]
+              "keywords": [
+                "bandage",
+                "face",
+                "head-bandage",
+                "hurt",
+                "injury",
+                "ouch"
+              ]
             },
             {
               "codepoint": "U+1F922",
               "name": "nauseated face",
-              "keywords": ["face", "nauseated", "vomit"]
+              "keywords": [
+                "face",
+                "gross",
+                "nasty",
+                "nauseated",
+                "sick",
+                "vomit"
+              ]
             },
             {
               "codepoint": "U+1F92E",
               "name": "face vomiting",
-              "keywords": ["face vomiting", "puke", "sick", "vomit"]
+              "keywords": [
+                "barf",
+                "ew",
+                "face",
+                "gross",
+                "puke",
+                "sick",
+                "spew",
+                "throw",
+                "up",
+                "vomit",
+                "vomiting"
+              ]
             },
             {
               "codepoint": "U+1F927",
               "name": "sneezing face",
-              "keywords": ["face", "gesundheit", "sneeze", "sneezing face"]
+              "keywords": [
+                "face",
+                "fever",
+                "flu",
+                "gesundheit",
+                "sick",
+                "sneeze",
+                "sneezing"
+              ]
             },
             {
               "codepoint": "U+1F975",
               "name": "hot face",
-              "keywords": ["feverish", "heat stroke", "hot", "hot face", "red-faced", "sweating"]
+              "keywords": [
+                "dying",
+                "face",
+                "feverish",
+                "heat",
+                "hot",
+                "panting",
+                "red-faced",
+                "stroke",
+                "sweating",
+                "tongue"
+              ]
             },
             {
               "codepoint": "U+1F976",
               "name": "cold face",
-              "keywords": ["blue-faced", "cold", "cold face", "freezing", "frostbite", "icicles"]
+              "keywords": [
+                "blue",
+                "blue-faced",
+                "cold",
+                "face",
+                "freezing",
+                "frostbite",
+                "icicles",
+                "subzero",
+                "teeth"
+              ]
             },
             {
               "codepoint": "U+1F974",
               "name": "woozy face",
-              "keywords": ["dizzy", "intoxicated", "tipsy", "uneven eyes", "wavy mouth", "woozy face"]
+              "keywords": [
+                "dizzy",
+                "drunk",
+                "eyes",
+                "face",
+                "intoxicated",
+                "mouth",
+                "tipsy",
+                "uneven",
+                "wavy",
+                "woozy"
+              ]
             },
             {
               "codepoint": "U+1F635",
               "name": "face with crossed-out eyes",
-              "keywords": ["crossed-out eyes", "dead", "face", "face with crossed-out eyes", "knocked out"]
+              "keywords": [
+                "crossed-out",
+                "dead",
+                "dizzy",
+                "eyes",
+                "face",
+                "feels",
+                "knocked",
+                "out",
+                "sick",
+                "tired"
+              ]
             },
             {
               "codepoint": "U+1F635 U+200D U+1F4AB",
               "name": "face with spiral eyes",
-              "keywords": ["dizzy", "face with spiral eyes", "hypnotized", "spiral", "trouble", "whoa"]
+              "keywords": [
+                "confused",
+                "dizzy",
+                "eyes",
+                "face",
+                "hypnotized",
+                "omg",
+                "smiley",
+                "spiral",
+                "trouble",
+                "whoa",
+                "woah",
+                "woozy"
+              ]
             },
             {
               "codepoint": "U+1F92F",
               "name": "exploding head",
-              "keywords": ["exploding head", "mind blown", "shocked"]
+              "keywords": [
+                "blown",
+                "explode",
+                "exploding",
+                "head",
+                "mind",
+                "mindblown",
+                "no",
+                "shocked",
+                "way"
+              ]
             }
           ]
         },
         {
-          "category": "face_hat",
+          "category": "face-hat",
           "contents": [
             {
               "codepoint": "U+1F920",
@@ -395,222 +1146,694 @@
             {
               "codepoint": "U+1F973",
               "name": "partying face",
-              "keywords": ["celebration", "hat", "horn", "party", "partying face"]
+              "keywords": [
+                "bday",
+                "birthday",
+                "celebrate",
+                "celebration",
+                "excited",
+                "face",
+                "happy",
+                "hat",
+                "hooray",
+                "horn",
+                "party",
+                "partying"
+              ]
             },
             {
               "codepoint": "U+1F978",
               "name": "disguised face",
-              "keywords": ["disguise", "disguised face", "face", "glasses", "incognito", "nose"]
+              "keywords": [
+                "disguise",
+                "eyebrow",
+                "face",
+                "glasses",
+                "incognito",
+                "moustache",
+                "mustache",
+                "nose",
+                "person",
+                "spy",
+                "tache",
+                "tash"
+              ]
             }
           ]
         },
         {
-          "category": "face_glasses",
+          "category": "face-glasses",
           "contents": [
             {
               "codepoint": "U+1F60E",
               "name": "smiling face with sunglasses",
-              "keywords": ["bright", "cool", "face", "smiling face with sunglasses", "sun", "sunglasses"]
+              "keywords": [
+                "awesome",
+                "beach",
+                "bright",
+                "bro",
+                "chilling",
+                "cool",
+                "face",
+                "rad",
+                "relaxed",
+                "shades",
+                "slay",
+                "smile",
+                "style",
+                "sunglasses",
+                "swag",
+                "win"
+              ]
             },
             {
               "codepoint": "U+1F913",
               "name": "nerd face",
-              "keywords": ["face", "geek", "nerd"]
+              "keywords": [
+                "brainy",
+                "clever",
+                "expert",
+                "face",
+                "geek",
+                "gifted",
+                "glasses",
+                "intelligent",
+                "nerd",
+                "smart"
+              ]
             },
             {
               "codepoint": "U+1F9D0",
               "name": "face with monocle",
-              "keywords": ["face with monocle", "stuffy", "wealthy"]
+              "keywords": [
+                "classy",
+                "face",
+                "fancy",
+                "monocle",
+                "rich",
+                "stuffy",
+                "wealthy"
+              ]
             }
           ]
         },
         {
-          "category": "face_concerned",
+          "category": "face-concerned",
           "contents": [
             {
               "codepoint": "U+1F615",
               "name": "confused face",
-              "keywords": ["confused", "face", "meh"]
+              "keywords": [
+                "befuddled",
+                "confused",
+                "confusing",
+                "dunno",
+                "face",
+                "frown",
+                "hm",
+                "meh",
+                "not",
+                "sad",
+                "sorry",
+                "sure"
+              ]
             },
             {
               "codepoint": "U+1FAE4",
               "name": "face with diagonal mouth",
-              "keywords": ["disappointed", "meh", "skeptical", "unsure"]
+              "keywords": [
+                "confused",
+                "confusion",
+                "diagonal",
+                "disappointed",
+                "doubt",
+                "doubtful",
+                "face",
+                "frustrated",
+                "frustration",
+                "meh",
+                "mouth",
+                "skeptical",
+                "unsure",
+                "whatever",
+                "wtv"
+              ]
             },
             {
               "codepoint": "U+1F61F",
               "name": "worried face",
-              "keywords": ["face", "worried"]
+              "keywords": [
+                "anxious",
+                "butterflies",
+                "face",
+                "nerves",
+                "nervous",
+                "sad",
+                "stress",
+                "stressed",
+                "surprised",
+                "worried",
+                "worry"
+              ]
             },
             {
               "codepoint": "U+1F641",
               "name": "slightly frowning face",
-              "keywords": ["face", "frown", "slightly frowning face"]
+              "keywords": ["face", "frown", "frowning", "sad", "slightly"]
             },
             {
               "codepoint": "U+2639",
               "name": "frowning face",
-              "keywords": ["face", "frown", "frowning face"]
+              "keywords": ["face", "frown", "frowning", "sad"]
             },
             {
               "codepoint": "U+1F62E",
               "name": "face with open mouth",
-              "keywords": ["face", "face with open mouth", "mouth", "open", "sympathy"]
+              "keywords": [
+                "believe",
+                "face",
+                "forgot",
+                "mouth",
+                "omg",
+                "open",
+                "shocked",
+                "surprised",
+                "sympathy",
+                "unbelievable",
+                "unreal",
+                "whoa",
+                "wow",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F62F",
               "name": "hushed face",
-              "keywords": ["face", "hushed", "stunned", "surprised"]
+              "keywords": [
+                "epic",
+                "face",
+                "hushed",
+                "omg",
+                "stunned",
+                "surprised",
+                "whoa",
+                "woah"
+              ]
             },
             {
               "codepoint": "U+1F632",
               "name": "astonished face",
-              "keywords": ["astonished", "face", "shocked", "totally"]
+              "keywords": [
+                "astonished",
+                "cost",
+                "face",
+                "no",
+                "omg",
+                "shocked",
+                "totally",
+                "way"
+              ]
             },
             {
               "codepoint": "U+1F633",
               "name": "flushed face",
-              "keywords": ["dazed", "face", "flushed"]
+              "keywords": [
+                "amazed",
+                "awkward",
+                "crazy",
+                "dazed",
+                "dead",
+                "disbelief",
+                "embarrassed",
+                "face",
+                "flushed",
+                "geez",
+                "heat",
+                "hot",
+                "impressed",
+                "jeez",
+                "what",
+                "wow"
+              ]
             },
             {
               "codepoint": "U+1F97A",
               "name": "pleading face",
-              "keywords": ["begging", "mercy", "pleading face", "puppy eyes"]
+              "keywords": [
+                "begging",
+                "big",
+                "eyes",
+                "face",
+                "mercy",
+                "not",
+                "pleading",
+                "please",
+                "pretty",
+                "puppy",
+                "sad",
+                "why"
+              ]
             },
             {
               "codepoint": "U+1F979",
               "name": "face holding back tears",
-              "keywords": ["angry", "cry", "proud", "resist", "sad"]
+              "keywords": [
+                "admiration",
+                "aww",
+                "back",
+                "cry",
+                "embarrassed",
+                "face",
+                "feelings",
+                "grateful",
+                "gratitude",
+                "holding",
+                "joy",
+                "please",
+                "proud",
+                "resist",
+                "sad",
+                "tears"
+              ]
             },
             {
               "codepoint": "U+1F626",
               "name": "frowning face with open mouth",
-              "keywords": ["face", "frown", "frowning face with open mouth", "mouth", "open"]
+              "keywords": [
+                "caught",
+                "face",
+                "frown",
+                "frowning",
+                "guard",
+                "mouth",
+                "open",
+                "scared",
+                "scary",
+                "surprise",
+                "what",
+                "wow"
+              ]
             },
             {
               "codepoint": "U+1F627",
               "name": "anguished face",
-              "keywords": ["anguished", "face"]
+              "keywords": [
+                "anguished",
+                "face",
+                "forgot",
+                "scared",
+                "scary",
+                "stressed",
+                "surprise",
+                "unhappy",
+                "what",
+                "wow"
+              ]
             },
             {
               "codepoint": "U+1F628",
               "name": "fearful face",
-              "keywords": ["face", "fear", "fearful", "scared"]
+              "keywords": [
+                "afraid",
+                "anxious",
+                "blame",
+                "face",
+                "fear",
+                "fearful",
+                "scared",
+                "worried"
+              ]
             },
             {
               "codepoint": "U+1F630",
               "name": "anxious face with sweat",
-              "keywords": ["anxious face with sweat", "blue", "cold", "face", "rushed", "sweat"]
+              "keywords": [
+                "anxious",
+                "blue",
+                "cold",
+                "eek",
+                "face",
+                "mouth",
+                "nervous",
+                "open",
+                "rushed",
+                "scared",
+                "sweat",
+                "yikes"
+              ]
             },
             {
               "codepoint": "U+1F625",
               "name": "sad but relieved face",
-              "keywords": ["disappointed", "face", "relieved", "sad but relieved face", "whew"]
+              "keywords": [
+                "anxious",
+                "call",
+                "close",
+                "complicated",
+                "disappointed",
+                "face",
+                "not",
+                "relieved",
+                "sad",
+                "sweat",
+                "time",
+                "whew"
+              ]
             },
             {
               "codepoint": "U+1F622",
               "name": "crying face",
-              "keywords": ["cry", "crying face", "face", "sad", "tear"]
+              "keywords": [
+                "awful",
+                "cry",
+                "crying",
+                "face",
+                "feels",
+                "miss",
+                "sad",
+                "tear",
+                "triste",
+                "unhappy"
+              ]
             },
             {
               "codepoint": "U+1F62D",
               "name": "loudly crying face",
-              "keywords": ["cry", "face", "loudly crying face", "sad", "sob", "tear"]
+              "keywords": [
+                "bawling",
+                "cry",
+                "crying",
+                "face",
+                "loudly",
+                "sad",
+                "sob",
+                "tear",
+                "tears",
+                "unhappy"
+              ]
             },
             {
               "codepoint": "U+1F631",
               "name": "face screaming in fear",
-              "keywords": ["face", "face screaming in fear", "fear", "munch", "scared", "scream"]
+              "keywords": [
+                "epic",
+                "face",
+                "fear",
+                "fearful",
+                "munch",
+                "scared",
+                "scream",
+                "screamer",
+                "screaming",
+                "shocked",
+                "surprised",
+                "woah"
+              ]
             },
             {
               "codepoint": "U+1F616",
               "name": "confounded face",
-              "keywords": ["confounded", "face"]
+              "keywords": [
+                "annoyed",
+                "confounded",
+                "confused",
+                "cringe",
+                "distraught",
+                "face",
+                "feels",
+                "frustrated",
+                "mad",
+                "sad"
+              ]
             },
             {
               "codepoint": "U+1F623",
               "name": "persevering face",
-              "keywords": ["face", "persevere", "persevering face"]
+              "keywords": [
+                "concentrate",
+                "concentration",
+                "face",
+                "focus",
+                "headache",
+                "persevere",
+                "persevering"
+              ]
             },
             {
               "codepoint": "U+1F61E",
               "name": "disappointed face",
-              "keywords": ["disappointed", "face"]
+              "keywords": [
+                "awful",
+                "blame",
+                "dejected",
+                "disappointed",
+                "face",
+                "fail",
+                "losing",
+                "sad",
+                "unhappy"
+              ]
             },
             {
               "codepoint": "U+1F613",
               "name": "downcast face with sweat",
-              "keywords": ["cold", "downcast face with sweat", "face", "sweat"]
+              "keywords": [
+                "close",
+                "cold",
+                "downcast",
+                "face",
+                "feels",
+                "headache",
+                "nervous",
+                "sad",
+                "scared",
+                "sweat",
+                "yikes"
+              ]
             },
             {
               "codepoint": "U+1F629",
               "name": "weary face",
-              "keywords": ["face", "tired", "weary"]
+              "keywords": [
+                "crying",
+                "face",
+                "fail",
+                "feels",
+                "hungry",
+                "mad",
+                "nooo",
+                "sad",
+                "sleepy",
+                "tired",
+                "unhappy",
+                "weary"
+              ]
             },
             {
               "codepoint": "U+1F62B",
               "name": "tired face",
-              "keywords": ["face", "tired"]
+              "keywords": [
+                "cost",
+                "face",
+                "feels",
+                "nap",
+                "sad",
+                "sneeze",
+                "tired"
+              ]
             },
             {
               "codepoint": "U+1F971",
               "name": "yawning face",
-              "keywords": ["bored", "tired", "yawn", "yawning face"]
+              "keywords": [
+                "bedtime",
+                "bored",
+                "face",
+                "goodnight",
+                "nap",
+                "night",
+                "sleep",
+                "sleepy",
+                "tired",
+                "whatever",
+                "yawn",
+                "yawning",
+                "zzz"
+              ]
             }
           ]
         },
         {
-          "category": "face_negative",
+          "category": "face-negative",
           "contents": [
             {
               "codepoint": "U+1F624",
               "name": "face with steam from nose",
-              "keywords": ["face", "face with steam from nose", "triumph", "won"]
+              "keywords": [
+                "anger",
+                "angry",
+                "face",
+                "feels",
+                "fume",
+                "fuming",
+                "furious",
+                "fury",
+                "mad",
+                "nose",
+                "steam",
+                "triumph",
+                "unhappy",
+                "won"
+              ]
             },
             {
               "codepoint": "U+1F621",
-              "name": "pouting face",
-              "keywords": ["angry", "face", "mad", "pouting", "rage", "red"]
+              "name": "enraged face",
+              "keywords": [
+                "anger",
+                "angry",
+                "enraged",
+                "face",
+                "feels",
+                "mad",
+                "maddening",
+                "pouting",
+                "rage",
+                "red",
+                "shade",
+                "unhappy",
+                "upset"
+              ]
             },
             {
               "codepoint": "U+1F620",
               "name": "angry face",
-              "keywords": ["anger", "angry", "face", "mad"]
+              "keywords": [
+                "anger",
+                "angry",
+                "blame",
+                "face",
+                "feels",
+                "frustrated",
+                "mad",
+                "maddening",
+                "rage",
+                "shade",
+                "unhappy",
+                "upset"
+              ]
             },
             {
               "codepoint": "U+1F92C",
               "name": "face with symbols on mouth",
-              "keywords": ["face with symbols on mouth", "swearing", "cursing"]
+              "keywords": [
+                "censor",
+                "cursing",
+                "cussing",
+                "face",
+                "mad",
+                "mouth",
+                "pissed",
+                "swearing",
+                "symbols"
+              ]
             },
             {
               "codepoint": "U+1F608",
               "name": "smiling face with horns",
-              "keywords": ["face", "fairy tale", "fantasy", "horns", "smile", "smiling face with horns"]
+              "keywords": [
+                "demon",
+                "devil",
+                "evil",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "horns",
+                "purple",
+                "shade",
+                "smile",
+                "smiling",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F47F",
               "name": "angry face with horns",
-              "keywords": ["angry face with horns", "demon", "devil", "face", "fantasy", "imp"]
+              "keywords": [
+                "angry",
+                "demon",
+                "devil",
+                "evil",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "horns",
+                "imp",
+                "mischievous",
+                "purple",
+                "shade",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F480",
               "name": "skull",
-              "keywords": ["death", "face", "fairy tale", "monster", "skull"]
+              "keywords": [
+                "body",
+                "dead",
+                "death",
+                "face",
+                "fairy",
+                "fairytale",
+                "i’m",
+                "lmao",
+                "monster",
+                "skull",
+                "tale",
+                "yolo"
+              ]
             },
             {
               "codepoint": "U+2620",
               "name": "skull and crossbones",
-              "keywords": ["crossbones", "death", "face", "monster", "skull", "skull and crossbones"]
+              "keywords": [
+                "bone",
+                "crossbones",
+                "dead",
+                "death",
+                "face",
+                "monster",
+                "skull"
+              ]
             }
           ]
         },
         {
-          "category": "face_costume",
+          "category": "face-costume",
           "contents": [
             {
               "codepoint": "U+1F4A9",
               "name": "pile of poo",
-              "keywords": ["dung", "face", "monster", "pile of poo", "poo", "poop"]
+              "keywords": [
+                "bs",
+                "comic",
+                "doo",
+                "dung",
+                "face",
+                "fml",
+                "monster",
+                "pile",
+                "poo",
+                "poop",
+                "smelly",
+                "smh",
+                "stink",
+                "stinks",
+                "stinky",
+                "turd"
+              ]
             },
             {
               "codepoint": "U+1F921",
@@ -620,27 +1843,94 @@
             {
               "codepoint": "U+1F479",
               "name": "ogre",
-              "keywords": ["creature", "face", "fairy tale", "fantasy", "monster", "ogre", "troll"]
+              "keywords": [
+                "creature",
+                "devil",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "mask",
+                "monster",
+                "ogre",
+                "scary",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F47A",
               "name": "goblin",
-              "keywords": ["creature", "face", "fairy tale", "fantasy", "goblin", "monster"]
+              "keywords": [
+                "angry",
+                "creature",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "goblin",
+                "mask",
+                "mean",
+                "monster",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F47B",
               "name": "ghost",
-              "keywords": ["creature", "face", "fairy tale", "fantasy", "ghost", "monster"]
+              "keywords": [
+                "boo",
+                "creature",
+                "excited",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "ghost",
+                "halloween",
+                "haunting",
+                "monster",
+                "scary",
+                "silly",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F47D",
               "name": "alien",
-              "keywords": ["alien", "creature", "extraterrestrial", "face", "fantasy", "ufo"]
+              "keywords": [
+                "alien",
+                "creature",
+                "extraterrestrial",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "monster",
+                "space",
+                "tale",
+                "ufo"
+              ]
             },
             {
               "codepoint": "U+1F47E",
               "name": "alien monster",
-              "keywords": ["alien", "creature", "extraterrestrial", "face", "monster", "ufo"]
+              "keywords": [
+                "alien",
+                "creature",
+                "extraterrestrial",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "game",
+                "gamer",
+                "games",
+                "monster",
+                "pixelated",
+                "space",
+                "tale",
+                "ufo"
+              ]
             },
             {
               "codepoint": "U+1F916",
@@ -650,72 +1940,175 @@
           ]
         },
         {
-          "category": "cat_face",
+          "category": "cat-face",
           "contents": [
             {
               "codepoint": "U+1F63A",
               "name": "grinning cat",
-              "keywords": ["cat", "face", "grinning", "mouth", "open", "smile"]
+              "keywords": [
+                "animal",
+                "cat",
+                "face",
+                "grinning",
+                "mouth",
+                "open",
+                "smile",
+                "smiling"
+              ]
             },
             {
               "codepoint": "U+1F638",
               "name": "grinning cat with smiling eyes",
-              "keywords": ["cat", "eye", "face", "grin", "grinning cat with smiling eyes", "smile"]
+              "keywords": [
+                "animal",
+                "cat",
+                "eye",
+                "eyes",
+                "face",
+                "grin",
+                "grinning",
+                "smile",
+                "smiling"
+              ]
             },
             {
               "codepoint": "U+1F639",
               "name": "cat with tears of joy",
-              "keywords": ["cat", "cat with tears of joy", "face", "joy", "tear"]
+              "keywords": [
+                "animal",
+                "cat",
+                "face",
+                "joy",
+                "laugh",
+                "laughing",
+                "lol",
+                "tear",
+                "tears"
+              ]
             },
             {
               "codepoint": "U+1F63B",
               "name": "smiling cat with heart-eyes",
-              "keywords": ["cat", "eye", "face", "heart", "love", "smile", "smiling cat with heart-eyes"]
+              "keywords": [
+                "animal",
+                "cat",
+                "eye",
+                "face",
+                "heart",
+                "heart-eyes",
+                "love",
+                "smile",
+                "smiling"
+              ]
             },
             {
               "codepoint": "U+1F63C",
               "name": "cat with wry smile",
-              "keywords": ["cat", "cat with wry smile", "face", "ironic", "smile", "wry"]
+              "keywords": ["animal", "cat", "face", "ironic", "smile", "wry"]
             },
             {
               "codepoint": "U+1F63D",
               "name": "kissing cat",
-              "keywords": ["cat", "eye", "face", "kiss", "kissing cat"]
+              "keywords": [
+                "animal",
+                "cat",
+                "closed",
+                "eye",
+                "eyes",
+                "face",
+                "kiss",
+                "kissing"
+              ]
             },
             {
               "codepoint": "U+1F640",
               "name": "weary cat",
-              "keywords": ["cat", "face", "oh", "surprised", "weary"]
+              "keywords": ["animal", "cat", "face", "oh", "surprised", "weary"]
             },
             {
               "codepoint": "U+1F63F",
               "name": "crying cat",
-              "keywords": ["cat", "cry", "crying cat", "face", "sad", "tear"]
+              "keywords": [
+                "animal",
+                "cat",
+                "cry",
+                "crying",
+                "face",
+                "sad",
+                "tear"
+              ]
             },
             {
               "codepoint": "U+1F63E",
               "name": "pouting cat",
-              "keywords": ["cat", "face", "pouting"]
+              "keywords": ["animal", "cat", "face", "pouting"]
             }
           ]
         },
         {
-          "category": "monkey_face",
+          "category": "monkey-face",
           "contents": [
             {
               "codepoint": "U+1F648",
               "name": "see-no-evil monkey",
-              "keywords": ["evil", "face", "forbidden", "monkey", "see", "see-no-evil monkey"]
+              "keywords": [
+                "embarrassed",
+                "evil",
+                "face",
+                "forbidden",
+                "forgot",
+                "gesture",
+                "hide",
+                "monkey",
+                "no",
+                "omg",
+                "prohibited",
+                "scared",
+                "secret",
+                "smh",
+                "watch"
+              ]
             },
             {
               "codepoint": "U+1F649",
               "name": "hear-no-evil monkey",
-              "keywords": ["evil", "face", "forbidden", "hear", "hear-no-evil monkey", "monkey"]
+              "keywords": [
+                "animal",
+                "ears",
+                "evil",
+                "face",
+                "forbidden",
+                "gesture",
+                "hear",
+                "listen",
+                "monkey",
+                "no",
+                "not",
+                "prohibited",
+                "secret",
+                "shh",
+                "tmi"
+              ]
             },
             {
               "codepoint": "U+1F64A",
               "name": "speak-no-evil monkey",
-              "keywords": ["evil", "face", "forbidden", "monkey", "speak", "speak-no-evil monkey"]
+              "keywords": [
+                "animal",
+                "evil",
+                "face",
+                "forbidden",
+                "gesture",
+                "monkey",
+                "no",
+                "not",
+                "oops",
+                "prohibited",
+                "quiet",
+                "secret",
+                "speak",
+                "stealth"
+              ]
             }
           ]
         },
@@ -725,127 +2118,315 @@
             {
               "codepoint": "U+1F48C",
               "name": "love letter",
-              "keywords": ["heart", "letter", "love", "mail"]
+              "keywords": [
+                "heart",
+                "letter",
+                "love",
+                "mail",
+                "romance",
+                "valentine"
+              ]
             },
             {
               "codepoint": "U+1F498",
               "name": "heart with arrow",
-              "keywords": ["arrow", "cupid", "heart with arrow"]
+              "keywords": [
+                "143",
+                "adorbs",
+                "arrow",
+                "cupid",
+                "date",
+                "emotion",
+                "heart",
+                "ily",
+                "love",
+                "romance",
+                "valentine"
+              ]
             },
             {
               "codepoint": "U+1F49D",
               "name": "heart with ribbon",
-              "keywords": ["heart with ribbon", "ribbon", "valentine"]
+              "keywords": [
+                "143",
+                "anniversary",
+                "emotion",
+                "heart",
+                "ily",
+                "kisses",
+                "ribbon",
+                "valentine",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F496",
               "name": "sparkling heart",
-              "keywords": ["excited", "sparkle", "sparkling heart"]
+              "keywords": [
+                "143",
+                "emotion",
+                "excited",
+                "good",
+                "heart",
+                "ily",
+                "kisses",
+                "morning",
+                "night",
+                "sparkle",
+                "sparkling",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F497",
               "name": "growing heart",
-              "keywords": ["excited", "growing", "growing heart", "nervous", "pulse"]
+              "keywords": [
+                "143",
+                "emotion",
+                "excited",
+                "growing",
+                "heart",
+                "heartpulse",
+                "ily",
+                "kisses",
+                "muah",
+                "nervous",
+                "pulse",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F493",
               "name": "beating heart",
-              "keywords": ["beating", "beating heart", "heartbeat", "pulsating"]
+              "keywords": [
+                "143",
+                "beating",
+                "cardio",
+                "emotion",
+                "heart",
+                "heartbeat",
+                "ily",
+                "love",
+                "pulsating",
+                "pulse"
+              ]
             },
             {
               "codepoint": "U+1F49E",
               "name": "revolving hearts",
-              "keywords": ["revolving", "revolving hearts"]
+              "keywords": [
+                "143",
+                "adorbs",
+                "anniversary",
+                "emotion",
+                "heart",
+                "hearts",
+                "revolving"
+              ]
             },
             {
               "codepoint": "U+1F495",
               "name": "two hearts",
-              "keywords": ["love", "two hearts"]
+              "keywords": [
+                "143",
+                "anniversary",
+                "date",
+                "dating",
+                "emotion",
+                "heart",
+                "hearts",
+                "ily",
+                "kisses",
+                "love",
+                "loving",
+                "two",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F49F",
               "name": "heart decoration",
-              "keywords": ["heart", "heart decoration"]
+              "keywords": [
+                "143",
+                "decoration",
+                "emotion",
+                "heart",
+                "hearth",
+                "purple",
+                "white"
+              ]
             },
             {
               "codepoint": "U+2763",
               "name": "heart exclamation",
-              "keywords": ["exclamation", "heart exclamation", "mark", "punctuation"]
+              "keywords": [
+                "exclamation",
+                "heart",
+                "heavy",
+                "mark",
+                "punctuation"
+              ]
             },
             {
               "codepoint": "U+1F494",
               "name": "broken heart",
-              "keywords": ["break", "broken", "broken heart"]
+              "keywords": [
+                "break",
+                "broken",
+                "crushed",
+                "emotion",
+                "heart",
+                "heartbroken",
+                "lonely",
+                "sad"
+              ]
             },
             {
               "codepoint": "U+2764 U+FE0F U+200D U+1F525",
               "name": "heart on fire",
-              "keywords": ["burn", "heart", "heart on fire", "love", "lust", "sacred heart"]
+              "keywords": ["burn", "fire", "heart", "love", "lust", "sacred"]
             },
             {
               "codepoint": "U+2764 U+FE0F U+200D U+1FA79",
               "name": "mending heart",
-              "keywords": ["healthier", "improving", "mending", "mending heart", "recovering", "recuperating", "well"]
+              "keywords": [
+                "healthier",
+                "heart",
+                "improving",
+                "mending",
+                "recovering",
+                "recuperating",
+                "well"
+              ]
             },
             {
               "codepoint": "U+2764",
               "name": "red heart",
-              "keywords": ["heart", "red heart"]
+              "keywords": ["emotion", "heart", "love", "red"]
             },
             {
               "codepoint": "U+1FA77",
               "name": "pink heart",
-              "keywords": ["cute", "heart", "like", "love", "pink"]
+              "keywords": [
+                "143",
+                "adorable",
+                "cute",
+                "emotion",
+                "heart",
+                "ily",
+                "like",
+                "love",
+                "pink",
+                "special",
+                "sweet"
+              ]
             },
             {
               "codepoint": "U+1F9E1",
               "name": "orange heart",
-              "keywords": ["orange", "orange heart"]
+              "keywords": ["143", "heart", "orange"]
             },
             {
               "codepoint": "U+1F49B",
               "name": "yellow heart",
-              "keywords": ["yellow", "yellow heart"]
+              "keywords": [
+                "143",
+                "cardiac",
+                "emotion",
+                "heart",
+                "ily",
+                "love",
+                "yellow"
+              ]
             },
             {
               "codepoint": "U+1F49A",
               "name": "green heart",
-              "keywords": ["green", "green heart"]
+              "keywords": [
+                "143",
+                "emotion",
+                "green",
+                "heart",
+                "ily",
+                "love",
+                "romantic"
+              ]
             },
             {
               "codepoint": "U+1F499",
               "name": "blue heart",
-              "keywords": ["blue", "blue heart"]
+              "keywords": [
+                "143",
+                "blue",
+                "emotion",
+                "heart",
+                "ily",
+                "love",
+                "romance"
+              ]
             },
             {
               "codepoint": "U+1FA75",
               "name": "light blue heart",
-              "keywords": ["cyan", "heart", "light blue", "light blue heart", "teal"]
+              "keywords": [
+                "143",
+                "blue",
+                "cute",
+                "cyan",
+                "emotion",
+                "heart",
+                "ily",
+                "light",
+                "like",
+                "love",
+                "sky",
+                "special",
+                "teal"
+              ]
             },
             {
               "codepoint": "U+1F49C",
               "name": "purple heart",
-              "keywords": ["purple", "purple heart"]
+              "keywords": [
+                "143",
+                "bestest",
+                "emotion",
+                "heart",
+                "ily",
+                "love",
+                "purple"
+              ]
             },
             {
               "codepoint": "U+1F90E",
               "name": "brown heart",
-              "keywords": ["brown", "heart"]
+              "keywords": ["143", "brown", "heart"]
             },
             {
               "codepoint": "U+1F5A4",
               "name": "black heart",
-              "keywords": ["black", "black heart", "evil", "wicked"]
+              "keywords": ["black", "evil", "heart", "wicked"]
             },
             {
               "codepoint": "U+1FA76",
               "name": "grey heart",
-              "keywords": ["gray", "grey heart", "heart", "silver", "slate"]
+              "keywords": [
+                "143",
+                "emotion",
+                "gray",
+                "grey",
+                "heart",
+                "ily",
+                "love",
+                "silver",
+                "slate",
+                "special"
+              ]
             },
             {
               "codepoint": "U+1F90D",
               "name": "white heart",
-              "keywords": ["heart", "white"]
+              "keywords": ["143", "heart", "white"]
             }
           ]
         },
@@ -855,72 +2436,179 @@
             {
               "codepoint": "U+1F48B",
               "name": "kiss mark",
-              "keywords": ["kiss", "kiss mark", "lips"]
+              "keywords": [
+                "dating",
+                "emotion",
+                "heart",
+                "kiss",
+                "kissing",
+                "lips",
+                "mark",
+                "romance",
+                "sexy"
+              ]
             },
             {
               "codepoint": "U+1F4AF",
               "name": "hundred points",
-              "keywords": ["100", "full", "hundred", "hundred points", "score"]
+              "keywords": [
+                "100",
+                "a+",
+                "agree",
+                "clearly",
+                "definitely",
+                "faithful",
+                "fleek",
+                "full",
+                "hundred",
+                "keep",
+                "perfect",
+                "point",
+                "score",
+                "TRUE",
+                "truth",
+                "yup"
+              ]
             },
             {
               "codepoint": "U+1F4A2",
               "name": "anger symbol",
-              "keywords": ["anger symbol", "angry", "comic", "mad"]
+              "keywords": ["anger", "angry", "comic", "mad", "symbol", "upset"]
             },
             {
               "codepoint": "U+1F4A5",
               "name": "collision",
-              "keywords": ["boom", "collision", "comic"]
+              "keywords": [
+                "bomb",
+                "boom",
+                "collide",
+                "collision",
+                "comic",
+                "explode"
+              ]
             },
             {
               "codepoint": "U+1F4AB",
               "name": "dizzy",
-              "keywords": ["comic", "dizzy", "star"]
+              "keywords": [
+                "comic",
+                "dizzy",
+                "shining",
+                "shooting",
+                "star",
+                "stars"
+              ]
             },
             {
               "codepoint": "U+1F4A6",
               "name": "sweat droplets",
-              "keywords": ["comic", "splashing", "sweat", "sweat droplets"]
+              "keywords": [
+                "comic",
+                "drip",
+                "droplet",
+                "droplets",
+                "drops",
+                "splashing",
+                "squirt",
+                "sweat",
+                "water",
+                "wet",
+                "work",
+                "workout"
+              ]
             },
             {
               "codepoint": "U+1F4A8",
               "name": "dashing away",
-              "keywords": ["comic", "dash", "dashing away", "running"]
+              "keywords": [
+                "away",
+                "cloud",
+                "comic",
+                "dash",
+                "dashing",
+                "fart",
+                "fast",
+                "go",
+                "gone",
+                "gotta",
+                "running",
+                "smoke"
+              ]
             },
-            {
-              "codepoint": "U+1F573",
-              "name": "hole",
-              "keywords": ["hole"]
-            },
+            { "codepoint": "U+1F573", "name": "hole", "keywords": ["hole"] },
             {
               "codepoint": "U+1F4AC",
               "name": "speech balloon",
-              "keywords": ["balloon", "bubble", "comic", "dialog", "speech"]
+              "keywords": [
+                "balloon",
+                "bubble",
+                "comic",
+                "dialog",
+                "message",
+                "sms",
+                "speech",
+                "talk",
+                "text",
+                "typing"
+              ]
             },
             {
               "codepoint": "U+1F441 U+FE0F U+200D U+1F5E8 U+FE0F",
               "name": "eye in speech bubble",
-              "keywords": ["eye", "eye in speech bubble", "speech bubble", "witness"]
+              "keywords": ["balloon", "bubble", "eye", "speech", "witness"]
             },
             {
               "codepoint": "U+1F5E8",
               "name": "left speech bubble",
-              "keywords": ["dialog", "left speech bubble", "speech"]
+              "keywords": ["balloon", "bubble", "dialog", "left", "speech"]
             },
             {
               "codepoint": "U+1F5EF",
               "name": "right anger bubble",
-              "keywords": ["angry", "balloon", "bubble", "mad", "right anger bubble"]
+              "keywords": [
+                "anger",
+                "angry",
+                "balloon",
+                "bubble",
+                "mad",
+                "right"
+              ]
             },
             {
               "codepoint": "U+1F4AD",
               "name": "thought balloon",
-              "keywords": ["balloon", "bubble", "comic", "thought"]
+              "keywords": [
+                "balloon",
+                "bubble",
+                "cartoon",
+                "cloud",
+                "comic",
+                "daydream",
+                "decisions",
+                "dream",
+                "idea",
+                "invent",
+                "invention",
+                "realize",
+                "think",
+                "thoughts",
+                "wonder"
+              ]
             },
             {
               "codepoint": "U+1F4A4",
-              "name": "zzz",
-              "keywords": ["comic", "sleep", "zzz"]
+              "name": "ZZZ",
+              "keywords": [
+                "comic",
+                "good",
+                "goodnight",
+                "night",
+                "sleep",
+                "sleeping",
+                "sleepy",
+                "tired",
+                "zzz"
+              ]
             }
           ]
         }
@@ -930,187 +2618,435 @@
       "category": "People & Body",
       "contents": [
         {
-          "category": "hand_fingers_open",
+          "category": "hand-fingers-open",
           "contents": [
             {
               "codepoint": "U+1F44B",
               "name": "waving hand",
-              "keywords": ["hand", "wave", "waving"]
+              "keywords": [
+                "bye",
+                "cya",
+                "g2g",
+                "greetings",
+                "gtg",
+                "hand",
+                "hello",
+                "hey",
+                "hi",
+                "later",
+                "outtie",
+                "ttfn",
+                "ttyl",
+                "wave",
+                "yo",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F91A",
               "name": "raised back of hand",
-              "keywords": ["backhand", "raised", "raised back of hand"]
+              "keywords": ["back", "backhand", "hand", "raised"]
             },
             {
               "codepoint": "U+1F590",
               "name": "hand with fingers splayed",
-              "keywords": ["finger", "hand", "hand with fingers splayed", "splayed"]
+              "keywords": [
+                "finger",
+                "fingers",
+                "hand",
+                "raised",
+                "splayed",
+                "stop"
+              ]
             },
             {
               "codepoint": "U+270B",
               "name": "raised hand",
-              "keywords": ["hand", "high 5", "high five", "raised hand"]
+              "keywords": ["5", "five", "hand", "high", "raised", "stop"]
             },
             {
               "codepoint": "U+1F596",
               "name": "vulcan salute",
-              "keywords": ["finger", "hand", "spock", "vulcan", "vulcan salute"]
+              "keywords": ["finger", "hand", "hands", "salute", "Vulcan"]
             },
             {
               "codepoint": "U+1FAF1",
               "name": "rightwards hand",
-              "keywords": ["hand", "right", "rightward"]
+              "keywords": [
+                "hand",
+                "handshake",
+                "hold",
+                "reach",
+                "right",
+                "rightward",
+                "rightwards",
+                "shake"
+              ]
             },
             {
               "codepoint": "U+1FAF2",
               "name": "leftwards hand",
-              "keywords": ["hand", "left", "leftward"]
+              "keywords": [
+                "hand",
+                "handshake",
+                "hold",
+                "left",
+                "leftward",
+                "leftwards",
+                "reach",
+                "shake"
+              ]
             },
             {
               "codepoint": "U+1FAF3",
               "name": "palm down hand",
-              "keywords": ["dismiss", "drop", "shoo"]
+              "keywords": [
+                "dismiss",
+                "down",
+                "drop",
+                "dropped",
+                "hand",
+                "palm",
+                "pick",
+                "shoo",
+                "up"
+              ]
             },
             {
               "codepoint": "U+1FAF4",
               "name": "palm up hand",
-              "keywords": ["beckon", "catch", "come", "offer"]
+              "keywords": [
+                "beckon",
+                "catch",
+                "come",
+                "hand",
+                "hold",
+                "know",
+                "lift",
+                "me",
+                "offer",
+                "palm",
+                "tell"
+              ]
             },
             {
               "codepoint": "U+1FAF7",
               "name": "leftwards pushing hand",
-              "keywords": ["high five", "leftward", "leftwards pushing hand", "push", "refuse", "stop", "wait"]
+              "keywords": [
+                "block",
+                "five",
+                "halt",
+                "hand",
+                "high",
+                "hold",
+                "leftward",
+                "leftwards",
+                "pause",
+                "push",
+                "pushing",
+                "refuse",
+                "slap",
+                "stop",
+                "wait"
+              ]
             },
             {
               "codepoint": "U+1FAF8",
               "name": "rightwards pushing hand",
-              "keywords": ["high five", "push", "refuse", "rightward", "rightwards pushing hand", "stop", "wait"]
+              "keywords": [
+                "block",
+                "five",
+                "halt",
+                "hand",
+                "high",
+                "hold",
+                "pause",
+                "push",
+                "pushing",
+                "refuse",
+                "rightward",
+                "rightwards",
+                "slap",
+                "stop",
+                "wait"
+              ]
             }
           ]
         },
         {
-          "category": "hand_fingers_partial",
+          "category": "hand-fingers-partial",
           "contents": [
             {
               "codepoint": "U+1F44C",
               "name": "OK hand",
-              "keywords": ["hand", "OK"]
+              "keywords": [
+                "awesome",
+                "bet",
+                "dope",
+                "fleek",
+                "fosho",
+                "got",
+                "gotcha",
+                "hand",
+                "legit",
+                "OK",
+                "okay",
+                "pinch",
+                "rad",
+                "sure",
+                "sweet",
+                "three"
+              ]
             },
             {
               "codepoint": "U+1F90C",
               "name": "pinched fingers",
-              "keywords": ["fingers", "hand gesture", "interrogation", "pinched", "sarcastic"]
+              "keywords": [
+                "fingers",
+                "gesture",
+                "hand",
+                "hold",
+                "huh",
+                "interrogation",
+                "patience",
+                "pinched",
+                "relax",
+                "sarcastic",
+                "ugh",
+                "what",
+                "zip"
+              ]
             },
             {
               "codepoint": "U+1F90F",
               "name": "pinching hand",
-              "keywords": ["pinching hand", "small amount"]
+              "keywords": [
+                "amount",
+                "bit",
+                "fingers",
+                "hand",
+                "little",
+                "pinching",
+                "small",
+                "sort"
+              ]
             },
             {
               "codepoint": "U+270C",
               "name": "victory hand",
-              "keywords": ["hand", "v", "victory"]
+              "keywords": ["hand", "peace", "v", "victory"]
             },
             {
               "codepoint": "U+1F91E",
               "name": "crossed fingers",
-              "keywords": ["cross", "crossed fingers", "finger", "hand", "luck"]
+              "keywords": [
+                "cross",
+                "crossed",
+                "finger",
+                "fingers",
+                "hand",
+                "luck"
+              ]
             },
             {
               "codepoint": "U+1FAF0",
               "name": "hand with index finger and thumb crossed",
-              "keywords": ["expensive", "heart", "love", "money", "snap"]
+              "keywords": [
+                "<3",
+                "crossed",
+                "expensive",
+                "finger",
+                "hand",
+                "heart",
+                "index",
+                "love",
+                "money",
+                "snap",
+                "thumb"
+              ]
             },
             {
               "codepoint": "U+1F91F",
               "name": "love-you gesture",
-              "keywords": ["hand", "ILY", "love-you gesture"]
+              "keywords": [
+                "fingers",
+                "gesture",
+                "hand",
+                "ILY",
+                "love",
+                "love-you",
+                "three",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F918",
               "name": "sign of the horns",
-              "keywords": ["finger", "hand", "horns", "rock-on", "sign of the horns"]
+              "keywords": ["finger", "hand", "horns", "rock-on", "sign"]
             },
             {
               "codepoint": "U+1F919",
               "name": "call me hand",
-              "keywords": ["call", "call me hand", "hand"]
+              "keywords": ["call", "hand", "hang", "loose", "me", "Shaka"]
             }
           ]
         },
         {
-          "category": "hand_single_finger",
+          "category": "hand-single-finger",
           "contents": [
             {
               "codepoint": "U+1F448",
               "name": "backhand index pointing left",
-              "keywords": ["backhand", "backhand index pointing left", "finger", "hand", "index", "point"]
+              "keywords": [
+                "backhand",
+                "finger",
+                "hand",
+                "index",
+                "left",
+                "point",
+                "pointing"
+              ]
             },
             {
               "codepoint": "U+1F449",
               "name": "backhand index pointing right",
-              "keywords": ["backhand", "backhand index pointing right", "finger", "hand", "index", "point"]
+              "keywords": [
+                "backhand",
+                "finger",
+                "hand",
+                "index",
+                "point",
+                "pointing",
+                "right"
+              ]
             },
             {
               "codepoint": "U+1F446",
               "name": "backhand index pointing up",
-              "keywords": ["backhand", "backhand index pointing up", "finger", "hand", "point", "up"]
+              "keywords": [
+                "backhand",
+                "finger",
+                "hand",
+                "index",
+                "point",
+                "pointing",
+                "up"
+              ]
             },
             {
               "codepoint": "U+1F595",
               "name": "middle finger",
-              "keywords": ["finger", "hand", "middle finger"]
+              "keywords": ["finger", "hand", "middle"]
             },
             {
               "codepoint": "U+1F447",
               "name": "backhand index pointing down",
-              "keywords": ["backhand", "backhand index pointing down", "down", "finger", "hand", "point"]
+              "keywords": [
+                "backhand",
+                "down",
+                "finger",
+                "hand",
+                "index",
+                "point",
+                "pointing"
+              ]
             },
             {
               "codepoint": "U+261D",
               "name": "index pointing up",
-              "keywords": ["finger", "hand", "index", "index pointing up", "point", "up"]
+              "keywords": [
+                "finger",
+                "hand",
+                "index",
+                "point",
+                "pointing",
+                "this",
+                "up"
+              ]
             },
             {
               "codepoint": "U+1FAF5",
               "name": "index pointing at the viewer",
-              "keywords": ["point", "you"]
+              "keywords": [
+                "at",
+                "finger",
+                "hand",
+                "index",
+                "pointing",
+                "poke",
+                "viewer",
+                "you"
+              ]
             }
           ]
         },
         {
-          "category": "hand_fingers_closed",
+          "category": "hand-fingers-closed",
           "contents": [
             {
               "codepoint": "U+1F44D",
               "name": "thumbs up",
-              "keywords": ["+1", "hand", "thumb", "thumbs up", "up"]
+              "keywords": ["+1", "good", "hand", "like", "thumb", "up", "yes"]
             },
             {
               "codepoint": "U+1F44E",
               "name": "thumbs down",
-              "keywords": ["-1", "down", "hand", "thumb", "thumbs down"]
+              "keywords": [
+                "-1",
+                "bad",
+                "dislike",
+                "down",
+                "good",
+                "hand",
+                "no",
+                "nope",
+                "thumb",
+                "thumbs"
+              ]
             },
             {
               "codepoint": "U+270A",
               "name": "raised fist",
-              "keywords": ["clenched", "fist", "hand", "punch", "raised fist"]
+              "keywords": [
+                "clenched",
+                "fist",
+                "hand",
+                "punch",
+                "raised",
+                "solidarity"
+              ]
             },
             {
               "codepoint": "U+1F44A",
               "name": "oncoming fist",
-              "keywords": ["clenched", "fist", "hand", "oncoming fist", "punch"]
+              "keywords": [
+                "absolutely",
+                "agree",
+                "boom",
+                "bro",
+                "bruh",
+                "bump",
+                "clenched",
+                "correct",
+                "fist",
+                "hand",
+                "knuckle",
+                "oncoming",
+                "pound",
+                "punch",
+                "rock",
+                "ttyl"
+              ]
             },
             {
               "codepoint": "U+1F91B",
               "name": "left-facing fist",
-              "keywords": ["fist", "left-facing fist", "leftwards"]
+              "keywords": ["fist", "left-facing", "leftwards"]
             },
             {
               "codepoint": "U+1F91C",
               "name": "right-facing fist",
-              "keywords": ["fist", "right-facing fist", "rightwards"]
+              "keywords": ["fist", "right-facing", "rightwards"]
             }
           ]
         },
@@ -1120,52 +3056,121 @@
             {
               "codepoint": "U+1F44F",
               "name": "clapping hands",
-              "keywords": ["clap", "clapping hands", "hand"]
+              "keywords": [
+                "applause",
+                "approval",
+                "awesome",
+                "clap",
+                "congrats",
+                "congratulations",
+                "excited",
+                "good",
+                "great",
+                "hand",
+                "homie",
+                "job",
+                "nice",
+                "prayed",
+                "well",
+                "yay"
+              ]
             },
             {
               "codepoint": "U+1F64C",
               "name": "raising hands",
-              "keywords": ["celebration", "gesture", "hand", "hooray", "raised", "raising hands"]
+              "keywords": [
+                "celebration",
+                "gesture",
+                "hand",
+                "hands",
+                "hooray",
+                "praise",
+                "raised",
+                "raising"
+              ]
             },
             {
               "codepoint": "U+1FAF6",
               "name": "heart hands",
-              "keywords": ["love"]
+              "keywords": ["<3", "hands", "heart", "love", "you"]
             },
             {
               "codepoint": "U+1F450",
               "name": "open hands",
-              "keywords": ["hand", "open", "open hands"]
+              "keywords": ["hand", "hands", "hug", "jazz", "open", "swerve"]
             },
             {
               "codepoint": "U+1F932",
               "name": "palms up together",
-              "keywords": ["palms up together", "prayer", "cupped hands"]
+              "keywords": [
+                "cupped",
+                "dua",
+                "hands",
+                "palms",
+                "pray",
+                "prayer",
+                "together",
+                "up",
+                "wish"
+              ]
             },
             {
               "codepoint": "U+1F91D",
               "name": "handshake",
-              "keywords": ["agreement", "hand", "handshake", "meeting", "shake"]
+              "keywords": [
+                "agreement",
+                "deal",
+                "hand",
+                "handshake",
+                "meeting",
+                "shake"
+              ]
             },
             {
               "codepoint": "U+1F64F",
               "name": "folded hands",
-              "keywords": ["ask", "folded hands", "hand", "high 5", "high five", "please", "pray", "thanks"]
+              "keywords": [
+                "appreciate",
+                "ask",
+                "beg",
+                "blessed",
+                "bow",
+                "cmon",
+                "five",
+                "folded",
+                "gesture",
+                "hand",
+                "high",
+                "please",
+                "pray",
+                "thanks",
+                "thx"
+              ]
             }
           ]
         },
         {
-          "category": "hand_prop",
+          "category": "hand-prop",
           "contents": [
             {
               "codepoint": "U+270D",
               "name": "writing hand",
-              "keywords": ["hand", "write", "writing hand"]
+              "keywords": ["hand", "write", "writing"]
             },
             {
               "codepoint": "U+1F485",
               "name": "nail polish",
-              "keywords": ["care", "cosmetics", "manicure", "nail", "polish"]
+              "keywords": [
+                "bored",
+                "care",
+                "cosmetics",
+                "done",
+                "makeup",
+                "manicure",
+                "nail",
+                "polish",
+                "whatever"
+              ]
             },
             {
               "codepoint": "U+1F933",
@@ -1175,97 +3180,185 @@
           ]
         },
         {
-          "category": "body_parts",
+          "category": "body-parts",
           "contents": [
             {
               "codepoint": "U+1F4AA",
               "name": "flexed biceps",
-              "keywords": ["biceps", "comic", "flex", "flexed biceps", "muscle"]
+              "keywords": [
+                "arm",
+                "beast",
+                "bench",
+                "biceps",
+                "bodybuilder",
+                "bro",
+                "curls",
+                "flex",
+                "gains",
+                "gym",
+                "jacked",
+                "muscle",
+                "press",
+                "ripped",
+                "strong",
+                "weightlift"
+              ]
             },
             {
               "codepoint": "U+1F9BE",
               "name": "mechanical arm",
-              "keywords": ["accessibility", "mechanical arm", "prosthetic"]
+              "keywords": ["accessibility", "arm", "mechanical", "prosthetic"]
             },
             {
               "codepoint": "U+1F9BF",
               "name": "mechanical leg",
-              "keywords": ["accessibility", "mechanical leg", "prosthetic"]
+              "keywords": ["accessibility", "leg", "mechanical", "prosthetic"]
             },
             {
               "codepoint": "U+1F9B5",
               "name": "leg",
-              "keywords": ["kick", "leg", "limb"]
+              "keywords": ["bent", "foot", "kick", "knee", "leg", "limb"]
             },
             {
               "codepoint": "U+1F9B6",
               "name": "foot",
-              "keywords": ["foot", "kick", "stomp"]
+              "keywords": ["ankle", "feet", "foot", "kick", "stomp"]
             },
             {
               "codepoint": "U+1F442",
               "name": "ear",
-              "keywords": ["body", "ear"]
+              "keywords": [
+                "body",
+                "ear",
+                "ears",
+                "hear",
+                "hearing",
+                "listen",
+                "listening",
+                "sound"
+              ]
             },
             {
               "codepoint": "U+1F9BB",
               "name": "ear with hearing aid",
-              "keywords": ["accessibility", "ear with hearing aid", "hard of hearing"]
+              "keywords": ["accessibility", "aid", "ear", "hard", "hearing"]
             },
             {
               "codepoint": "U+1F443",
               "name": "nose",
-              "keywords": ["body", "nose"]
+              "keywords": [
+                "body",
+                "nose",
+                "noses",
+                "nosey",
+                "odor",
+                "smell",
+                "smells"
+              ]
             },
             {
               "codepoint": "U+1F9E0",
               "name": "brain",
-              "keywords": ["brain", "intelligent"]
+              "keywords": ["brain", "intelligent", "smart"]
             },
             {
               "codepoint": "U+1FAC0",
               "name": "anatomical heart",
-              "keywords": ["anatomical", "cardiology", "heart", "organ", "pulse"]
+              "keywords": [
+                "anatomical",
+                "beat",
+                "cardiology",
+                "heart",
+                "heartbeat",
+                "organ",
+                "pulse",
+                "real",
+                "red"
+              ]
             },
             {
               "codepoint": "U+1FAC1",
               "name": "lungs",
-              "keywords": ["breath", "exhalation", "inhalation", "lungs", "organ", "respiration"]
+              "keywords": [
+                "breath",
+                "breathe",
+                "exhalation",
+                "inhalation",
+                "lung",
+                "lungs",
+                "organ",
+                "respiration"
+              ]
             },
             {
               "codepoint": "U+1F9B7",
               "name": "tooth",
-              "keywords": ["dentist", "tooth"]
+              "keywords": ["dentist", "pearly", "teeth", "tooth", "white"]
             },
             {
               "codepoint": "U+1F9B4",
               "name": "bone",
-              "keywords": ["bone", "skeleton"]
+              "keywords": ["bone", "bones", "dog", "skeleton", "wishbone"]
             },
             {
               "codepoint": "U+1F440",
               "name": "eyes",
-              "keywords": ["eye", "eyes", "face"]
+              "keywords": [
+                "body",
+                "eye",
+                "eyes",
+                "face",
+                "googly",
+                "look",
+                "looking",
+                "omg",
+                "peep",
+                "see",
+                "seeing"
+              ]
             },
             {
               "codepoint": "U+1F441",
               "name": "eye",
-              "keywords": ["body", "eye"]
+              "keywords": ["1", "body", "eye", "one"]
             },
             {
               "codepoint": "U+1F445",
               "name": "tongue",
-              "keywords": ["body", "tongue"]
+              "keywords": ["body", "lick", "slurp", "tongue"]
             },
             {
               "codepoint": "U+1F444",
               "name": "mouth",
-              "keywords": ["lips", "mouth"]
+              "keywords": [
+                "beauty",
+                "body",
+                "kiss",
+                "kissing",
+                "lips",
+                "lipstick",
+                "mouth"
+              ]
             },
             {
               "codepoint": "U+1FAE6",
               "name": "biting lip",
-              "keywords": ["anxious", "fear", "flirting", "nervous", "uncomfortable", "worried"]
+              "keywords": [
+                "anxious",
+                "bite",
+                "biting",
+                "fear",
+                "flirt",
+                "flirting",
+                "kiss",
+                "lip",
+                "lipstick",
+                "nervous",
+                "sexy",
+                "uncomfortable",
+                "worried",
+                "worry"
+              ]
             }
           ]
         },
@@ -1275,317 +3368,739 @@
             {
               "codepoint": "U+1F476",
               "name": "baby",
-              "keywords": ["baby", "young"]
+              "keywords": [
+                "babies",
+                "baby",
+                "children",
+                "goo",
+                "infant",
+                "newborn",
+                "pregnant",
+                "young"
+              ]
             },
             {
               "codepoint": "U+1F9D2",
               "name": "child",
-              "keywords": ["child", "gender-neutral", "unspecified gender", "young"]
+              "keywords": [
+                "bright-eyed",
+                "child",
+                "grandchild",
+                "kid",
+                "young",
+                "younger"
+              ]
             },
             {
               "codepoint": "U+1F466",
               "name": "boy",
-              "keywords": ["boy", "young"]
+              "keywords": [
+                "boy",
+                "bright-eyed",
+                "child",
+                "grandson",
+                "kid",
+                "son",
+                "young",
+                "younger"
+              ]
             },
             {
               "codepoint": "U+1F467",
               "name": "girl",
-              "keywords": ["girl", "Virgo", "young", "zodiac"]
+              "keywords": [
+                "bright-eyed",
+                "child",
+                "daughter",
+                "girl",
+                "granddaughter",
+                "kid",
+                "Virgo",
+                "young",
+                "younger",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+1F9D1",
               "name": "person",
-              "keywords": ["adult", "gender-neutral", "person", "unspecified gender"]
+              "keywords": ["adult", "person"]
             },
             {
               "codepoint": "U+1F471",
               "name": "person: blond hair",
-              "keywords": ["blond", "blond-haired person", "hair", "person: blond hair"]
+              "keywords": ["blond", "blond-haired", "human", "person"]
             },
             {
               "codepoint": "U+1F468",
               "name": "man",
-              "keywords": ["adult", "man"]
+              "keywords": ["adult", "bro", "man"]
             },
             {
               "codepoint": "U+1F9D4",
               "name": "person: beard",
-              "keywords": ["beard", "person", "person: beard", "bewhiskered"]
+              "keywords": ["beard", "bearded", "person", "whiskers"]
             },
             {
               "codepoint": "U+1F9D4 U+200D U+2642 U+FE0F",
               "name": "man: beard",
-              "keywords": ["beard", "man", "man: beard"]
+              "keywords": ["beard", "bearded", "man", "whiskers"]
             },
             {
               "codepoint": "U+1F9D4 U+200D U+2640 U+FE0F",
               "name": "woman: beard",
-              "keywords": ["beard", "woman", "woman: beard"]
+              "keywords": ["beard", "bearded", "whiskers", "woman"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9B0",
               "name": "man: red hair",
-              "keywords": ["adult", "man", "red hair"]
+              "keywords": ["adult", "bro", "man", "red hair"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9B1",
               "name": "man: curly hair",
-              "keywords": ["adult", "curly hair", "man"]
+              "keywords": ["adult", "bro", "curly hair", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9B3",
               "name": "man: white hair",
-              "keywords": ["adult", "man", "white hair"]
+              "keywords": ["adult", "bro", "man", "white hair"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9B2",
               "name": "man: bald",
-              "keywords": ["adult", "bald", "man"]
+              "keywords": ["adult", "bald", "bro", "man"]
             },
             {
               "codepoint": "U+1F469",
               "name": "woman",
-              "keywords": ["adult", "woman"]
+              "keywords": ["adult", "lady", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9B0",
               "name": "woman: red hair",
-              "keywords": ["adult", "red hair", "woman"]
+              "keywords": ["adult", "lady", "red hair", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9B0",
               "name": "person: red hair",
-              "keywords": ["adult", "gender-neutral", "person", "red hair", "unspecified gender"]
+              "keywords": ["adult", "person", "red hair"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9B1",
               "name": "woman: curly hair",
-              "keywords": ["adult", "curly hair", "woman"]
+              "keywords": ["adult", "curly hair", "lady", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9B1",
               "name": "person: curly hair",
-              "keywords": ["adult", "curly hair", "gender-neutral", "person", "unspecified gender"]
+              "keywords": ["adult", "curly hair", "person"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9B3",
               "name": "woman: white hair",
-              "keywords": ["adult", "white hair", "woman"]
+              "keywords": ["adult", "lady", "white hair", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9B3",
               "name": "person: white hair",
-              "keywords": ["adult", "gender-neutral", "person", "unspecified gender", "white hair"]
+              "keywords": ["adult", "person", "white hair"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9B2",
               "name": "woman: bald",
-              "keywords": ["adult", "bald", "woman"]
+              "keywords": ["adult", "bald", "lady", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9B2",
               "name": "person: bald",
-              "keywords": ["adult", "bald", "gender-neutral", "person", "unspecified gender"]
+              "keywords": ["adult", "bald", "person"]
             },
             {
               "codepoint": "U+1F471 U+200D U+2640 U+FE0F",
               "name": "woman: blond hair",
-              "keywords": ["blond-haired woman", "blonde", "hair", "woman", "woman: blond hair"]
+              "keywords": ["blond", "blond-haired", "blonde", "hair", "woman"]
             },
             {
               "codepoint": "U+1F471 U+200D U+2642 U+FE0F",
               "name": "man: blond hair",
-              "keywords": ["blond", "blond-haired man", "hair", "man", "man: blond hair"]
+              "keywords": ["blond", "blond-haired", "hair", "man"]
             },
             {
               "codepoint": "U+1F9D3",
               "name": "older person",
-              "keywords": ["adult", "gender-neutral", "old", "older person", "unspecified gender"]
+              "keywords": [
+                "adult",
+                "elderly",
+                "grandparent",
+                "old",
+                "person",
+                "wise"
+              ]
             },
             {
               "codepoint": "U+1F474",
               "name": "old man",
-              "keywords": ["adult", "man", "old"]
+              "keywords": [
+                "adult",
+                "bald",
+                "elderly",
+                "gramps",
+                "grandfather",
+                "grandpa",
+                "man",
+                "old",
+                "wise"
+              ]
             },
             {
               "codepoint": "U+1F475",
               "name": "old woman",
-              "keywords": ["adult", "old", "woman"]
+              "keywords": [
+                "adult",
+                "elderly",
+                "grandma",
+                "grandmother",
+                "granny",
+                "lady",
+                "old",
+                "wise",
+                "woman"
+              ]
             }
           ]
         },
         {
-          "category": "person_gesture",
+          "category": "person-gesture",
           "contents": [
             {
               "codepoint": "U+1F64D",
               "name": "person frowning",
-              "keywords": ["frown", "gesture", "person frowning"]
+              "keywords": [
+                "annoyed",
+                "disappointed",
+                "disgruntled",
+                "disturbed",
+                "frown",
+                "frowning",
+                "frustrated",
+                "gesture",
+                "irritated",
+                "person",
+                "upset"
+              ]
             },
             {
               "codepoint": "U+1F64D U+200D U+2642 U+FE0F",
               "name": "man frowning",
-              "keywords": ["frowning", "gesture", "man"]
+              "keywords": [
+                "annoyed",
+                "disappointed",
+                "disgruntled",
+                "disturbed",
+                "frown",
+                "frowning",
+                "frustrated",
+                "gesture",
+                "irritated",
+                "man",
+                "upset"
+              ]
             },
             {
               "codepoint": "U+1F64D U+200D U+2640 U+FE0F",
               "name": "woman frowning",
-              "keywords": ["frowning", "gesture", "woman"]
+              "keywords": [
+                "annoyed",
+                "disappointed",
+                "disgruntled",
+                "disturbed",
+                "frown",
+                "frowning",
+                "frustrated",
+                "gesture",
+                "irritated",
+                "upset",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F64E",
               "name": "person pouting",
-              "keywords": ["gesture", "person pouting", "pouting"]
+              "keywords": [
+                "disappointed",
+                "downtrodden",
+                "frown",
+                "grimace",
+                "person",
+                "pouting",
+                "scowl",
+                "sulk",
+                "upset",
+                "whine"
+              ]
             },
             {
               "codepoint": "U+1F64E U+200D U+2642 U+FE0F",
               "name": "man pouting",
-              "keywords": ["gesture", "man", "pouting"]
+              "keywords": [
+                "disappointed",
+                "downtrodden",
+                "frown",
+                "grimace",
+                "man",
+                "pouting",
+                "scowl",
+                "sulk",
+                "upset",
+                "whine"
+              ]
             },
             {
               "codepoint": "U+1F64E U+200D U+2640 U+FE0F",
               "name": "woman pouting",
-              "keywords": ["gesture", "pouting", "woman"]
+              "keywords": [
+                "disappointed",
+                "downtrodden",
+                "frown",
+                "grimace",
+                "pouting",
+                "scowl",
+                "sulk",
+                "upset",
+                "whine",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F645",
               "name": "person gesturing NO",
-              "keywords": ["forbidden", "gesture", "hand", "person gesturing NO", "prohibited"]
+              "keywords": [
+                "forbidden",
+                "gesture",
+                "hand",
+                "NO",
+                "not",
+                "person",
+                "prohibit"
+              ]
             },
             {
               "codepoint": "U+1F645 U+200D U+2642 U+FE0F",
               "name": "man gesturing NO",
-              "keywords": ["forbidden", "gesture", "hand", "man", "man gesturing NO", "prohibited"]
+              "keywords": [
+                "forbidden",
+                "gesture",
+                "hand",
+                "man",
+                "NO",
+                "not",
+                "prohibit"
+              ]
             },
             {
               "codepoint": "U+1F645 U+200D U+2640 U+FE0F",
               "name": "woman gesturing NO",
-              "keywords": ["forbidden", "gesture", "hand", "prohibited", "woman", "woman gesturing NO"]
+              "keywords": [
+                "forbidden",
+                "gesture",
+                "hand",
+                "NO",
+                "not",
+                "prohibit",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F646",
               "name": "person gesturing OK",
-              "keywords": ["gesture", "hand", "OK", "person gesturing OK"]
+              "keywords": [
+                "exercise",
+                "gesture",
+                "gesturing",
+                "hand",
+                "OK",
+                "omg",
+                "person"
+              ]
             },
             {
               "codepoint": "U+1F646 U+200D U+2642 U+FE0F",
               "name": "man gesturing OK",
-              "keywords": ["gesture", "hand", "man", "man gesturing OK", "OK"]
+              "keywords": [
+                "exercise",
+                "gesture",
+                "gesturing",
+                "hand",
+                "man",
+                "OK",
+                "omg"
+              ]
             },
             {
               "codepoint": "U+1F646 U+200D U+2640 U+FE0F",
               "name": "woman gesturing OK",
-              "keywords": ["gesture", "hand", "OK", "woman", "woman gesturing OK"]
+              "keywords": [
+                "exercise",
+                "gesture",
+                "gesturing",
+                "hand",
+                "OK",
+                "omg",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F481",
               "name": "person tipping hand",
-              "keywords": ["hand", "help", "information", "person tipping hand", "sassy", "tipping"]
+              "keywords": [
+                "fetch",
+                "flick",
+                "flip",
+                "gossip",
+                "hand",
+                "person",
+                "sarcasm",
+                "sarcastic",
+                "sassy",
+                "seriously",
+                "tipping",
+                "whatever"
+              ]
             },
             {
               "codepoint": "U+1F481 U+200D U+2642 U+FE0F",
               "name": "man tipping hand",
-              "keywords": ["man", "man tipping hand", "sassy", "tipping hand"]
+              "keywords": [
+                "fetch",
+                "flick",
+                "flip",
+                "gossip",
+                "hand",
+                "man",
+                "sarcasm",
+                "sarcastic",
+                "sassy",
+                "seriously",
+                "tipping",
+                "whatever"
+              ]
             },
             {
               "codepoint": "U+1F481 U+200D U+2640 U+FE0F",
               "name": "woman tipping hand",
-              "keywords": ["sassy", "tipping hand", "woman", "woman tipping hand"]
+              "keywords": [
+                "fetch",
+                "flick",
+                "flip",
+                "gossip",
+                "hand",
+                "sarcasm",
+                "sarcastic",
+                "sassy",
+                "seriously",
+                "tipping",
+                "whatever",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F64B",
               "name": "person raising hand",
-              "keywords": ["gesture", "hand", "happy", "person raising hand", "raised"]
+              "keywords": [
+                "gesture",
+                "hand",
+                "here",
+                "know",
+                "me",
+                "person",
+                "pick",
+                "question",
+                "raise",
+                "raising"
+              ]
             },
             {
               "codepoint": "U+1F64B U+200D U+2642 U+FE0F",
               "name": "man raising hand",
-              "keywords": ["gesture", "man", "man raising hand", "raising hand"]
+              "keywords": [
+                "gesture",
+                "hand",
+                "here",
+                "know",
+                "man",
+                "me",
+                "pick",
+                "question",
+                "raise",
+                "raising"
+              ]
             },
             {
               "codepoint": "U+1F64B U+200D U+2640 U+FE0F",
               "name": "woman raising hand",
-              "keywords": ["gesture", "raising hand", "woman", "woman raising hand"]
+              "keywords": [
+                "gesture",
+                "hand",
+                "here",
+                "know",
+                "me",
+                "pick",
+                "question",
+                "raise",
+                "raising",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9CF",
               "name": "deaf person",
-              "keywords": ["accessibility", "deaf", "deaf person", "ear", "hear"]
+              "keywords": [
+                "accessibility",
+                "deaf",
+                "ear",
+                "gesture",
+                "hear",
+                "person"
+              ]
             },
             {
               "codepoint": "U+1F9CF U+200D U+2642 U+FE0F",
               "name": "deaf man",
-              "keywords": ["deaf", "man"]
+              "keywords": [
+                "accessibility",
+                "deaf",
+                "ear",
+                "gesture",
+                "hear",
+                "man"
+              ]
             },
             {
               "codepoint": "U+1F9CF U+200D U+2640 U+FE0F",
               "name": "deaf woman",
-              "keywords": ["deaf", "woman"]
+              "keywords": [
+                "accessibility",
+                "deaf",
+                "ear",
+                "gesture",
+                "hear",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F647",
               "name": "person bowing",
-              "keywords": ["apology", "bow", "gesture", "person bowing", "sorry"]
+              "keywords": [
+                "apology",
+                "ask",
+                "beg",
+                "bow",
+                "bowing",
+                "favor",
+                "forgive",
+                "gesture",
+                "meditate",
+                "meditation",
+                "person",
+                "pity",
+                "regret",
+                "sorry"
+              ]
             },
             {
               "codepoint": "U+1F647 U+200D U+2642 U+FE0F",
               "name": "man bowing",
-              "keywords": ["apology", "bowing", "favor", "gesture", "man", "sorry"]
+              "keywords": [
+                "apology",
+                "ask",
+                "beg",
+                "bow",
+                "bowing",
+                "favor",
+                "forgive",
+                "gesture",
+                "man",
+                "meditate",
+                "meditation",
+                "pity",
+                "regret",
+                "sorry"
+              ]
             },
             {
               "codepoint": "U+1F647 U+200D U+2640 U+FE0F",
               "name": "woman bowing",
-              "keywords": ["apology", "bowing", "favor", "gesture", "sorry", "woman"]
+              "keywords": [
+                "apology",
+                "ask",
+                "beg",
+                "bow",
+                "bowing",
+                "favor",
+                "forgive",
+                "gesture",
+                "meditate",
+                "meditation",
+                "pity",
+                "regret",
+                "sorry",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F926",
               "name": "person facepalming",
-              "keywords": ["disbelief", "exasperation", "face", "palm", "person facepalming"]
+              "keywords": [
+                "again",
+                "bewilder",
+                "disbelief",
+                "exasperation",
+                "facepalm",
+                "no",
+                "not",
+                "oh",
+                "omg",
+                "person",
+                "shock",
+                "smh"
+              ]
             },
             {
               "codepoint": "U+1F926 U+200D U+2642 U+FE0F",
               "name": "man facepalming",
-              "keywords": ["disbelief", "exasperation", "facepalm", "man", "man facepalming"]
+              "keywords": [
+                "again",
+                "bewilder",
+                "disbelief",
+                "exasperation",
+                "facepalm",
+                "man",
+                "no",
+                "not",
+                "oh",
+                "omg",
+                "shock",
+                "smh"
+              ]
             },
             {
               "codepoint": "U+1F926 U+200D U+2640 U+FE0F",
               "name": "woman facepalming",
-              "keywords": ["disbelief", "exasperation", "facepalm", "woman", "woman facepalming"]
+              "keywords": [
+                "again",
+                "bewilder",
+                "disbelief",
+                "exasperation",
+                "facepalm",
+                "no",
+                "not",
+                "oh",
+                "omg",
+                "shock",
+                "smh",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F937",
               "name": "person shrugging",
-              "keywords": ["doubt", "ignorance", "indifference", "person shrugging", "shrug"]
+              "keywords": [
+                "doubt",
+                "dunno",
+                "guess",
+                "idk",
+                "ignorance",
+                "indifference",
+                "knows",
+                "maybe",
+                "person",
+                "shrug",
+                "shrugging",
+                "whatever",
+                "who"
+              ]
             },
             {
               "codepoint": "U+1F937 U+200D U+2642 U+FE0F",
               "name": "man shrugging",
-              "keywords": ["doubt", "ignorance", "indifference", "man", "man shrugging", "shrug"]
+              "keywords": [
+                "doubt",
+                "dunno",
+                "guess",
+                "idk",
+                "ignorance",
+                "indifference",
+                "knows",
+                "man",
+                "maybe",
+                "shrug",
+                "shrugging",
+                "whatever",
+                "who"
+              ]
             },
             {
               "codepoint": "U+1F937 U+200D U+2640 U+FE0F",
               "name": "woman shrugging",
-              "keywords": ["doubt", "ignorance", "indifference", "shrug", "woman", "woman shrugging"]
+              "keywords": [
+                "doubt",
+                "dunno",
+                "guess",
+                "idk",
+                "ignorance",
+                "indifference",
+                "knows",
+                "maybe",
+                "shrug",
+                "shrugging",
+                "whatever",
+                "who",
+                "woman"
+              ]
             }
           ]
         },
         {
-          "category": "person_role",
+          "category": "person-role",
           "contents": [
             {
               "codepoint": "U+1F9D1 U+200D U+2695 U+FE0F",
               "name": "health worker",
-              "keywords": ["doctor", "health worker", "healthcare", "nurse", "therapist"]
+              "keywords": [
+                "doctor",
+                "health",
+                "healthcare",
+                "nurse",
+                "therapist",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+2695 U+FE0F",
               "name": "man health worker",
-              "keywords": ["doctor", "healthcare", "man", "man health worker", "nurse", "therapist"]
+              "keywords": [
+                "doctor",
+                "health",
+                "healthcare",
+                "man",
+                "nurse",
+                "therapist",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+2695 U+FE0F",
               "name": "woman health worker",
-              "keywords": ["doctor", "healthcare", "nurse", "therapist", "woman", "woman health worker"]
+              "keywords": [
+                "doctor",
+                "health",
+                "healthcare",
+                "nurse",
+                "therapist",
+                "woman",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F393",
@@ -1605,32 +4120,44 @@
             {
               "codepoint": "U+1F9D1 U+200D U+1F3EB",
               "name": "teacher",
-              "keywords": ["instructor", "professor", "teacher"]
+              "keywords": ["instructor", "lecturer", "professor", "teacher"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F3EB",
               "name": "man teacher",
-              "keywords": ["instructor", "man", "professor", "teacher"]
+              "keywords": [
+                "instructor",
+                "lecturer",
+                "man",
+                "professor",
+                "teacher"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F3EB",
               "name": "woman teacher",
-              "keywords": ["instructor", "professor", "teacher", "woman"]
+              "keywords": [
+                "instructor",
+                "lecturer",
+                "professor",
+                "teacher",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+2696 U+FE0F",
               "name": "judge",
-              "keywords": ["judge", "justice", "scales"]
+              "keywords": ["judge", "justice", "law", "scales"]
             },
             {
               "codepoint": "U+1F468 U+200D U+2696 U+FE0F",
               "name": "man judge",
-              "keywords": ["judge", "justice", "man", "scales"]
+              "keywords": ["judge", "justice", "law", "man", "scales"]
             },
             {
               "codepoint": "U+1F469 U+200D U+2696 U+FE0F",
               "name": "woman judge",
-              "keywords": ["judge", "justice", "scales", "woman"]
+              "keywords": ["judge", "justice", "law", "scales", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F33E",
@@ -1670,12 +4197,24 @@
             {
               "codepoint": "U+1F468 U+200D U+1F527",
               "name": "man mechanic",
-              "keywords": ["electrician", "man", "mechanic", "plumber", "tradesperson"]
+              "keywords": [
+                "electrician",
+                "man",
+                "mechanic",
+                "plumber",
+                "tradesperson"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F527",
               "name": "woman mechanic",
-              "keywords": ["electrician", "mechanic", "plumber", "tradesperson", "woman"]
+              "keywords": [
+                "electrician",
+                "mechanic",
+                "plumber",
+                "tradesperson",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F3ED",
@@ -1690,67 +4229,165 @@
             {
               "codepoint": "U+1F469 U+200D U+1F3ED",
               "name": "woman factory worker",
-              "keywords": ["assembly", "factory", "industrial", "woman", "worker"]
+              "keywords": [
+                "assembly",
+                "factory",
+                "industrial",
+                "woman",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F4BC",
               "name": "office worker",
-              "keywords": ["architect", "business", "manager", "office worker", "white-collar"]
+              "keywords": [
+                "architect",
+                "business",
+                "manager",
+                "office",
+                "white-collar",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F4BC",
               "name": "man office worker",
-              "keywords": ["architect", "business", "man", "man office worker", "manager", "white-collar"]
+              "keywords": [
+                "architect",
+                "business",
+                "man",
+                "manager",
+                "office",
+                "white-collar",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F4BC",
               "name": "woman office worker",
-              "keywords": ["architect", "business", "manager", "white-collar", "woman", "woman office worker"]
+              "keywords": [
+                "architect",
+                "business",
+                "manager",
+                "office",
+                "white-collar",
+                "woman",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F52C",
               "name": "scientist",
-              "keywords": ["biologist", "chemist", "engineer", "physicist", "scientist"]
+              "keywords": [
+                "biologist",
+                "chemist",
+                "engineer",
+                "mathematician",
+                "physicist",
+                "scientist"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F52C",
               "name": "man scientist",
-              "keywords": ["biologist", "chemist", "engineer", "man", "physicist", "scientist"]
+              "keywords": [
+                "biologist",
+                "chemist",
+                "engineer",
+                "man",
+                "mathematician",
+                "physicist",
+                "scientist"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F52C",
               "name": "woman scientist",
-              "keywords": ["biologist", "chemist", "engineer", "physicist", "scientist", "woman"]
+              "keywords": [
+                "biologist",
+                "chemist",
+                "engineer",
+                "mathematician",
+                "physicist",
+                "scientist",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F4BB",
               "name": "technologist",
-              "keywords": ["coder", "developer", "inventor", "software", "technologist"]
+              "keywords": [
+                "coder",
+                "computer",
+                "developer",
+                "inventor",
+                "software",
+                "technologist"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F4BB",
               "name": "man technologist",
-              "keywords": ["coder", "developer", "inventor", "man", "software", "technologist"]
+              "keywords": [
+                "coder",
+                "computer",
+                "developer",
+                "inventor",
+                "man",
+                "software",
+                "technologist"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F4BB",
               "name": "woman technologist",
-              "keywords": ["coder", "developer", "inventor", "software", "technologist", "woman"]
+              "keywords": [
+                "coder",
+                "computer",
+                "developer",
+                "inventor",
+                "software",
+                "technologist",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F3A4",
               "name": "singer",
-              "keywords": ["actor", "entertainer", "rock", "singer", "star"]
+              "keywords": [
+                "actor",
+                "entertainer",
+                "rock",
+                "rockstar",
+                "singer",
+                "star"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F3A4",
               "name": "man singer",
-              "keywords": ["actor", "entertainer", "man", "rock", "singer", "star"]
+              "keywords": [
+                "actor",
+                "entertainer",
+                "man",
+                "rock",
+                "rockstar",
+                "singer",
+                "star"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F3A4",
               "name": "woman singer",
-              "keywords": ["actor", "entertainer", "rock", "singer", "star", "woman"]
+              "keywords": [
+                "actor",
+                "entertainer",
+                "rock",
+                "rockstar",
+                "singer",
+                "star",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F3A8",
@@ -1785,47 +4422,82 @@
             {
               "codepoint": "U+1F9D1 U+200D U+1F680",
               "name": "astronaut",
-              "keywords": ["astronaut", "rocket"]
+              "keywords": ["astronaut", "rocket", "space"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F680",
               "name": "man astronaut",
-              "keywords": ["astronaut", "man", "rocket"]
+              "keywords": ["astronaut", "man", "rocket", "space"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F680",
               "name": "woman astronaut",
-              "keywords": ["astronaut", "rocket", "woman"]
+              "keywords": ["astronaut", "rocket", "space", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F692",
               "name": "firefighter",
-              "keywords": ["firefighter", "firetruck"]
+              "keywords": ["fire", "firefighter", "firetruck"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F692",
               "name": "man firefighter",
-              "keywords": ["firefighter", "firetruck", "man"]
+              "keywords": ["fire", "firefighter", "firetruck", "man"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F692",
               "name": "woman firefighter",
-              "keywords": ["firefighter", "firetruck", "woman"]
+              "keywords": ["fire", "firefighter", "firetruck", "woman"]
             },
             {
               "codepoint": "U+1F46E",
               "name": "police officer",
-              "keywords": ["cop", "officer", "police"]
+              "keywords": [
+                "apprehend",
+                "arrest",
+                "citation",
+                "cop",
+                "law",
+                "officer",
+                "over",
+                "police",
+                "pulled",
+                "undercover"
+              ]
             },
             {
               "codepoint": "U+1F46E U+200D U+2642 U+FE0F",
               "name": "man police officer",
-              "keywords": ["cop", "man", "officer", "police"]
+              "keywords": [
+                "apprehend",
+                "arrest",
+                "citation",
+                "cop",
+                "law",
+                "man",
+                "officer",
+                "over",
+                "police",
+                "pulled",
+                "undercover"
+              ]
             },
             {
               "codepoint": "U+1F46E U+200D U+2640 U+FE0F",
               "name": "woman police officer",
-              "keywords": ["cop", "officer", "police", "woman"]
+              "keywords": [
+                "apprehend",
+                "arrest",
+                "citation",
+                "cop",
+                "law",
+                "officer",
+                "over",
+                "police",
+                "pulled",
+                "undercover",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F575",
@@ -1845,107 +4517,219 @@
             {
               "codepoint": "U+1F482",
               "name": "guard",
-              "keywords": ["guard"]
+              "keywords": ["buckingham", "guard", "helmet", "london", "palace"]
             },
             {
               "codepoint": "U+1F482 U+200D U+2642 U+FE0F",
               "name": "man guard",
-              "keywords": ["guard", "man"]
+              "keywords": [
+                "buckingham",
+                "guard",
+                "helmet",
+                "london",
+                "man",
+                "palace"
+              ]
             },
             {
               "codepoint": "U+1F482 U+200D U+2640 U+FE0F",
               "name": "woman guard",
-              "keywords": ["guard", "woman"]
+              "keywords": [
+                "buckingham",
+                "guard",
+                "helmet",
+                "london",
+                "palace",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F977",
               "name": "ninja",
-              "keywords": ["fighter", "hidden", "ninja", "stealth"]
+              "keywords": [
+                "assassin",
+                "fight",
+                "fighter",
+                "hidden",
+                "ninja",
+                "person",
+                "secret",
+                "skills",
+                "sly",
+                "soldier",
+                "stealth",
+                "war"
+              ]
             },
             {
               "codepoint": "U+1F477",
               "name": "construction worker",
-              "keywords": ["construction", "hat", "worker"]
+              "keywords": [
+                "build",
+                "construction",
+                "fix",
+                "hardhat",
+                "hat",
+                "man",
+                "person",
+                "rebuild",
+                "remodel",
+                "repair",
+                "work",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F477 U+200D U+2642 U+FE0F",
               "name": "man construction worker",
-              "keywords": ["construction", "man", "worker"]
+              "keywords": [
+                "build",
+                "construction",
+                "fix",
+                "hardhat",
+                "hat",
+                "man",
+                "rebuild",
+                "remodel",
+                "repair",
+                "work",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1F477 U+200D U+2640 U+FE0F",
               "name": "woman construction worker",
-              "keywords": ["construction", "woman", "worker"]
+              "keywords": [
+                "build",
+                "construction",
+                "fix",
+                "hardhat",
+                "hat",
+                "man",
+                "rebuild",
+                "remodel",
+                "repair",
+                "woman",
+                "work",
+                "worker"
+              ]
             },
             {
               "codepoint": "U+1FAC5",
               "name": "person with crown",
-              "keywords": ["monarch", "noble", "regal", "royalty"]
+              "keywords": [
+                "crown",
+                "monarch",
+                "noble",
+                "person",
+                "regal",
+                "royal",
+                "royalty"
+              ]
             },
             {
               "codepoint": "U+1F934",
               "name": "prince",
-              "keywords": ["prince"]
+              "keywords": [
+                "crown",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "king",
+                "prince",
+                "royal",
+                "royalty",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F478",
               "name": "princess",
-              "keywords": ["fairy tale", "fantasy", "princess"]
+              "keywords": [
+                "crown",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "princess",
+                "queen",
+                "royal",
+                "royalty",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F473",
               "name": "person wearing turban",
-              "keywords": ["person wearing turban", "turban"]
+              "keywords": ["person", "turban", "wearing"]
             },
             {
               "codepoint": "U+1F473 U+200D U+2642 U+FE0F",
               "name": "man wearing turban",
-              "keywords": ["man", "man wearing turban", "turban"]
+              "keywords": ["man", "turban", "wearing"]
             },
             {
               "codepoint": "U+1F473 U+200D U+2640 U+FE0F",
               "name": "woman wearing turban",
-              "keywords": ["turban", "woman", "woman wearing turban"]
+              "keywords": ["turban", "wearing", "woman"]
             },
             {
               "codepoint": "U+1F472",
               "name": "person with skullcap",
-              "keywords": ["cap", "gua pi mao", "hat", "person", "person with skullcap", "skullcap"]
+              "keywords": [
+                "cap",
+                "Chinese",
+                "gua",
+                "guapi",
+                "hat",
+                "mao",
+                "person",
+                "pi",
+                "skullcap"
+              ]
             },
             {
               "codepoint": "U+1F9D5",
               "name": "woman with headscarf",
-              "keywords": ["headscarf", "hijab", "mantilla", "tichel", "woman with headscarf", "bandana", "head kerchief"]
+              "keywords": [
+                "bandana",
+                "head",
+                "headscarf",
+                "hijab",
+                "kerchief",
+                "mantilla",
+                "tichel",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F935",
               "name": "person in tuxedo",
-              "keywords": ["groom", "person", "person in tuxedo", "tuxedo"]
+              "keywords": ["formal", "person", "tuxedo", "wedding"]
             },
             {
               "codepoint": "U+1F935 U+200D U+2642 U+FE0F",
               "name": "man in tuxedo",
-              "keywords": ["man", "man in tuxedo", "tuxedo"]
+              "keywords": ["formal", "groom", "man", "tuxedo", "wedding"]
             },
             {
               "codepoint": "U+1F935 U+200D U+2640 U+FE0F",
               "name": "woman in tuxedo",
-              "keywords": ["tuxedo", "woman", "woman in tuxedo"]
+              "keywords": ["formal", "tuxedo", "wedding", "woman"]
             },
             {
               "codepoint": "U+1F470",
               "name": "person with veil",
-              "keywords": ["bride", "person", "person with veil", "veil", "wedding"]
+              "keywords": ["person", "veil", "wedding"]
             },
             {
               "codepoint": "U+1F470 U+200D U+2642 U+FE0F",
               "name": "man with veil",
-              "keywords": ["man", "man with veil", "veil"]
+              "keywords": ["man", "veil", "wedding"]
             },
             {
               "codepoint": "U+1F470 U+200D U+2640 U+FE0F",
               "name": "woman with veil",
-              "keywords": ["veil", "woman", "woman with veil"]
+              "keywords": ["bride", "veil", "wedding", "woman"]
             },
             {
               "codepoint": "U+1F930",
@@ -1955,412 +4739,1349 @@
             {
               "codepoint": "U+1FAC3",
               "name": "pregnant man",
-              "keywords": ["belly", "bloated", "full", "pregnant"]
+              "keywords": [
+                "belly",
+                "bloated",
+                "full",
+                "man",
+                "overeat",
+                "pregnant"
+              ]
             },
             {
               "codepoint": "U+1FAC4",
               "name": "pregnant person",
-              "keywords": ["belly", "bloated", "full", "pregnant"]
+              "keywords": [
+                "belly",
+                "bloated",
+                "full",
+                "overeat",
+                "person",
+                "pregnant",
+                "stuffed"
+              ]
             },
             {
               "codepoint": "U+1F931",
               "name": "breast-feeding",
-              "keywords": ["baby", "breast", "breast-feeding", "nursing"]
+              "keywords": [
+                "baby",
+                "breast",
+                "breast-feeding",
+                "feeding",
+                "mom",
+                "mother",
+                "nursing",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F37C",
               "name": "woman feeding baby",
-              "keywords": ["baby", "feeding", "nursing", "woman"]
+              "keywords": [
+                "baby",
+                "feed",
+                "feeding",
+                "mom",
+                "mother",
+                "nanny",
+                "newborn",
+                "nursing",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F37C",
               "name": "man feeding baby",
-              "keywords": ["baby", "feeding", "man", "nursing"]
+              "keywords": [
+                "baby",
+                "dad",
+                "father",
+                "feed",
+                "feeding",
+                "man",
+                "nanny",
+                "newborn",
+                "nursing"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F37C",
               "name": "person feeding baby",
-              "keywords": ["baby", "feeding", "nursing", "person"]
+              "keywords": [
+                "baby",
+                "feed",
+                "feeding",
+                "nanny",
+                "newborn",
+                "nursing",
+                "parent"
+              ]
             }
           ]
         },
         {
-          "category": "person_fantasy",
+          "category": "person-fantasy",
           "contents": [
             {
               "codepoint": "U+1F47C",
               "name": "baby angel",
-              "keywords": ["angel", "baby", "face", "fairy tale", "fantasy"]
+              "keywords": [
+                "angel",
+                "baby",
+                "church",
+                "face",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F385",
               "name": "Santa Claus",
-              "keywords": ["celebration", "Christmas", "claus", "father", "santa", "Santa Claus"]
+              "keywords": [
+                "celebration",
+                "Christmas",
+                "claus",
+                "fairy",
+                "fantasy",
+                "father",
+                "holiday",
+                "merry",
+                "santa",
+                "tale",
+                "xmas"
+              ]
             },
             {
               "codepoint": "U+1F936",
               "name": "Mrs. Claus",
-              "keywords": ["celebration", "Christmas", "claus", "mother", "Mrs.", "Mrs. Claus"]
+              "keywords": [
+                "celebration",
+                "Christmas",
+                "claus",
+                "fairy",
+                "fantasy",
+                "holiday",
+                "merry",
+                "mother",
+                "Mrs",
+                "santa",
+                "tale",
+                "xmas"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F384",
-              "name": "mx claus",
-              "keywords": ["Claus, christmas", "mx claus"]
+              "name": "Mx Claus",
+              "keywords": [
+                "celebration",
+                "Christmas",
+                "claus",
+                "fairy",
+                "fantasy",
+                "holiday",
+                "merry",
+                "Mx",
+                "santa",
+                "tale",
+                "xmas"
+              ]
             },
             {
               "codepoint": "U+1F9B8",
               "name": "superhero",
-              "keywords": ["good", "hero", "heroine", "superhero", "superpower"]
+              "keywords": ["good", "hero", "superhero", "superpower"]
             },
             {
               "codepoint": "U+1F9B8 U+200D U+2642 U+FE0F",
               "name": "man superhero",
-              "keywords": ["good", "hero", "man", "man superhero", "superpower"]
+              "keywords": ["good", "hero", "man", "superhero", "superpower"]
             },
             {
               "codepoint": "U+1F9B8 U+200D U+2640 U+FE0F",
               "name": "woman superhero",
-              "keywords": ["good", "hero", "heroine", "superpower", "woman", "woman superhero"]
+              "keywords": [
+                "good",
+                "hero",
+                "heroine",
+                "superhero",
+                "superpower",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9B9",
               "name": "supervillain",
-              "keywords": ["criminal", "evil", "superpower", "supervillain", "villain"]
+              "keywords": [
+                "bad",
+                "criminal",
+                "evil",
+                "superpower",
+                "supervillain",
+                "villain"
+              ]
             },
             {
               "codepoint": "U+1F9B9 U+200D U+2642 U+FE0F",
               "name": "man supervillain",
-              "keywords": ["criminal", "evil", "man", "man supervillain", "superpower", "villain"]
+              "keywords": [
+                "bad",
+                "criminal",
+                "evil",
+                "man",
+                "superpower",
+                "supervillain",
+                "villain"
+              ]
             },
             {
               "codepoint": "U+1F9B9 U+200D U+2640 U+FE0F",
               "name": "woman supervillain",
-              "keywords": ["criminal", "evil", "superpower", "villain", "woman", "woman supervillain"]
+              "keywords": [
+                "bad",
+                "criminal",
+                "evil",
+                "superpower",
+                "supervillain",
+                "villain",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D9",
               "name": "mage",
-              "keywords": ["mage", "sorcerer", "sorceress", "witch", "wizard"]
+              "keywords": [
+                "fantasy",
+                "mage",
+                "magic",
+                "play",
+                "sorcerer",
+                "sorceress",
+                "sorcery",
+                "spell",
+                "summon",
+                "witch",
+                "wizard"
+              ]
             },
             {
               "codepoint": "U+1F9D9 U+200D U+2642 U+FE0F",
               "name": "man mage",
-              "keywords": ["man mage", "sorcerer", "wizard"]
+              "keywords": [
+                "fantasy",
+                "mage",
+                "magic",
+                "man",
+                "play",
+                "sorcerer",
+                "sorceress",
+                "sorcery",
+                "spell",
+                "summon",
+                "witch",
+                "wizard"
+              ]
             },
             {
               "codepoint": "U+1F9D9 U+200D U+2640 U+FE0F",
               "name": "woman mage",
-              "keywords": ["sorceress", "witch", "woman mage"]
+              "keywords": [
+                "fantasy",
+                "mage",
+                "magic",
+                "play",
+                "sorcerer",
+                "sorceress",
+                "sorcery",
+                "spell",
+                "summon",
+                "witch",
+                "wizard",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9DA",
               "name": "fairy",
-              "keywords": ["fairy", "Oberon", "Puck", "Titania"]
+              "keywords": [
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "myth",
+                "person",
+                "pixie",
+                "tale",
+                "wings"
+              ]
             },
             {
               "codepoint": "U+1F9DA U+200D U+2642 U+FE0F",
               "name": "man fairy",
-              "keywords": ["man fairy", "Oberon", "Puck"]
+              "keywords": [
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "man",
+                "myth",
+                "Oberon",
+                "person",
+                "pixie",
+                "Puck",
+                "tale",
+                "wings"
+              ]
             },
             {
               "codepoint": "U+1F9DA U+200D U+2640 U+FE0F",
               "name": "woman fairy",
-              "keywords": ["Titania", "woman fairy"]
+              "keywords": [
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "myth",
+                "person",
+                "pixie",
+                "tale",
+                "Titania",
+                "wings",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9DB",
               "name": "vampire",
-              "keywords": ["Dracula", "undead", "vampire"]
+              "keywords": [
+                "blood",
+                "Dracula",
+                "fangs",
+                "halloween",
+                "scary",
+                "supernatural",
+                "teeth",
+                "undead",
+                "vampire"
+              ]
             },
             {
               "codepoint": "U+1F9DB U+200D U+2642 U+FE0F",
               "name": "man vampire",
-              "keywords": ["Dracula", "man vampire", "undead"]
+              "keywords": [
+                "blood",
+                "fangs",
+                "halloween",
+                "man",
+                "scary",
+                "supernatural",
+                "teeth",
+                "undead",
+                "vampire"
+              ]
             },
             {
               "codepoint": "U+1F9DB U+200D U+2640 U+FE0F",
               "name": "woman vampire",
-              "keywords": ["undead", "woman vampire"]
+              "keywords": [
+                "blood",
+                "fangs",
+                "halloween",
+                "scary",
+                "supernatural",
+                "teeth",
+                "undead",
+                "vampire",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9DC",
               "name": "merperson",
-              "keywords": ["mermaid", "merman", "merperson", "merwoman"]
+              "keywords": [
+                "creature",
+                "fairytale",
+                "folklore",
+                "merperson",
+                "ocean",
+                "sea",
+                "siren",
+                "trident"
+              ]
             },
             {
               "codepoint": "U+1F9DC U+200D U+2642 U+FE0F",
               "name": "merman",
-              "keywords": ["merman", "Triton"]
+              "keywords": [
+                "creature",
+                "fairytale",
+                "folklore",
+                "merman",
+                "Neptune",
+                "ocean",
+                "Poseidon",
+                "sea",
+                "siren",
+                "trident",
+                "Triton"
+              ]
             },
             {
               "codepoint": "U+1F9DC U+200D U+2640 U+FE0F",
               "name": "mermaid",
-              "keywords": ["mermaid", "merwoman"]
+              "keywords": [
+                "creature",
+                "fairytale",
+                "folklore",
+                "mermaid",
+                "merwoman",
+                "ocean",
+                "sea",
+                "siren",
+                "trident"
+              ]
             },
             {
               "codepoint": "U+1F9DD",
               "name": "elf",
-              "keywords": ["elf", "magical", "LOTR style"]
+              "keywords": [
+                "elf",
+                "elves",
+                "enchantment",
+                "fantasy",
+                "folklore",
+                "magic",
+                "magical",
+                "myth"
+              ]
             },
             {
               "codepoint": "U+1F9DD U+200D U+2642 U+FE0F",
               "name": "man elf",
-              "keywords": ["magical", "man elf"]
+              "keywords": [
+                "elf",
+                "elves",
+                "enchantment",
+                "fantasy",
+                "folklore",
+                "magic",
+                "magical",
+                "man",
+                "myth"
+              ]
             },
             {
               "codepoint": "U+1F9DD U+200D U+2640 U+FE0F",
               "name": "woman elf",
-              "keywords": ["magical", "woman elf"]
+              "keywords": [
+                "elf",
+                "elves",
+                "enchantment",
+                "fantasy",
+                "folklore",
+                "magic",
+                "magical",
+                "myth",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9DE",
               "name": "genie",
-              "keywords": ["djinn", "genie", "(non-human color)"]
+              "keywords": [
+                "djinn",
+                "fantasy",
+                "genie",
+                "jinn",
+                "lamp",
+                "myth",
+                "rub",
+                "wishes"
+              ]
             },
             {
               "codepoint": "U+1F9DE U+200D U+2642 U+FE0F",
               "name": "man genie",
-              "keywords": ["djinn", "man genie"]
+              "keywords": [
+                "djinn",
+                "fantasy",
+                "genie",
+                "jinn",
+                "lamp",
+                "man",
+                "myth",
+                "rub",
+                "wishes"
+              ]
             },
             {
               "codepoint": "U+1F9DE U+200D U+2640 U+FE0F",
               "name": "woman genie",
-              "keywords": ["djinn", "woman genie"]
+              "keywords": [
+                "djinn",
+                "fantasy",
+                "genie",
+                "jinn",
+                "lamp",
+                "myth",
+                "rub",
+                "wishes",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9DF",
               "name": "zombie",
-              "keywords": ["undead", "walking dead", "zombie", "(non-human color)"]
+              "keywords": [
+                "apocalypse",
+                "dead",
+                "halloween",
+                "horror",
+                "scary",
+                "undead",
+                "walking",
+                "zombie"
+              ]
             },
             {
               "codepoint": "U+1F9DF U+200D U+2642 U+FE0F",
               "name": "man zombie",
-              "keywords": ["man zombie", "undead", "walking dead"]
+              "keywords": [
+                "apocalypse",
+                "dead",
+                "halloween",
+                "horror",
+                "man",
+                "scary",
+                "undead",
+                "walking",
+                "zombie"
+              ]
             },
             {
               "codepoint": "U+1F9DF U+200D U+2640 U+FE0F",
               "name": "woman zombie",
-              "keywords": ["undead", "walking dead", "woman zombie"]
+              "keywords": [
+                "apocalypse",
+                "dead",
+                "halloween",
+                "horror",
+                "scary",
+                "undead",
+                "walking",
+                "woman",
+                "zombie"
+              ]
             },
             {
               "codepoint": "U+1F9CC",
               "name": "troll",
-              "keywords": ["fairy tale", "fantasy", "monster"]
+              "keywords": [
+                "fairy",
+                "fantasy",
+                "monster",
+                "tale",
+                "troll",
+                "trolling"
+              ]
             }
           ]
         },
         {
-          "category": "person_activity",
+          "category": "person-activity",
           "contents": [
             {
               "codepoint": "U+1F486",
               "name": "person getting massage",
-              "keywords": ["face", "massage", "person getting massage", "salon"]
+              "keywords": [
+                "face",
+                "getting",
+                "headache",
+                "massage",
+                "person",
+                "relax",
+                "relaxing",
+                "salon",
+                "soothe",
+                "spa",
+                "tension",
+                "therapy",
+                "treatment"
+              ]
             },
             {
               "codepoint": "U+1F486 U+200D U+2642 U+FE0F",
               "name": "man getting massage",
-              "keywords": ["face", "man", "man getting massage", "massage"]
+              "keywords": [
+                "face",
+                "getting",
+                "headache",
+                "man",
+                "massage",
+                "relax",
+                "relaxing",
+                "salon",
+                "soothe",
+                "spa",
+                "tension",
+                "therapy",
+                "treatment"
+              ]
             },
             {
               "codepoint": "U+1F486 U+200D U+2640 U+FE0F",
               "name": "woman getting massage",
-              "keywords": ["face", "massage", "woman", "woman getting massage"]
+              "keywords": [
+                "face",
+                "getting",
+                "headache",
+                "massage",
+                "relax",
+                "relaxing",
+                "salon",
+                "soothe",
+                "spa",
+                "tension",
+                "therapy",
+                "treatment",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F487",
               "name": "person getting haircut",
-              "keywords": ["barber", "beauty", "haircut", "parlor", "person getting haircut"]
+              "keywords": [
+                "barber",
+                "beauty",
+                "chop",
+                "cosmetology",
+                "cut",
+                "groom",
+                "hair",
+                "haircut",
+                "parlor",
+                "person",
+                "shears",
+                "style"
+              ]
             },
             {
               "codepoint": "U+1F487 U+200D U+2642 U+FE0F",
               "name": "man getting haircut",
-              "keywords": ["haircut", "man", "man getting haircut"]
+              "keywords": [
+                "barber",
+                "beauty",
+                "chop",
+                "cosmetology",
+                "cut",
+                "groom",
+                "hair",
+                "haircut",
+                "man",
+                "parlor",
+                "person",
+                "shears",
+                "style"
+              ]
             },
             {
               "codepoint": "U+1F487 U+200D U+2640 U+FE0F",
               "name": "woman getting haircut",
-              "keywords": ["haircut", "woman", "woman getting haircut"]
+              "keywords": [
+                "barber",
+                "beauty",
+                "chop",
+                "cosmetology",
+                "cut",
+                "groom",
+                "hair",
+                "haircut",
+                "parlor",
+                "person",
+                "shears",
+                "style",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F6B6",
               "name": "person walking",
-              "keywords": ["hike", "person walking", "walk", "walking"]
+              "keywords": [
+                "amble",
+                "gait",
+                "hike",
+                "man",
+                "pace",
+                "pedestrian",
+                "person",
+                "stride",
+                "stroll",
+                "walk",
+                "walking"
+              ]
             },
             {
               "codepoint": "U+1F6B6 U+200D U+2642 U+FE0F",
               "name": "man walking",
-              "keywords": ["hike", "man", "man walking", "walk"]
+              "keywords": [
+                "amble",
+                "gait",
+                "hike",
+                "man",
+                "pace",
+                "pedestrian",
+                "stride",
+                "stroll",
+                "walk",
+                "walking"
+              ]
             },
             {
               "codepoint": "U+1F6B6 U+200D U+2640 U+FE0F",
               "name": "woman walking",
-              "keywords": ["hike", "walk", "woman", "woman walking"]
+              "keywords": [
+                "amble",
+                "gait",
+                "hike",
+                "man",
+                "pace",
+                "pedestrian",
+                "stride",
+                "stroll",
+                "walk",
+                "walking",
+                "woman"
+              ]
+            },
+            {
+              "codepoint": "U+1F6B6 U+200D U+27A1 U+FE0F",
+              "name": "person walking: facing right",
+              "keywords": [
+                "amble",
+                "facing",
+                "gait",
+                "hike",
+                "man",
+                "pace",
+                "pedestrian",
+                "person",
+                "right",
+                "stride",
+                "stroll",
+                "walk",
+                "walking"
+              ]
+            },
+            {
+              "codepoint": "U+1F6B6 U+200D U+2640 U+FE0F U+200D U+27A1 U+FE0F",
+              "name": "woman walking: facing right",
+              "keywords": [
+                "amble",
+                "facing",
+                "gait",
+                "hike",
+                "man",
+                "pace",
+                "pedestrian",
+                "right",
+                "stride",
+                "stroll",
+                "walk",
+                "walking",
+                "woman"
+              ]
+            },
+            {
+              "codepoint": "U+1F6B6 U+200D U+2642 U+FE0F U+200D U+27A1 U+FE0F",
+              "name": "man walking: facing right",
+              "keywords": [
+                "amble",
+                "facing",
+                "gait",
+                "hike",
+                "man",
+                "pace",
+                "pedestrian",
+                "right",
+                "stride",
+                "stroll",
+                "walk",
+                "walking"
+              ]
             },
             {
               "codepoint": "U+1F9CD",
               "name": "person standing",
-              "keywords": ["person standing", "stand", "standing"]
+              "keywords": ["person", "stand", "standing"]
             },
             {
               "codepoint": "U+1F9CD U+200D U+2642 U+FE0F",
               "name": "man standing",
-              "keywords": ["man", "standing"]
+              "keywords": ["man", "stand", "standing"]
             },
             {
               "codepoint": "U+1F9CD U+200D U+2640 U+FE0F",
               "name": "woman standing",
-              "keywords": ["standing", "woman"]
+              "keywords": ["stand", "standing", "woman"]
             },
             {
               "codepoint": "U+1F9CE",
               "name": "person kneeling",
-              "keywords": ["kneel", "kneeling", "person kneeling"]
+              "keywords": ["kneel", "kneeling", "knees", "person"]
             },
             {
               "codepoint": "U+1F9CE U+200D U+2642 U+FE0F",
               "name": "man kneeling",
-              "keywords": ["kneeling", "man"]
+              "keywords": ["kneel", "kneeling", "knees", "man"]
             },
             {
               "codepoint": "U+1F9CE U+200D U+2640 U+FE0F",
               "name": "woman kneeling",
-              "keywords": ["kneeling", "woman"]
+              "keywords": ["kneel", "kneeling", "knees", "woman"]
+            },
+            {
+              "codepoint": "U+1F9CE U+200D U+27A1 U+FE0F",
+              "name": "person kneeling: facing right",
+              "keywords": [
+                "facing",
+                "kneel",
+                "kneeling",
+                "knees",
+                "person",
+                "right"
+              ]
+            },
+            {
+              "codepoint": "U+1F9CE U+200D U+2640 U+FE0F U+200D U+27A1 U+FE0F",
+              "name": "woman kneeling: facing right",
+              "keywords": [
+                "facing",
+                "kneel",
+                "kneeling",
+                "knees",
+                "right",
+                "woman"
+              ]
+            },
+            {
+              "codepoint": "U+1F9CE U+200D U+2642 U+FE0F U+200D U+27A1 U+FE0F",
+              "name": "man kneeling: facing right",
+              "keywords": [
+                "facing",
+                "kneel",
+                "kneeling",
+                "knees",
+                "man",
+                "right"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9AF",
               "name": "person with white cane",
-              "keywords": ["accessibility", "blind", "person with white cane"]
+              "keywords": [
+                "accessibility",
+                "blind",
+                "cane",
+                "person",
+                "probing",
+                "white"
+              ]
+            },
+            {
+              "codepoint": "U+1F9D1 U+200D U+1F9AF U+200D U+27A1 U+FE0F",
+              "name": "person with white cane: facing right",
+              "keywords": [
+                "accessibility",
+                "blind",
+                "cane",
+                "facing",
+                "person",
+                "probing",
+                "right",
+                "white"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9AF",
               "name": "man with white cane",
-              "keywords": ["accessibility", "blind", "man", "man with white cane"]
+              "keywords": [
+                "accessibility",
+                "blind",
+                "cane",
+                "man",
+                "probing",
+                "white"
+              ]
+            },
+            {
+              "codepoint": "U+1F468 U+200D U+1F9AF U+200D U+27A1 U+FE0F",
+              "name": "man with white cane: facing right",
+              "keywords": [
+                "accessibility",
+                "blind",
+                "cane",
+                "facing",
+                "man",
+                "probing",
+                "right",
+                "white"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9AF",
               "name": "woman with white cane",
-              "keywords": ["accessibility", "blind", "woman", "woman with white cane"]
+              "keywords": [
+                "accessibility",
+                "blind",
+                "cane",
+                "probing",
+                "white",
+                "woman"
+              ]
+            },
+            {
+              "codepoint": "U+1F469 U+200D U+1F9AF U+200D U+27A1 U+FE0F",
+              "name": "woman with white cane: facing right",
+              "keywords": [
+                "accessibility",
+                "blind",
+                "cane",
+                "facing",
+                "probing",
+                "right",
+                "white",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9BC",
               "name": "person in motorized wheelchair",
-              "keywords": ["accessibility", "person in motorized wheelchair", "wheelchair"]
+              "keywords": ["accessibility", "motorized", "person", "wheelchair"]
+            },
+            {
+              "codepoint": "U+1F9D1 U+200D U+1F9BC U+200D U+27A1 U+FE0F",
+              "name": "person in motorized wheelchair: facing right",
+              "keywords": [
+                "accessibility",
+                "facing",
+                "motorized",
+                "person",
+                "right",
+                "wheelchair"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9BC",
               "name": "man in motorized wheelchair",
-              "keywords": ["accessibility", "man", "man in motorized wheelchair", "wheelchair"]
+              "keywords": ["accessibility", "man", "motorized", "wheelchair"]
+            },
+            {
+              "codepoint": "U+1F468 U+200D U+1F9BC U+200D U+27A1 U+FE0F",
+              "name": "man in motorized wheelchair: facing right",
+              "keywords": [
+                "accessibility",
+                "facing",
+                "man",
+                "motorized",
+                "right",
+                "wheelchair"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9BC",
               "name": "woman in motorized wheelchair",
-              "keywords": ["accessibility", "wheelchair", "woman", "woman in motorized wheelchair"]
+              "keywords": ["accessibility", "motorized", "wheelchair", "woman"]
+            },
+            {
+              "codepoint": "U+1F469 U+200D U+1F9BC U+200D U+27A1 U+FE0F",
+              "name": "woman in motorized wheelchair: facing right",
+              "keywords": [
+                "accessibility",
+                "facing",
+                "motorized",
+                "right",
+                "wheelchair",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9BD",
               "name": "person in manual wheelchair",
-              "keywords": ["accessibility", "person in manual wheelchair", "wheelchair"]
+              "keywords": ["accessibility", "manual", "person", "wheelchair"]
+            },
+            {
+              "codepoint": "U+1F9D1 U+200D U+1F9BD U+200D U+27A1 U+FE0F",
+              "name": "person in manual wheelchair: facing right",
+              "keywords": [
+                "accessibility",
+                "facing",
+                "manual",
+                "person",
+                "right",
+                "wheelchair"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9BD",
               "name": "man in manual wheelchair",
-              "keywords": ["accessibility", "man", "man in manual wheelchair", "wheelchair"]
+              "keywords": ["accessibility", "man", "manual", "wheelchair"]
+            },
+            {
+              "codepoint": "U+1F468 U+200D U+1F9BD U+200D U+27A1 U+FE0F",
+              "name": "man in manual wheelchair: facing right",
+              "keywords": [
+                "accessibility",
+                "facing",
+                "man",
+                "manual",
+                "right",
+                "wheelchair"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9BD",
               "name": "woman in manual wheelchair",
-              "keywords": ["accessibility", "wheelchair", "woman", "woman in manual wheelchair"]
+              "keywords": ["accessibility", "manual", "wheelchair", "woman"]
+            },
+            {
+              "codepoint": "U+1F469 U+200D U+1F9BD U+200D U+27A1 U+FE0F",
+              "name": "woman in manual wheelchair: facing right",
+              "keywords": [
+                "accessibility",
+                "facing",
+                "manual",
+                "right",
+                "wheelchair",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F3C3",
               "name": "person running",
-              "keywords": ["marathon", "person running", "running"]
+              "keywords": [
+                "fast",
+                "hurry",
+                "marathon",
+                "move",
+                "person",
+                "quick",
+                "race",
+                "racing",
+                "run",
+                "rush",
+                "speed"
+              ]
             },
             {
               "codepoint": "U+1F3C3 U+200D U+2642 U+FE0F",
               "name": "man running",
-              "keywords": ["man", "marathon", "racing", "running"]
+              "keywords": [
+                "fast",
+                "hurry",
+                "man",
+                "marathon",
+                "move",
+                "quick",
+                "race",
+                "racing",
+                "run",
+                "rush",
+                "speed"
+              ]
             },
             {
               "codepoint": "U+1F3C3 U+200D U+2640 U+FE0F",
               "name": "woman running",
-              "keywords": ["marathon", "racing", "running", "woman"]
+              "keywords": [
+                "fast",
+                "hurry",
+                "marathon",
+                "move",
+                "quick",
+                "race",
+                "racing",
+                "run",
+                "rush",
+                "speed",
+                "woman"
+              ]
+            },
+            {
+              "codepoint": "U+1F3C3 U+200D U+27A1 U+FE0F",
+              "name": "person running: facing right",
+              "keywords": [
+                "facing",
+                "fast",
+                "hurry",
+                "marathon",
+                "move",
+                "person",
+                "quick",
+                "race",
+                "racing",
+                "right",
+                "run",
+                "rush",
+                "speed"
+              ]
+            },
+            {
+              "codepoint": "U+1F3C3 U+200D U+2640 U+FE0F U+200D U+27A1 U+FE0F",
+              "name": "woman running: facing right",
+              "keywords": [
+                "facing",
+                "fast",
+                "hurry",
+                "marathon",
+                "move",
+                "quick",
+                "race",
+                "racing",
+                "right",
+                "run",
+                "rush",
+                "speed",
+                "woman"
+              ]
+            },
+            {
+              "codepoint": "U+1F3C3 U+200D U+2642 U+FE0F U+200D U+27A1 U+FE0F",
+              "name": "man running: facing right",
+              "keywords": [
+                "facing",
+                "fast",
+                "hurry",
+                "man",
+                "marathon",
+                "move",
+                "quick",
+                "race",
+                "racing",
+                "right",
+                "run",
+                "rush",
+                "speed"
+              ]
             },
             {
               "codepoint": "U+1F483",
               "name": "woman dancing",
-              "keywords": ["dance", "dancing", "woman"]
+              "keywords": [
+                "dance",
+                "dancer",
+                "dancing",
+                "elegant",
+                "festive",
+                "flair",
+                "flamenco",
+                "groove",
+                "let’s",
+                "salsa",
+                "tango",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F57A",
               "name": "man dancing",
-              "keywords": ["dance", "dancing", "man"]
+              "keywords": [
+                "dance",
+                "dancer",
+                "dancing",
+                "elegant",
+                "festive",
+                "flair",
+                "flamenco",
+                "groove",
+                "let’s",
+                "man",
+                "salsa",
+                "tango"
+              ]
             },
             {
               "codepoint": "U+1F574",
               "name": "person in suit levitating",
-              "keywords": ["business", "person", "person in suit levitating", "suit"]
+              "keywords": ["business", "levitating", "person", "suit"]
             },
             {
               "codepoint": "U+1F46F",
               "name": "people with bunny ears",
-              "keywords": ["bunny ear", "dancer", "partying", "people with bunny ears"]
+              "keywords": [
+                "bestie",
+                "bff",
+                "bunny",
+                "counterpart",
+                "dancer",
+                "double",
+                "ear",
+                "identical",
+                "pair",
+                "party",
+                "partying",
+                "people",
+                "soulmate",
+                "twin",
+                "twinsies"
+              ]
             },
             {
               "codepoint": "U+1F46F U+200D U+2642 U+FE0F",
               "name": "men with bunny ears",
-              "keywords": ["bunny ear", "dancer", "men", "men with bunny ears", "partying"]
+              "keywords": [
+                "bestie",
+                "bff",
+                "bunny",
+                "counterpart",
+                "dancer",
+                "double",
+                "ear",
+                "identical",
+                "men",
+                "pair",
+                "party",
+                "partying",
+                "people",
+                "soulmate",
+                "twin",
+                "twinsies"
+              ]
             },
             {
               "codepoint": "U+1F46F U+200D U+2640 U+FE0F",
               "name": "women with bunny ears",
-              "keywords": ["bunny ear", "dancer", "partying", "women", "women with bunny ears"]
+              "keywords": [
+                "bestie",
+                "bff",
+                "bunny",
+                "counterpart",
+                "dancer",
+                "double",
+                "ear",
+                "identical",
+                "pair",
+                "party",
+                "partying",
+                "people",
+                "soulmate",
+                "twin",
+                "twinsies",
+                "women"
+              ]
             },
             {
               "codepoint": "U+1F9D6",
               "name": "person in steamy room",
-              "keywords": ["person in steamy room", "sauna", "steam room", "hamam", "steambath"]
+              "keywords": [
+                "day",
+                "luxurious",
+                "pamper",
+                "person",
+                "relax",
+                "room",
+                "sauna",
+                "spa",
+                "steam",
+                "steambath",
+                "unwind"
+              ]
             },
             {
               "codepoint": "U+1F9D6 U+200D U+2642 U+FE0F",
               "name": "man in steamy room",
-              "keywords": ["man in steamy room", "sauna", "steam room"]
+              "keywords": [
+                "day",
+                "luxurious",
+                "man",
+                "pamper",
+                "relax",
+                "room",
+                "sauna",
+                "spa",
+                "steam",
+                "steambath",
+                "unwind"
+              ]
             },
             {
               "codepoint": "U+1F9D6 U+200D U+2640 U+FE0F",
               "name": "woman in steamy room",
-              "keywords": ["sauna", "steam room", "woman in steamy room"]
+              "keywords": [
+                "day",
+                "luxurious",
+                "pamper",
+                "relax",
+                "room",
+                "sauna",
+                "spa",
+                "steam",
+                "steambath",
+                "unwind",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F9D7",
               "name": "person climbing",
-              "keywords": ["climber", "person climbing"]
+              "keywords": [
+                "climb",
+                "climber",
+                "climbing",
+                "mountain",
+                "person",
+                "rock",
+                "scale",
+                "up"
+              ]
             },
             {
               "codepoint": "U+1F9D7 U+200D U+2642 U+FE0F",
               "name": "man climbing",
-              "keywords": ["climber", "man climbing"]
+              "keywords": [
+                "climb",
+                "climber",
+                "climbing",
+                "man",
+                "mountain",
+                "rock",
+                "scale",
+                "up"
+              ]
             },
             {
               "codepoint": "U+1F9D7 U+200D U+2640 U+FE0F",
               "name": "woman climbing",
-              "keywords": ["climber", "woman climbing"]
+              "keywords": [
+                "climb",
+                "climber",
+                "climbing",
+                "mountain",
+                "rock",
+                "scale",
+                "up",
+                "woman"
+              ]
             }
           ]
         },
         {
-          "category": "person_sport",
+          "category": "person-sport",
           "contents": [
             {
               "codepoint": "U+1F93A",
               "name": "person fencing",
-              "keywords": ["fencer", "fencing", "person fencing", "sword"]
+              "keywords": ["fencer", "fencing", "person", "sword"]
             },
             {
               "codepoint": "U+1F3C7",
               "name": "horse racing",
-              "keywords": ["horse", "jockey", "racehorse", "racing"]
+              "keywords": [
+                "horse",
+                "jockey",
+                "racehorse",
+                "racing",
+                "riding",
+                "sport"
+              ]
             },
             {
               "codepoint": "U+26F7",
@@ -2370,232 +6091,709 @@
             {
               "codepoint": "U+1F3C2",
               "name": "snowboarder",
-              "keywords": ["ski", "snow", "snowboard", "snowboarder"]
+              "keywords": ["ski", "snow", "snowboard", "snowboarder", "sport"]
             },
             {
               "codepoint": "U+1F3CC",
               "name": "person golfing",
-              "keywords": ["ball", "golf", "person golfing"]
+              "keywords": [
+                "ball",
+                "birdie",
+                "caddy",
+                "driving",
+                "golf",
+                "golfing",
+                "green",
+                "person",
+                "pga",
+                "putt",
+                "range",
+                "tee"
+              ]
             },
             {
               "codepoint": "U+1F3CC U+FE0F U+200D U+2642 U+FE0F",
               "name": "man golfing",
-              "keywords": ["golf", "man", "man golfing"]
+              "keywords": [
+                "ball",
+                "birdie",
+                "caddy",
+                "driving",
+                "golf",
+                "golfing",
+                "green",
+                "man",
+                "pga",
+                "putt",
+                "range",
+                "tee"
+              ]
             },
             {
               "codepoint": "U+1F3CC U+FE0F U+200D U+2640 U+FE0F",
               "name": "woman golfing",
-              "keywords": ["golf", "woman", "woman golfing"]
+              "keywords": [
+                "ball",
+                "birdie",
+                "caddy",
+                "driving",
+                "golf",
+                "golfing",
+                "green",
+                "pga",
+                "putt",
+                "range",
+                "tee",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F3C4",
               "name": "person surfing",
-              "keywords": ["person surfing", "surfing"]
+              "keywords": [
+                "beach",
+                "ocean",
+                "person",
+                "sport",
+                "surf",
+                "surfer",
+                "surfing",
+                "swell",
+                "waves"
+              ]
             },
             {
               "codepoint": "U+1F3C4 U+200D U+2642 U+FE0F",
               "name": "man surfing",
-              "keywords": ["man", "surfing"]
+              "keywords": [
+                "beach",
+                "man",
+                "ocean",
+                "sport",
+                "surf",
+                "surfer",
+                "surfing",
+                "swell",
+                "waves"
+              ]
             },
             {
               "codepoint": "U+1F3C4 U+200D U+2640 U+FE0F",
               "name": "woman surfing",
-              "keywords": ["surfing", "woman"]
+              "keywords": [
+                "beach",
+                "ocean",
+                "person",
+                "sport",
+                "surf",
+                "surfer",
+                "surfing",
+                "swell",
+                "waves"
+              ]
             },
             {
               "codepoint": "U+1F6A3",
               "name": "person rowing boat",
-              "keywords": ["boat", "person rowing boat", "rowboat"]
+              "keywords": [
+                "boat",
+                "canoe",
+                "cruise",
+                "fishing",
+                "lake",
+                "oar",
+                "paddle",
+                "person",
+                "raft",
+                "river",
+                "row",
+                "rowboat",
+                "rowing"
+              ]
             },
             {
               "codepoint": "U+1F6A3 U+200D U+2642 U+FE0F",
               "name": "man rowing boat",
-              "keywords": ["boat", "man", "man rowing boat", "rowboat"]
+              "keywords": [
+                "boat",
+                "canoe",
+                "cruise",
+                "fishing",
+                "lake",
+                "man",
+                "oar",
+                "paddle",
+                "raft",
+                "river",
+                "row",
+                "rowboat",
+                "rowing"
+              ]
             },
             {
               "codepoint": "U+1F6A3 U+200D U+2640 U+FE0F",
               "name": "woman rowing boat",
-              "keywords": ["boat", "rowboat", "woman", "woman rowing boat"]
+              "keywords": [
+                "boat",
+                "canoe",
+                "cruise",
+                "fishing",
+                "lake",
+                "oar",
+                "paddle",
+                "raft",
+                "river",
+                "row",
+                "rowboat",
+                "rowing",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F3CA",
               "name": "person swimming",
-              "keywords": ["person swimming", "swim"]
+              "keywords": [
+                "freestyle",
+                "person",
+                "sport",
+                "swim",
+                "swimmer",
+                "swimming",
+                "triathlon"
+              ]
             },
             {
               "codepoint": "U+1F3CA U+200D U+2642 U+FE0F",
               "name": "man swimming",
-              "keywords": ["man", "man swimming", "swim"]
+              "keywords": [
+                "freestyle",
+                "man",
+                "sport",
+                "swim",
+                "swimmer",
+                "swimming",
+                "triathlon"
+              ]
             },
             {
               "codepoint": "U+1F3CA U+200D U+2640 U+FE0F",
               "name": "woman swimming",
-              "keywords": ["swim", "woman", "woman swimming"]
+              "keywords": [
+                "freestyle",
+                "man",
+                "sport",
+                "swim",
+                "swimmer",
+                "swimming",
+                "triathlon"
+              ]
             },
             {
               "codepoint": "U+26F9",
               "name": "person bouncing ball",
-              "keywords": ["ball", "person bouncing ball"]
+              "keywords": [
+                "athletic",
+                "ball",
+                "basketball",
+                "bouncing",
+                "championship",
+                "dribble",
+                "net",
+                "person",
+                "player",
+                "throw"
+              ]
             },
             {
               "codepoint": "U+26F9 U+FE0F U+200D U+2642 U+FE0F",
               "name": "man bouncing ball",
-              "keywords": ["ball", "man", "man bouncing ball"]
+              "keywords": [
+                "athletic",
+                "ball",
+                "basketball",
+                "bouncing",
+                "championship",
+                "dribble",
+                "man",
+                "net",
+                "player",
+                "throw"
+              ]
             },
             {
               "codepoint": "U+26F9 U+FE0F U+200D U+2640 U+FE0F",
               "name": "woman bouncing ball",
-              "keywords": ["ball", "woman", "woman bouncing ball"]
+              "keywords": [
+                "athletic",
+                "ball",
+                "basketball",
+                "bouncing",
+                "championship",
+                "dribble",
+                "net",
+                "player",
+                "throw",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F3CB",
               "name": "person lifting weights",
-              "keywords": ["lifter", "person lifting weights", "weight"]
+              "keywords": [
+                "barbell",
+                "bodybuilder",
+                "deadlift",
+                "lifter",
+                "lifting",
+                "person",
+                "powerlifting",
+                "weight",
+                "weightlifter",
+                "weights",
+                "workout"
+              ]
             },
             {
               "codepoint": "U+1F3CB U+FE0F U+200D U+2642 U+FE0F",
               "name": "man lifting weights",
-              "keywords": ["man", "man lifting weights", "weight lifter"]
+              "keywords": [
+                "barbell",
+                "bodybuilder",
+                "deadlift",
+                "lifter",
+                "lifting",
+                "man",
+                "powerlifting",
+                "weight",
+                "weightlifter",
+                "weights",
+                "workout"
+              ]
             },
             {
               "codepoint": "U+1F3CB U+FE0F U+200D U+2640 U+FE0F",
               "name": "woman lifting weights",
-              "keywords": ["weight lifter", "woman", "woman lifting weights"]
+              "keywords": [
+                "barbell",
+                "bodybuilder",
+                "deadlift",
+                "lifter",
+                "lifting",
+                "powerlifting",
+                "weight",
+                "weightlifter",
+                "weights",
+                "woman",
+                "workout"
+              ]
             },
             {
               "codepoint": "U+1F6B4",
               "name": "person biking",
-              "keywords": ["bicycle", "biking", "cyclist", "person biking"]
+              "keywords": [
+                "bicycle",
+                "bicyclist",
+                "bike",
+                "biking",
+                "cycle",
+                "cyclist",
+                "person",
+                "riding",
+                "sport"
+              ]
             },
             {
               "codepoint": "U+1F6B4 U+200D U+2642 U+FE0F",
               "name": "man biking",
-              "keywords": ["bicycle", "biking", "cyclist", "man"]
+              "keywords": [
+                "bicycle",
+                "bicyclist",
+                "bike",
+                "biking",
+                "cycle",
+                "cyclist",
+                "man",
+                "riding",
+                "sport"
+              ]
             },
             {
               "codepoint": "U+1F6B4 U+200D U+2640 U+FE0F",
               "name": "woman biking",
-              "keywords": ["bicycle", "biking", "cyclist", "woman"]
+              "keywords": [
+                "bicycle",
+                "bicyclist",
+                "bike",
+                "biking",
+                "cycle",
+                "cyclist",
+                "riding",
+                "sport",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F6B5",
               "name": "person mountain biking",
-              "keywords": ["bicycle", "bicyclist", "bike", "cyclist", "mountain", "person mountain biking"]
+              "keywords": [
+                "bicycle",
+                "bicyclist",
+                "bike",
+                "biking",
+                "cycle",
+                "cyclist",
+                "mountain",
+                "person",
+                "riding",
+                "sport"
+              ]
             },
             {
               "codepoint": "U+1F6B5 U+200D U+2642 U+FE0F",
               "name": "man mountain biking",
-              "keywords": ["bicycle", "bike", "cyclist", "man", "man mountain biking", "mountain"]
+              "keywords": [
+                "bicycle",
+                "bicyclist",
+                "bike",
+                "biking",
+                "cycle",
+                "cyclist",
+                "man",
+                "mountain",
+                "riding",
+                "sport"
+              ]
             },
             {
               "codepoint": "U+1F6B5 U+200D U+2640 U+FE0F",
               "name": "woman mountain biking",
-              "keywords": ["bicycle", "bike", "biking", "cyclist", "mountain", "woman"]
+              "keywords": [
+                "bicycle",
+                "bicyclist",
+                "bike",
+                "biking",
+                "cycle",
+                "cyclist",
+                "mountain",
+                "riding",
+                "sport",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F938",
               "name": "person cartwheeling",
-              "keywords": ["cartwheel", "gymnastics", "person cartwheeling"]
+              "keywords": [
+                "active",
+                "cartwheel",
+                "cartwheeling",
+                "excited",
+                "flip",
+                "gymnastics",
+                "happy",
+                "person",
+                "somersault"
+              ]
             },
             {
               "codepoint": "U+1F938 U+200D U+2642 U+FE0F",
               "name": "man cartwheeling",
-              "keywords": ["cartwheel", "gymnastics", "man", "man cartwheeling"]
+              "keywords": [
+                "active",
+                "cartwheel",
+                "cartwheeling",
+                "excited",
+                "flip",
+                "gymnastics",
+                "happy",
+                "man",
+                "somersault"
+              ]
             },
             {
               "codepoint": "U+1F938 U+200D U+2640 U+FE0F",
               "name": "woman cartwheeling",
-              "keywords": ["cartwheel", "gymnastics", "woman", "woman cartwheeling"]
+              "keywords": [
+                "active",
+                "cartwheel",
+                "cartwheeling",
+                "excited",
+                "flip",
+                "gymnastics",
+                "happy",
+                "somersault",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F93C",
               "name": "people wrestling",
-              "keywords": ["people wrestling", "wrestle", "wrestler"]
+              "keywords": [
+                "combat",
+                "duel",
+                "grapple",
+                "people",
+                "ring",
+                "tournament",
+                "wrestle",
+                "wrestling"
+              ]
             },
             {
               "codepoint": "U+1F93C U+200D U+2642 U+FE0F",
               "name": "men wrestling",
-              "keywords": ["men", "men wrestling", "wrestle"]
+              "keywords": [
+                "combat",
+                "duel",
+                "grapple",
+                "men",
+                "ring",
+                "tournament",
+                "wrestle",
+                "wrestling"
+              ]
             },
             {
               "codepoint": "U+1F93C U+200D U+2640 U+FE0F",
               "name": "women wrestling",
-              "keywords": ["women", "women wrestling", "wrestle"]
+              "keywords": [
+                "combat",
+                "duel",
+                "grapple",
+                "ring",
+                "tournament",
+                "women",
+                "wrestle",
+                "wrestling"
+              ]
             },
             {
               "codepoint": "U+1F93D",
               "name": "person playing water polo",
-              "keywords": ["person playing water polo", "polo", "water"]
+              "keywords": [
+                "person",
+                "playing",
+                "polo",
+                "sport",
+                "swimming",
+                "water",
+                "waterpolo"
+              ]
             },
             {
               "codepoint": "U+1F93D U+200D U+2642 U+FE0F",
               "name": "man playing water polo",
-              "keywords": ["man", "man playing water polo", "water polo"]
+              "keywords": [
+                "man",
+                "playing",
+                "polo",
+                "sport",
+                "swimming",
+                "water",
+                "waterpolo"
+              ]
             },
             {
               "codepoint": "U+1F93D U+200D U+2640 U+FE0F",
               "name": "woman playing water polo",
-              "keywords": ["water polo", "woman", "woman playing water polo"]
+              "keywords": [
+                "playing",
+                "polo",
+                "sport",
+                "swimming",
+                "water",
+                "waterpolo",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F93E",
               "name": "person playing handball",
-              "keywords": ["ball", "handball", "person playing handball"]
+              "keywords": [
+                "athletics",
+                "ball",
+                "catch",
+                "chuck",
+                "handball",
+                "hurl",
+                "lob",
+                "person",
+                "pitch",
+                "playing",
+                "sport",
+                "throw",
+                "toss"
+              ]
             },
             {
               "codepoint": "U+1F93E U+200D U+2642 U+FE0F",
               "name": "man playing handball",
-              "keywords": ["handball", "man", "man playing handball"]
+              "keywords": [
+                "athletics",
+                "ball",
+                "catch",
+                "chuck",
+                "handball",
+                "hurl",
+                "lob",
+                "man",
+                "pitch",
+                "playing",
+                "sport",
+                "throw",
+                "toss"
+              ]
             },
             {
               "codepoint": "U+1F93E U+200D U+2640 U+FE0F",
               "name": "woman playing handball",
-              "keywords": ["handball", "woman", "woman playing handball"]
+              "keywords": [
+                "athletics",
+                "ball",
+                "catch",
+                "chuck",
+                "handball",
+                "hurl",
+                "lob",
+                "pitch",
+                "playing",
+                "sport",
+                "throw",
+                "toss",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F939",
               "name": "person juggling",
-              "keywords": ["balance", "juggle", "multitask", "person juggling", "skill"]
+              "keywords": [
+                "act",
+                "balance",
+                "balancing",
+                "handle",
+                "juggle",
+                "juggling",
+                "manage",
+                "multitask",
+                "person",
+                "skill"
+              ]
             },
             {
               "codepoint": "U+1F939 U+200D U+2642 U+FE0F",
               "name": "man juggling",
-              "keywords": ["juggling", "man", "multitask"]
+              "keywords": [
+                "act",
+                "balance",
+                "balancing",
+                "handle",
+                "juggle",
+                "juggling",
+                "man",
+                "manage",
+                "multitask",
+                "skill"
+              ]
             },
             {
               "codepoint": "U+1F939 U+200D U+2640 U+FE0F",
               "name": "woman juggling",
-              "keywords": ["juggling", "multitask", "woman"]
+              "keywords": [
+                "act",
+                "balance",
+                "balancing",
+                "handle",
+                "juggle",
+                "juggling",
+                "manage",
+                "multitask",
+                "skill",
+                "woman"
+              ]
             }
           ]
         },
         {
-          "category": "person_resting",
+          "category": "person-resting",
           "contents": [
             {
               "codepoint": "U+1F9D8",
               "name": "person in lotus position",
-              "keywords": ["meditation", "person in lotus position", "yoga", "serenity"]
+              "keywords": [
+                "cross",
+                "legged",
+                "legs",
+                "lotus",
+                "meditation",
+                "peace",
+                "person",
+                "position",
+                "relax",
+                "serenity",
+                "yoga",
+                "yogi",
+                "zen"
+              ]
             },
             {
               "codepoint": "U+1F9D8 U+200D U+2642 U+FE0F",
               "name": "man in lotus position",
-              "keywords": ["man in lotus position", "meditation", "yoga"]
+              "keywords": [
+                "cross",
+                "legged",
+                "legs",
+                "lotus",
+                "man",
+                "meditation",
+                "peace",
+                "position",
+                "relax",
+                "serenity",
+                "yoga",
+                "yogi",
+                "zen"
+              ]
             },
             {
               "codepoint": "U+1F9D8 U+200D U+2640 U+FE0F",
               "name": "woman in lotus position",
-              "keywords": ["meditation", "woman in lotus position", "yoga"]
+              "keywords": [
+                "cross",
+                "legged",
+                "legs",
+                "lotus",
+                "meditation",
+                "peace",
+                "position",
+                "relax",
+                "serenity",
+                "woman",
+                "yoga",
+                "yogi",
+                "zen"
+              ]
             },
             {
               "codepoint": "U+1F6C0",
               "name": "person taking bath",
-              "keywords": ["bath", "bathtub", "person taking bath"]
+              "keywords": ["bath", "bathtub", "person", "taking", "tub"]
             },
             {
               "codepoint": "U+1F6CC",
               "name": "person in bed",
-              "keywords": ["hotel", "person in bed", "sleep"]
+              "keywords": [
+                "bed",
+                "bedtime",
+                "good",
+                "goodnight",
+                "hotel",
+                "nap",
+                "night",
+                "person",
+                "sleep",
+                "tired",
+                "zzz"
+              ]
             }
           ]
         },
@@ -2605,197 +6803,369 @@
             {
               "codepoint": "U+1F9D1 U+200D U+1F91D U+200D U+1F9D1",
               "name": "people holding hands",
-              "keywords": ["couple", "hand", "hold", "holding hands", "people holding hands", "person"]
+              "keywords": [
+                "bae",
+                "bestie",
+                "bff",
+                "couple",
+                "dating",
+                "flirt",
+                "friends",
+                "hand",
+                "hold",
+                "people",
+                "twins"
+              ]
             },
             {
               "codepoint": "U+1F46D",
               "name": "women holding hands",
-              "keywords": ["couple", "hand", "holding hands", "women", "women holding hands"]
+              "keywords": [
+                "bae",
+                "bestie",
+                "bff",
+                "couple",
+                "dating",
+                "flirt",
+                "friends",
+                "girls",
+                "hand",
+                "hold",
+                "sisters",
+                "twins",
+                "women"
+              ]
             },
             {
               "codepoint": "U+1F46B",
               "name": "woman and man holding hands",
-              "keywords": ["couple", "hand", "hold", "holding hands", "man", "woman", "woman and man holding hands"]
+              "keywords": [
+                "bae",
+                "bestie",
+                "bff",
+                "couple",
+                "dating",
+                "flirt",
+                "friends",
+                "hand",
+                "hold",
+                "man",
+                "twins",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F46C",
               "name": "men holding hands",
-              "keywords": ["couple", "Gemini", "holding hands", "man", "men", "men holding hands", "twins", "zodiac"]
+              "keywords": [
+                "bae",
+                "bestie",
+                "bff",
+                "boys",
+                "brothers",
+                "couple",
+                "dating",
+                "flirt",
+                "friends",
+                "hand",
+                "hold",
+                "men",
+                "twins"
+              ]
             },
             {
               "codepoint": "U+1F48F",
               "name": "kiss",
-              "keywords": ["couple", "kiss"]
+              "keywords": [
+                "anniversary",
+                "babe",
+                "bae",
+                "couple",
+                "date",
+                "dating",
+                "heart",
+                "kiss",
+                "love",
+                "mwah",
+                "person",
+                "romance",
+                "together",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F468",
               "name": "kiss: woman, man",
-              "keywords": ["couple", "kiss", "man", "woman"]
+              "keywords": [
+                "anniversary",
+                "babe",
+                "bae",
+                "couple",
+                "date",
+                "dating",
+                "heart",
+                "kiss",
+                "love",
+                "man",
+                "mwah",
+                "person",
+                "romance",
+                "together",
+                "woman",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F468",
               "name": "kiss: man, man",
-              "keywords": ["couple", "kiss", "man"]
+              "keywords": [
+                "anniversary",
+                "babe",
+                "bae",
+                "couple",
+                "date",
+                "dating",
+                "heart",
+                "kiss",
+                "love",
+                "man",
+                "mwah",
+                "person",
+                "romance",
+                "together",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F469",
               "name": "kiss: woman, woman",
-              "keywords": ["couple", "kiss", "woman"]
+              "keywords": [
+                "anniversary",
+                "babe",
+                "bae",
+                "couple",
+                "date",
+                "dating",
+                "heart",
+                "kiss",
+                "love",
+                "mwah",
+                "person",
+                "romance",
+                "together",
+                "woman",
+                "xoxo"
+              ]
             },
             {
               "codepoint": "U+1F491",
               "name": "couple with heart",
-              "keywords": ["couple", "couple with heart", "love"]
+              "keywords": [
+                "anniversary",
+                "babe",
+                "bae",
+                "couple",
+                "dating",
+                "heart",
+                "kiss",
+                "love",
+                "person",
+                "relationship",
+                "romance",
+                "together",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F468",
               "name": "couple with heart: woman, man",
-              "keywords": ["couple", "couple with heart", "love", "man", "woman"]
+              "keywords": [
+                "anniversary",
+                "babe",
+                "bae",
+                "couple",
+                "dating",
+                "heart",
+                "kiss",
+                "love",
+                "man",
+                "person",
+                "relationship",
+                "romance",
+                "together",
+                "woman",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+2764 U+FE0F U+200D U+1F468",
               "name": "couple with heart: man, man",
-              "keywords": ["couple", "couple with heart", "love", "man"]
+              "keywords": [
+                "anniversary",
+                "babe",
+                "bae",
+                "couple",
+                "dating",
+                "heart",
+                "kiss",
+                "love",
+                "man",
+                "person",
+                "relationship",
+                "romance",
+                "together",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F469",
               "name": "couple with heart: woman, woman",
-              "keywords": ["couple", "couple with heart", "love", "woman"]
-            },
-            {
-              "codepoint": "U+1F46A",
-              "name": "family",
-              "keywords": ["family"]
+              "keywords": [
+                "anniversary",
+                "babe",
+                "bae",
+                "couple",
+                "dating",
+                "heart",
+                "kiss",
+                "love",
+                "person",
+                "relationship",
+                "romance",
+                "together",
+                "woman",
+                "you"
+              ]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F466",
               "name": "family: man, woman, boy",
-              "keywords": ["boy", "family", "man", "woman"]
+              "keywords": ["boy", "child", "family", "man", "woman"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F467",
               "name": "family: man, woman, girl",
-              "keywords": ["family", "girl", "man", "woman"]
+              "keywords": ["child", "family", "girl", "man", "woman"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466",
               "name": "family: man, woman, girl, boy",
-              "keywords": ["boy", "family", "girl", "man", "woman"]
+              "keywords": ["boy", "child", "family", "girl", "man", "woman"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F466 U+200D U+1F466",
               "name": "family: man, woman, boy, boy",
-              "keywords": ["boy", "family", "man", "woman"]
+              "keywords": ["boy", "child", "family", "man", "woman"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F467",
               "name": "family: man, woman, girl, girl",
-              "keywords": ["family", "girl", "man", "woman"]
+              "keywords": ["child", "family", "girl", "man", "woman"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F466",
               "name": "family: man, man, boy",
-              "keywords": ["boy", "family", "man"]
+              "keywords": ["boy", "child", "family", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F467",
               "name": "family: man, man, girl",
-              "keywords": ["family", "girl", "man"]
+              "keywords": ["child", "family", "girl", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F467 U+200D U+1F466",
               "name": "family: man, man, girl, boy",
-              "keywords": ["boy", "family", "girl", "man"]
+              "keywords": ["boy", "child", "family", "girl", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F466 U+200D U+1F466",
               "name": "family: man, man, boy, boy",
-              "keywords": ["boy", "family", "man"]
+              "keywords": ["boy", "child", "family", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F468 U+200D U+1F467 U+200D U+1F467",
               "name": "family: man, man, girl, girl",
-              "keywords": ["family", "girl", "man"]
+              "keywords": ["child", "family", "girl", "man"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F466",
               "name": "family: woman, woman, boy",
-              "keywords": ["boy", "family", "woman"]
+              "keywords": ["boy", "child", "family", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F467",
               "name": "family: woman, woman, girl",
-              "keywords": ["family", "girl", "woman"]
+              "keywords": ["child", "family", "girl", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466",
               "name": "family: woman, woman, girl, boy",
-              "keywords": ["boy", "family", "girl", "woman"]
+              "keywords": ["boy", "child", "family", "girl", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F466 U+200D U+1F466",
               "name": "family: woman, woman, boy, boy",
-              "keywords": ["boy", "family", "woman"]
+              "keywords": ["boy", "child", "family", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F469 U+200D U+1F467 U+200D U+1F467",
               "name": "family: woman, woman, girl, girl",
-              "keywords": ["family", "girl", "woman"]
+              "keywords": ["child", "family", "girl", "woman"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F466",
               "name": "family: man, boy",
-              "keywords": ["boy", "family", "man"]
+              "keywords": ["boy", "child", "family", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F466 U+200D U+1F466",
               "name": "family: man, boy, boy",
-              "keywords": ["boy", "family", "man"]
+              "keywords": ["boy", "child", "family", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F467",
               "name": "family: man, girl",
-              "keywords": ["family", "girl", "man"]
+              "keywords": ["child", "family", "girl", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F467 U+200D U+1F466",
               "name": "family: man, girl, boy",
-              "keywords": ["boy", "family", "girl", "man"]
+              "keywords": ["boy", "child", "family", "girl", "man"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F467 U+200D U+1F467",
               "name": "family: man, girl, girl",
-              "keywords": ["family", "girl", "man"]
+              "keywords": ["child", "family", "girl", "man"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F466",
               "name": "family: woman, boy",
-              "keywords": ["boy", "family", "woman"]
+              "keywords": ["boy", "child", "family", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F466 U+200D U+1F466",
               "name": "family: woman, boy, boy",
-              "keywords": ["boy", "family", "woman"]
+              "keywords": ["boy", "child", "family", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F467",
               "name": "family: woman, girl",
-              "keywords": ["family", "girl", "woman"]
+              "keywords": ["child", "family", "girl", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F467 U+200D U+1F466",
               "name": "family: woman, girl, boy",
-              "keywords": ["boy", "family", "girl", "woman"]
+              "keywords": ["boy", "child", "family", "girl", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F467 U+200D U+1F467",
               "name": "family: woman, girl, girl",
-              "keywords": ["family", "girl", "woman"]
+              "keywords": ["child", "family", "girl", "woman"]
             }
           ]
         },
         {
-          "category": "person_symbol",
+          "category": "person-symbol",
           "contents": [
             {
               "codepoint": "U+1F5E3",
@@ -2805,22 +7175,92 @@
             {
               "codepoint": "U+1F464",
               "name": "bust in silhouette",
-              "keywords": ["bust", "bust in silhouette", "silhouette"]
+              "keywords": ["bust", "mysterious", "shadow", "silhouette"]
             },
             {
               "codepoint": "U+1F465",
               "name": "busts in silhouette",
-              "keywords": ["bust", "busts in silhouette", "silhouette"]
+              "keywords": [
+                "bff",
+                "bust",
+                "busts",
+                "everyone",
+                "friend",
+                "friends",
+                "people",
+                "silhouette"
+              ]
             },
             {
               "codepoint": "U+1FAC2",
               "name": "people hugging",
-              "keywords": ["goodbye", "hello", "hug", "people hugging", "thanks"]
+              "keywords": [
+                "comfort",
+                "embrace",
+                "farewell",
+                "friendship",
+                "goodbye",
+                "hello",
+                "hug",
+                "hugging",
+                "love",
+                "people",
+                "thanks"
+              ]
+            },
+            {
+              "codepoint": "U+1F46A",
+              "name": "family",
+              "keywords": ["child", "family"]
+            },
+            {
+              "codepoint": "U+1F9D1 U+200D U+1F9D1 U+200D U+1F9D2",
+              "name": "family: adult, adult, child",
+              "keywords": ["adult", "child", "family"]
+            },
+            {
+              "codepoint": "U+1F9D1 U+200D U+1F9D1 U+200D U+1F9D2 U+200D U+1F9D2",
+              "name": "family: adult, adult, child, child",
+              "keywords": ["adult", "child", "family"]
+            },
+            {
+              "codepoint": "U+1F9D1 U+200D U+1F9D2",
+              "name": "family: adult, child",
+              "keywords": ["adult", "child", "family"]
+            },
+            {
+              "codepoint": "U+1F9D1 U+200D U+1F9D2 U+200D U+1F9D2",
+              "name": "family: adult, child, child",
+              "keywords": ["adult", "child", "family"]
             },
             {
               "codepoint": "U+1F463",
               "name": "footprints",
-              "keywords": ["clothing", "footprint", "footprints", "print"]
+              "keywords": [
+                "barefoot",
+                "clothing",
+                "footprint",
+                "footprints",
+                "omw",
+                "print",
+                "walk"
+              ]
+            },
+            {
+              "codepoint": "U+1FAC6",
+              "name": "fingerprint",
+              "keywords": [
+                "clue",
+                "crime",
+                "detective",
+                "fingerprint",
+                "forensics",
+                "identity",
+                "mystery",
+                "print",
+                "safety",
+                "trace"
+              ]
             }
           ]
         }
@@ -2830,151 +7270,225 @@
       "category": "Component",
       "contents": [
         {
-        "category": "hair_style",
-        "contents": [
-          {
-            "codepoint": "U+1F9B0",
-            "name": "red hair",
-            "keywords": ["ginger", "red hair", "redhead"]
-          },
-          {
-            "codepoint": "U+1F9B1",
-            "name": "curly hair",
-            "keywords": ["afro", "curly", "curly hair", "ringlets"]
-          },
-          {
-            "codepoint": "U+1F9B3",
-            "name": "white hair",
-            "keywords": ["gray", "hair", "old", "white"]
-          },
-          {
-            "codepoint": "U+1F9B2",
-            "name": "bald",
-            "keywords": ["bald", "chemotherapy", "hairless", "no hair", "shaven"]
-          }
-        ]
-      }]
+          "category": "hair-style",
+          "contents": [
+            {
+              "codepoint": "U+1F9B0",
+              "name": "red hair",
+              "keywords": ["ginger", "hair", "red", "redhead"]
+            },
+            {
+              "codepoint": "U+1F9B1",
+              "name": "curly hair",
+              "keywords": ["afro", "curly", "hair", "ringlets"]
+            },
+            {
+              "codepoint": "U+1F9B3",
+              "name": "white hair",
+              "keywords": ["gray", "hair", "old", "white"]
+            },
+            {
+              "codepoint": "U+1F9B2",
+              "name": "bald",
+              "keywords": [
+                "bald",
+                "chemotherapy",
+                "hair",
+                "hairless",
+                "no",
+                "shaven"
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
       "category": "Animals & Nature",
       "contents": [
         {
-          "category": "animal_mammal",
+          "category": "animal-mammal",
           "contents": [
             {
               "codepoint": "U+1F435",
               "name": "monkey face",
-              "keywords": ["face", "monkey"]
+              "keywords": ["animal", "banana", "face", "monkey"]
             },
             {
               "codepoint": "U+1F412",
               "name": "monkey",
-              "keywords": ["monkey"]
+              "keywords": ["animal", "banana", "monkey"]
             },
             {
               "codepoint": "U+1F98D",
               "name": "gorilla",
-              "keywords": ["gorilla"]
+              "keywords": ["animal", "gorilla"]
             },
             {
               "codepoint": "U+1F9A7",
               "name": "orangutan",
-              "keywords": ["ape", "orangutan"]
+              "keywords": ["animal", "ape", "monkey", "orangutan"]
             },
             {
               "codepoint": "U+1F436",
               "name": "dog face",
-              "keywords": ["dog", "face", "pet"]
+              "keywords": [
+                "adorbs",
+                "animal",
+                "dog",
+                "face",
+                "pet",
+                "puppies",
+                "puppy"
+              ]
             },
             {
               "codepoint": "U+1F415",
               "name": "dog",
-              "keywords": ["dog", "pet"]
+              "keywords": ["animal", "animals", "dog", "dogs", "pet"]
             },
             {
               "codepoint": "U+1F9AE",
               "name": "guide dog",
-              "keywords": ["accessibility", "blind", "guide", "guide dog"]
+              "keywords": ["accessibility", "animal", "blind", "dog", "guide"]
             },
             {
               "codepoint": "U+1F415 U+200D U+1F9BA",
               "name": "service dog",
-              "keywords": ["accessibility", "assistance", "dog", "service"]
+              "keywords": [
+                "accessibility",
+                "animal",
+                "assistance",
+                "dog",
+                "service"
+              ]
             },
             {
               "codepoint": "U+1F429",
               "name": "poodle",
-              "keywords": ["dog", "poodle"]
+              "keywords": ["animal", "dog", "fluffy", "poodle"]
             },
             {
               "codepoint": "U+1F43A",
               "name": "wolf",
-              "keywords": ["face", "wolf"]
+              "keywords": ["animal", "face", "wolf"]
             },
             {
               "codepoint": "U+1F98A",
               "name": "fox",
-              "keywords": ["face", "fox"]
+              "keywords": ["animal", "face", "fox"]
             },
             {
               "codepoint": "U+1F99D",
               "name": "raccoon",
-              "keywords": ["curious", "raccoon", "sly"]
+              "keywords": ["animal", "curious", "raccoon", "sly"]
             },
             {
               "codepoint": "U+1F431",
               "name": "cat face",
-              "keywords": ["cat", "face", "pet"]
+              "keywords": ["animal", "cat", "face", "kitten", "kitty", "pet"]
             },
             {
               "codepoint": "U+1F408",
               "name": "cat",
-              "keywords": ["cat", "pet"]
+              "keywords": ["animal", "animals", "cat", "cats", "kitten", "pet"]
             },
             {
               "codepoint": "U+1F408 U+200D U+2B1B",
               "name": "black cat",
-              "keywords": ["black", "cat", "unlucky"]
+              "keywords": [
+                "animal",
+                "black",
+                "cat",
+                "feline",
+                "halloween",
+                "meow",
+                "unlucky"
+              ]
             },
             {
               "codepoint": "U+1F981",
               "name": "lion",
-              "keywords": ["face", "Leo", "lion", "zodiac"]
+              "keywords": [
+                "alpha",
+                "animal",
+                "face",
+                "Leo",
+                "lion",
+                "mane",
+                "order",
+                "rawr",
+                "roar",
+                "safari",
+                "strong",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+1F42F",
               "name": "tiger face",
-              "keywords": ["face", "tiger"]
+              "keywords": ["animal", "big", "cat", "face", "predator", "tiger"]
             },
             {
               "codepoint": "U+1F405",
               "name": "tiger",
-              "keywords": ["tiger"]
+              "keywords": ["animal", "big", "cat", "predator", "tiger", "zoo"]
             },
             {
               "codepoint": "U+1F406",
               "name": "leopard",
-              "keywords": ["leopard"]
+              "keywords": ["animal", "big", "cat", "leopard", "predator", "zoo"]
             },
             {
               "codepoint": "U+1F434",
               "name": "horse face",
-              "keywords": ["face", "horse"]
+              "keywords": [
+                "animal",
+                "dressage",
+                "equine",
+                "face",
+                "farm",
+                "horse",
+                "horses"
+              ]
             },
             {
               "codepoint": "U+1FACE",
               "name": "moose",
-              "keywords": ["animal", "antlers", "elk", "mammal", "moose"]
+              "keywords": [
+                "alces",
+                "animal",
+                "antlers",
+                "elk",
+                "mammal",
+                "moose"
+              ]
             },
             {
               "codepoint": "U+1FACF",
               "name": "donkey",
-              "keywords": ["animal", "ass", "burro", "donkey", "mammal", "mule", "stubborn"]
+              "keywords": [
+                "animal",
+                "ass",
+                "burro",
+                "donkey",
+                "hinny",
+                "mammal",
+                "mule",
+                "stubborn"
+              ]
             },
             {
               "codepoint": "U+1F40E",
               "name": "horse",
-              "keywords": ["equestrian", "horse", "racehorse", "racing"]
+              "keywords": [
+                "animal",
+                "equestrian",
+                "farm",
+                "horse",
+                "racehorse",
+                "racing"
+              ]
             },
             {
               "codepoint": "U+1F984",
@@ -2984,182 +7498,269 @@
             {
               "codepoint": "U+1F993",
               "name": "zebra",
-              "keywords": ["stripe", "zebra"]
+              "keywords": ["animal", "stripe", "zebra"]
             },
             {
               "codepoint": "U+1F98C",
               "name": "deer",
-              "keywords": ["deer"]
+              "keywords": ["animal", "deer"]
             },
             {
               "codepoint": "U+1F9AC",
               "name": "bison",
-              "keywords": ["bison", "buffalo", "herd", "wisent"]
+              "keywords": ["animal", "bison", "buffalo", "herd", "wisent"]
             },
             {
               "codepoint": "U+1F42E",
               "name": "cow face",
-              "keywords": ["cow", "face"]
+              "keywords": ["animal", "cow", "face", "farm", "milk", "moo"]
             },
             {
               "codepoint": "U+1F402",
               "name": "ox",
-              "keywords": ["bull", "ox", "Taurus", "zodiac"]
+              "keywords": [
+                "animal",
+                "animals",
+                "bull",
+                "farm",
+                "ox",
+                "Taurus",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+1F403",
               "name": "water buffalo",
-              "keywords": ["buffalo", "water"]
+              "keywords": ["animal", "buffalo", "water", "zoo"]
             },
             {
               "codepoint": "U+1F404",
               "name": "cow",
-              "keywords": ["cow"]
+              "keywords": ["animal", "animals", "cow", "farm", "milk", "moo"]
             },
             {
               "codepoint": "U+1F437",
               "name": "pig face",
-              "keywords": ["face", "pig"]
+              "keywords": ["animal", "bacon", "face", "farm", "pig", "pork"]
             },
             {
               "codepoint": "U+1F416",
               "name": "pig",
-              "keywords": ["pig", "sow"]
+              "keywords": ["animal", "bacon", "farm", "pig", "pork", "sow"]
             },
             {
               "codepoint": "U+1F417",
               "name": "boar",
-              "keywords": ["boar", "pig"]
+              "keywords": ["animal", "boar", "pig"]
             },
             {
               "codepoint": "U+1F43D",
               "name": "pig nose",
-              "keywords": ["face", "nose", "pig"]
+              "keywords": [
+                "animal",
+                "face",
+                "farm",
+                "nose",
+                "pig",
+                "smell",
+                "snout"
+              ]
             },
             {
               "codepoint": "U+1F40F",
               "name": "ram",
-              "keywords": ["Aries", "male", "ram", "sheep", "zodiac"]
+              "keywords": [
+                "animal",
+                "Aries",
+                "horns",
+                "male",
+                "ram",
+                "sheep",
+                "zodiac",
+                "zoo"
+              ]
             },
             {
               "codepoint": "U+1F411",
               "name": "ewe",
-              "keywords": ["ewe", "female", "sheep"]
+              "keywords": [
+                "animal",
+                "baa",
+                "ewe",
+                "farm",
+                "female",
+                "fluffy",
+                "lamb",
+                "sheep",
+                "wool"
+              ]
             },
             {
               "codepoint": "U+1F410",
               "name": "goat",
-              "keywords": ["Capricorn", "goat", "zodiac"]
+              "keywords": [
+                "animal",
+                "Capricorn",
+                "farm",
+                "goat",
+                "milk",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+1F42A",
               "name": "camel",
-              "keywords": ["camel", "dromedary", "hump"]
+              "keywords": [
+                "animal",
+                "camel",
+                "desert",
+                "dromedary",
+                "hump",
+                "one"
+              ]
             },
             {
               "codepoint": "U+1F42B",
               "name": "two-hump camel",
-              "keywords": ["bactrian", "camel", "hump", "two-hump camel"]
+              "keywords": [
+                "animal",
+                "bactrian",
+                "camel",
+                "desert",
+                "hump",
+                "two",
+                "two-hump"
+              ]
             },
             {
               "codepoint": "U+1F999",
               "name": "llama",
-              "keywords": ["alpaca", "guanaco", "llama", "vicuña", "wool"]
+              "keywords": [
+                "alpaca",
+                "animal",
+                "guanaco",
+                "llama",
+                "vicuña",
+                "wool"
+              ]
             },
             {
               "codepoint": "U+1F992",
               "name": "giraffe",
-              "keywords": ["giraffe", "spots"]
+              "keywords": ["animal", "giraffe", "spots"]
             },
             {
               "codepoint": "U+1F418",
               "name": "elephant",
-              "keywords": ["elephant"]
+              "keywords": ["animal", "elephant"]
             },
             {
               "codepoint": "U+1F9A3",
               "name": "mammoth",
-              "keywords": ["extinction", "large", "mammoth", "tusk", "woolly"]
+              "keywords": [
+                "animal",
+                "extinction",
+                "large",
+                "mammoth",
+                "tusk",
+                "wooly"
+              ]
             },
             {
               "codepoint": "U+1F98F",
               "name": "rhinoceros",
-              "keywords": ["rhinoceros"]
+              "keywords": ["animal", "rhinoceros"]
             },
             {
               "codepoint": "U+1F99B",
               "name": "hippopotamus",
-              "keywords": ["hippo", "hippopotamus"]
+              "keywords": ["animal", "hippo", "hippopotamus"]
             },
             {
               "codepoint": "U+1F42D",
               "name": "mouse face",
-              "keywords": ["face", "mouse"]
+              "keywords": ["animal", "face", "mouse"]
             },
             {
               "codepoint": "U+1F401",
               "name": "mouse",
-              "keywords": ["mouse"]
+              "keywords": ["animal", "animals", "mouse"]
             },
             {
               "codepoint": "U+1F400",
               "name": "rat",
-              "keywords": ["rat"]
+              "keywords": ["animal", "rat"]
             },
             {
               "codepoint": "U+1F439",
               "name": "hamster",
-              "keywords": ["face", "hamster", "pet"]
+              "keywords": ["animal", "face", "hamster", "pet"]
             },
             {
               "codepoint": "U+1F430",
               "name": "rabbit face",
-              "keywords": ["bunny", "face", "pet", "rabbit"]
+              "keywords": ["animal", "bunny", "face", "pet", "rabbit"]
             },
             {
               "codepoint": "U+1F407",
               "name": "rabbit",
-              "keywords": ["bunny", "pet", "rabbit"]
+              "keywords": ["animal", "bunny", "pet", "rabbit"]
             },
             {
               "codepoint": "U+1F43F",
               "name": "chipmunk",
-              "keywords": ["chipmunk", "squirrel"]
+              "keywords": ["animal", "chipmunk", "squirrel"]
             },
             {
               "codepoint": "U+1F9AB",
               "name": "beaver",
-              "keywords": ["beaver", "dam"]
+              "keywords": ["animal", "beaver", "dam", "teeth"]
             },
             {
               "codepoint": "U+1F994",
               "name": "hedgehog",
-              "keywords": ["hedgehog", "spiny"]
+              "keywords": ["animal", "hedgehog", "spiny"]
             },
             {
               "codepoint": "U+1F987",
               "name": "bat",
-              "keywords": ["bat", "vampire"]
+              "keywords": ["animal", "bat", "vampire"]
             },
             {
               "codepoint": "U+1F43B",
               "name": "bear",
-              "keywords": ["bear", "face"]
+              "keywords": [
+                "animal",
+                "bear",
+                "face",
+                "grizzly",
+                "growl",
+                "honey"
+              ]
             },
             {
               "codepoint": "U+1F43B U+200D U+2744 U+FE0F",
               "name": "polar bear",
-              "keywords": ["arctic", "bear", "polar bear", "white"]
+              "keywords": ["animal", "arctic", "bear", "polar", "white"]
             },
             {
               "codepoint": "U+1F428",
               "name": "koala",
-              "keywords": ["face", "koala", "marsupial"]
+              "keywords": [
+                "animal",
+                "australia",
+                "bear",
+                "down",
+                "face",
+                "koala",
+                "marsupial",
+                "under"
+              ]
             },
             {
               "codepoint": "U+1F43C",
               "name": "panda",
-              "keywords": ["face", "panda"]
+              "keywords": ["animal", "bamboo", "face", "panda"]
             },
             {
               "codepoint": "U+1F9A5",
@@ -3169,102 +7770,131 @@
             {
               "codepoint": "U+1F9A6",
               "name": "otter",
-              "keywords": ["fishing", "otter", "playful"]
+              "keywords": ["animal", "fishing", "otter", "playful"]
             },
             {
               "codepoint": "U+1F9A8",
               "name": "skunk",
-              "keywords": ["skunk", "stink"]
+              "keywords": ["animal", "skunk", "stink"]
             },
             {
               "codepoint": "U+1F998",
               "name": "kangaroo",
-              "keywords": ["Australia", "joey", "jump", "kangaroo", "marsupial"]
+              "keywords": ["animal", "joey", "jump", "kangaroo", "marsupial"]
             },
             {
               "codepoint": "U+1F9A1",
               "name": "badger",
-              "keywords": ["badger", "honey badger", "pester"]
+              "keywords": ["animal", "badger", "honey", "pester"]
             },
             {
               "codepoint": "U+1F43E",
               "name": "paw prints",
-              "keywords": ["feet", "paw", "paw prints", "print"]
+              "keywords": ["feet", "paw", "paws", "print", "prints"]
             }
           ]
         },
         {
-          "category": "animal_bird",
+          "category": "animal-bird",
           "contents": [
             {
               "codepoint": "U+1F983",
               "name": "turkey",
-              "keywords": ["bird", "turkey"]
+              "keywords": ["bird", "gobble", "thanksgiving", "turkey"]
             },
             {
               "codepoint": "U+1F414",
               "name": "chicken",
-              "keywords": ["bird", "chicken"]
+              "keywords": ["animal", "bird", "chicken", "ornithology"]
             },
             {
               "codepoint": "U+1F413",
               "name": "rooster",
-              "keywords": ["bird", "rooster"]
+              "keywords": ["animal", "bird", "ornithology", "rooster"]
             },
             {
               "codepoint": "U+1F423",
               "name": "hatching chick",
-              "keywords": ["baby", "bird", "chick", "hatching"]
+              "keywords": ["animal", "baby", "bird", "chick", "egg", "hatching"]
             },
             {
               "codepoint": "U+1F424",
               "name": "baby chick",
-              "keywords": ["baby", "bird", "chick"]
+              "keywords": ["animal", "baby", "bird", "chick", "ornithology"]
             },
             {
               "codepoint": "U+1F425",
               "name": "front-facing baby chick",
-              "keywords": ["baby", "bird", "chick", "front-facing baby chick"]
+              "keywords": [
+                "animal",
+                "baby",
+                "bird",
+                "chick",
+                "front-facing",
+                "newborn",
+                "ornithology"
+              ]
             },
             {
               "codepoint": "U+1F426",
               "name": "bird",
-              "keywords": ["bird"]
+              "keywords": ["animal", "bird", "ornithology"]
             },
             {
               "codepoint": "U+1F427",
               "name": "penguin",
-              "keywords": ["bird", "penguin"]
+              "keywords": [
+                "animal",
+                "antarctica",
+                "bird",
+                "ornithology",
+                "penguin"
+              ]
             },
             {
               "codepoint": "U+1F54A",
               "name": "dove",
-              "keywords": ["bird", "dove", "fly", "peace"]
+              "keywords": ["bird", "dove", "fly", "ornithology", "peace"]
             },
             {
               "codepoint": "U+1F985",
               "name": "eagle",
-              "keywords": ["bird", "eagle"]
+              "keywords": ["animal", "bird", "eagle", "ornithology"]
             },
             {
               "codepoint": "U+1F986",
               "name": "duck",
-              "keywords": ["bird", "duck"]
+              "keywords": ["animal", "bird", "duck", "ornithology"]
             },
             {
               "codepoint": "U+1F9A2",
               "name": "swan",
-              "keywords": ["bird", "cygnet", "swan", "ugly duckling"]
+              "keywords": [
+                "animal",
+                "bird",
+                "cygnet",
+                "duckling",
+                "ornithology",
+                "swan",
+                "ugly"
+              ]
             },
             {
               "codepoint": "U+1F989",
               "name": "owl",
-              "keywords": ["bird", "owl", "wise"]
+              "keywords": ["animal", "bird", "ornithology", "owl", "wise"]
             },
             {
               "codepoint": "U+1F9A4",
               "name": "dodo",
-              "keywords": ["dodo", "extinction", "large", "Mauritius"]
+              "keywords": [
+                "animal",
+                "bird",
+                "dodo",
+                "extinction",
+                "large",
+                "ornithology"
+              ]
             },
             {
               "codepoint": "U+1FAB6",
@@ -3274,161 +7904,333 @@
             {
               "codepoint": "U+1F9A9",
               "name": "flamingo",
-              "keywords": ["flamboyant", "flamingo", "tropical"]
+              "keywords": [
+                "animal",
+                "bird",
+                "flamboyant",
+                "flamingo",
+                "ornithology",
+                "tropical"
+              ]
             },
             {
               "codepoint": "U+1F99A",
               "name": "peacock",
-              "keywords": ["bird", "ostentatious", "peacock", "peahen", "proud"]
+              "keywords": [
+                "animal",
+                "bird",
+                "colorful",
+                "ornithology",
+                "ostentatious",
+                "peacock",
+                "peahen",
+                "pretty",
+                "proud"
+              ]
             },
             {
               "codepoint": "U+1F99C",
               "name": "parrot",
-              "keywords": ["bird", "parrot", "pirate", "talk"]
+              "keywords": [
+                "animal",
+                "bird",
+                "ornithology",
+                "parrot",
+                "pirate",
+                "talk"
+              ]
             },
             {
               "codepoint": "U+1FABD",
               "name": "wing",
-              "keywords": ["angelic", "aviation", "bird", "flying", "mythology", "wing"]
+              "keywords": [
+                "angelic",
+                "ascend",
+                "aviation",
+                "bird",
+                "fly",
+                "flying",
+                "heavenly",
+                "mythology",
+                "soar",
+                "wing"
+              ]
             },
             {
               "codepoint": "U+1F426 U+200D U+2B1B",
               "name": "black bird",
-              "keywords": ["bird", "black", "crow", "raven", "rook"]
+              "keywords": [
+                "animal",
+                "beak",
+                "bird",
+                "black",
+                "caw",
+                "corvid",
+                "crow",
+                "ornithology",
+                "raven",
+                "rook"
+              ]
             },
             {
               "codepoint": "U+1FABF",
               "name": "goose",
-              "keywords": ["bird", "fowl", "goose", "honk", "silly"]
+              "keywords": [
+                "animal",
+                "bird",
+                "duck",
+                "flock",
+                "fowl",
+                "gaggle",
+                "gander",
+                "geese",
+                "goose",
+                "honk",
+                "ornithology",
+                "silly"
+              ]
+            },
+            {
+              "codepoint": "U+1F426 U+200D U+1F525",
+              "name": "phoenix",
+              "keywords": [
+                "ascend",
+                "ascension",
+                "emerge",
+                "fantasy",
+                "firebird",
+                "glory",
+                "immortal",
+                "phoenix",
+                "rebirth",
+                "reincarnation",
+                "reinvent",
+                "renewal",
+                "revival",
+                "revive",
+                "rise",
+                "transform"
+              ]
             }
           ]
         },
         {
-          "category": "animal_amphibian",
+          "category": "animal-amphibian",
           "contents": [
             {
-            "codepoint": "U+1F438",
-            "name": "frog",
-            "keywords": ["face", "frog"]
-          }]
+              "codepoint": "U+1F438",
+              "name": "frog",
+              "keywords": ["animal", "face", "frog"]
+            }
+          ]
         },
         {
-          "category": "animal_reptile",
+          "category": "animal-reptile",
           "contents": [
             {
               "codepoint": "U+1F40A",
               "name": "crocodile",
-              "keywords": ["crocodile"]
+              "keywords": ["animal", "crocodile", "zoo"]
             },
             {
               "codepoint": "U+1F422",
               "name": "turtle",
-              "keywords": ["terrapin", "tortoise", "turtle"]
+              "keywords": ["animal", "terrapin", "tortoise", "turtle"]
             },
             {
               "codepoint": "U+1F98E",
               "name": "lizard",
-              "keywords": ["lizard", "reptile"]
+              "keywords": ["animal", "lizard", "reptile"]
             },
             {
               "codepoint": "U+1F40D",
               "name": "snake",
-              "keywords": ["bearer", "Ophiuchus", "serpent", "snake", "zodiac"]
+              "keywords": [
+                "animal",
+                "bearer",
+                "Ophiuchus",
+                "serpent",
+                "snake",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+1F432",
               "name": "dragon face",
-              "keywords": ["dragon", "face", "fairy tale"]
+              "keywords": [
+                "animal",
+                "dragon",
+                "face",
+                "fairy",
+                "fairytale",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F409",
               "name": "dragon",
-              "keywords": ["dragon", "fairy tale"]
+              "keywords": [
+                "animal",
+                "dragon",
+                "fairy",
+                "fairytale",
+                "knights",
+                "tale"
+              ]
             },
             {
               "codepoint": "U+1F995",
               "name": "sauropod",
-              "keywords": ["brachiosaurus", "brontosaurus", "diplodocus", "sauropod"]
+              "keywords": [
+                "brachiosaurus",
+                "brontosaurus",
+                "dinosaur",
+                "diplodocus",
+                "sauropod"
+              ]
             },
             {
               "codepoint": "U+1F996",
               "name": "T-Rex",
-              "keywords": ["T-Rex", "Tyrannosaurus Rex"]
+              "keywords": ["dinosaur", "Rex", "T", "T-Rex", "Tyrannosaurus"]
             }
           ]
         },
         {
-          "category": "animal_marine",
+          "category": "animal-marine",
           "contents": [
             {
               "codepoint": "U+1F433",
               "name": "spouting whale",
-              "keywords": ["face", "spouting", "whale"]
+              "keywords": [
+                "animal",
+                "beach",
+                "face",
+                "ocean",
+                "spouting",
+                "whale"
+              ]
             },
             {
               "codepoint": "U+1F40B",
               "name": "whale",
-              "keywords": ["whale"]
+              "keywords": ["animal", "beach", "ocean", "whale"]
             },
             {
               "codepoint": "U+1F42C",
               "name": "dolphin",
-              "keywords": ["dolphin", "flipper"]
+              "keywords": ["animal", "beach", "dolphin", "flipper", "ocean"]
             },
             {
               "codepoint": "U+1F9AD",
               "name": "seal",
-              "keywords": ["sea lion", "seal"]
+              "keywords": ["animal", "lion", "ocean", "sea", "seal"]
             },
             {
               "codepoint": "U+1F41F",
               "name": "fish",
-              "keywords": ["fish", "Pisces", "zodiac"]
+              "keywords": [
+                "animal",
+                "dinner",
+                "fish",
+                "fishes",
+                "fishing",
+                "Pisces",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+1F420",
               "name": "tropical fish",
-              "keywords": ["fish", "tropical"]
+              "keywords": ["animal", "fish", "fishes", "tropical"]
             },
             {
               "codepoint": "U+1F421",
               "name": "blowfish",
-              "keywords": ["blowfish", "fish"]
+              "keywords": ["animal", "blowfish", "fish"]
             },
             {
               "codepoint": "U+1F988",
               "name": "shark",
-              "keywords": ["fish", "shark"]
+              "keywords": ["animal", "fish", "shark"]
             },
             {
               "codepoint": "U+1F419",
               "name": "octopus",
-              "keywords": ["octopus"]
+              "keywords": ["animal", "creature", "ocean", "octopus"]
             },
             {
               "codepoint": "U+1F41A",
               "name": "spiral shell",
-              "keywords": ["shell", "spiral"]
+              "keywords": ["animal", "beach", "conch", "sea", "shell", "spiral"]
             },
             {
               "codepoint": "U+1FAB8",
               "name": "coral",
-              "keywords": ["ocean", "reef"]
+              "keywords": ["change", "climate", "coral", "ocean", "reef", "sea"]
             },
             {
               "codepoint": "U+1FABC",
               "name": "jellyfish",
-              "keywords": ["burn", "invertebrate", "jelly", "jellyfish", "marine", "ouch", "stinger"]
+              "keywords": [
+                "animal",
+                "aquarium",
+                "burn",
+                "invertebrate",
+                "jelly",
+                "jellyfish",
+                "life",
+                "marine",
+                "ocean",
+                "ouch",
+                "plankton",
+                "sea",
+                "sting",
+                "stinger",
+                "tentacles"
+              ]
+            },
+            {
+              "codepoint": "U+1F980",
+              "name": "crab",
+              "keywords": ["Cancer", "crab", "zodiac"]
+            },
+            {
+              "codepoint": "U+1F99E",
+              "name": "lobster",
+              "keywords": ["animal", "bisque", "claws", "lobster", "seafood"]
+            },
+            {
+              "codepoint": "U+1F990",
+              "name": "shrimp",
+              "keywords": ["food", "shellfish", "shrimp", "small"]
+            },
+            {
+              "codepoint": "U+1F991",
+              "name": "squid",
+              "keywords": ["animal", "food", "mollusk", "squid"]
+            },
+            {
+              "codepoint": "U+1F9AA",
+              "name": "oyster",
+              "keywords": ["diving", "oyster", "pearl"]
             }
           ]
         },
         {
-          "category": "animal_bug",
+          "category": "animal-bug",
           "contents": [
             {
               "codepoint": "U+1F40C",
               "name": "snail",
-              "keywords": ["snail"]
+              "keywords": [
+                "animal",
+                "escargot",
+                "garden",
+                "nature",
+                "slug",
+                "snail"
+              ]
             },
             {
               "codepoint": "U+1F98B",
@@ -3438,42 +8240,67 @@
             {
               "codepoint": "U+1F41B",
               "name": "bug",
-              "keywords": ["bug", "insect"]
+              "keywords": ["animal", "bug", "garden", "insect"]
             },
             {
               "codepoint": "U+1F41C",
               "name": "ant",
-              "keywords": ["ant", "insect"]
+              "keywords": ["animal", "ant", "garden", "insect"]
             },
             {
               "codepoint": "U+1F41D",
               "name": "honeybee",
-              "keywords": ["bee", "honeybee", "insect"]
+              "keywords": [
+                "animal",
+                "bee",
+                "bumblebee",
+                "honey",
+                "honeybee",
+                "insect",
+                "nature",
+                "spring"
+              ]
             },
             {
               "codepoint": "U+1FAB2",
               "name": "beetle",
-              "keywords": ["beetle", "bug", "insect"]
+              "keywords": ["animal", "beetle", "bug", "insect"]
             },
             {
               "codepoint": "U+1F41E",
               "name": "lady beetle",
-              "keywords": ["beetle", "insect", "lady beetle", "ladybird", "ladybug"]
+              "keywords": [
+                "animal",
+                "beetle",
+                "garden",
+                "insect",
+                "lady",
+                "ladybird",
+                "ladybug",
+                "nature"
+              ]
             },
             {
               "codepoint": "U+1F997",
               "name": "cricket",
-              "keywords": ["cricket", "grasshopper", "Orthoptera"]
+              "keywords": [
+                "animal",
+                "bug",
+                "cricket",
+                "grasshopper",
+                "insect",
+                "Orthoptera"
+              ]
             },
             {
               "codepoint": "U+1FAB3",
               "name": "cockroach",
-              "keywords": ["cockroach", "insect", "pest", "roach"]
+              "keywords": ["animal", "cockroach", "insect", "pest", "roach"]
             },
             {
               "codepoint": "U+1F577",
               "name": "spider",
-              "keywords": ["insect", "spider"]
+              "keywords": ["animal", "insect", "spider"]
             },
             {
               "codepoint": "U+1F578",
@@ -3483,52 +8310,95 @@
             {
               "codepoint": "U+1F982",
               "name": "scorpion",
-              "keywords": ["scorpio", "Scorpio", "scorpion", "zodiac"]
+              "keywords": ["Scorpio", "scorpion", "Scorpius", "zodiac"]
             },
             {
               "codepoint": "U+1F99F",
               "name": "mosquito",
-              "keywords": ["disease", "fever", "malaria", "mosquito", "pest", "virus"]
+              "keywords": [
+                "bite",
+                "disease",
+                "fever",
+                "insect",
+                "malaria",
+                "mosquito",
+                "pest",
+                "virus"
+              ]
             },
             {
               "codepoint": "U+1FAB0",
               "name": "fly",
-              "keywords": ["disease", "fly", "maggot", "pest", "rotting"]
+              "keywords": [
+                "animal",
+                "disease",
+                "fly",
+                "insect",
+                "maggot",
+                "pest",
+                "rotting"
+              ]
             },
             {
               "codepoint": "U+1FAB1",
               "name": "worm",
-              "keywords": ["annelid", "earthworm", "parasite", "worm"]
+              "keywords": ["animal", "annelid", "earthworm", "parasite", "worm"]
             },
             {
               "codepoint": "U+1F9A0",
               "name": "microbe",
-              "keywords": ["amoeba", "bacteria", "microbe", "virus"]
+              "keywords": ["amoeba", "bacteria", "microbe", "science", "virus"]
             }
           ]
         },
         {
-          "category": "plant_flower",
+          "category": "plant-flower",
           "contents": [
             {
               "codepoint": "U+1F490",
               "name": "bouquet",
-              "keywords": ["bouquet", "flower"]
+              "keywords": [
+                "anniversary",
+                "birthday",
+                "bouquet",
+                "date",
+                "flower",
+                "love",
+                "plant",
+                "romance"
+              ]
             },
             {
               "codepoint": "U+1F338",
               "name": "cherry blossom",
-              "keywords": ["blossom", "cherry", "flower"]
+              "keywords": [
+                "blossom",
+                "cherry",
+                "flower",
+                "plant",
+                "spring",
+                "springtime"
+              ]
             },
             {
               "codepoint": "U+1F4AE",
               "name": "white flower",
-              "keywords": ["flower", "white flower"]
+              "keywords": ["flower", "white"]
             },
             {
               "codepoint": "U+1FAB7",
               "name": "lotus",
-              "keywords": ["Buddhism", "flower", "Hinduism", "India", "purity", "Vietnam"]
+              "keywords": [
+                "beauty",
+                "Buddhism",
+                "calm",
+                "flower",
+                "Hinduism",
+                "lotus",
+                "peace",
+                "purity",
+                "serenity"
+              ]
             },
             {
               "codepoint": "U+1F3F5",
@@ -3538,92 +8408,146 @@
             {
               "codepoint": "U+1F339",
               "name": "rose",
-              "keywords": ["flower", "rose"]
+              "keywords": [
+                "beauty",
+                "elegant",
+                "flower",
+                "love",
+                "plant",
+                "red",
+                "rose",
+                "valentine"
+              ]
             },
             {
               "codepoint": "U+1F940",
               "name": "wilted flower",
-              "keywords": ["flower", "wilted"]
+              "keywords": ["dying", "flower", "wilted"]
             },
             {
               "codepoint": "U+1F33A",
               "name": "hibiscus",
-              "keywords": ["flower", "hibiscus"]
+              "keywords": ["flower", "hibiscus", "plant"]
             },
             {
               "codepoint": "U+1F33B",
               "name": "sunflower",
-              "keywords": ["flower", "sun", "sunflower"]
+              "keywords": ["flower", "outdoors", "plant", "sun", "sunflower"]
             },
             {
               "codepoint": "U+1F33C",
               "name": "blossom",
-              "keywords": ["blossom", "flower"]
+              "keywords": [
+                "blossom",
+                "buttercup",
+                "dandelion",
+                "flower",
+                "plant"
+              ]
             },
             {
               "codepoint": "U+1F337",
               "name": "tulip",
-              "keywords": ["flower", "tulip"]
+              "keywords": ["blossom", "flower", "growth", "plant", "tulip"]
             },
             {
               "codepoint": "U+1FABB",
               "name": "hyacinth",
-              "keywords": ["bluebonnet", "flower", "hyacinth", "lavender", "lupine", "snapdragon"]
+              "keywords": [
+                "bloom",
+                "bluebonnet",
+                "flower",
+                "hyacinth",
+                "indigo",
+                "lavender",
+                "lilac",
+                "lupine",
+                "plant",
+                "purple",
+                "shrub",
+                "snapdragon",
+                "spring",
+                "violet"
+              ]
             }
           ]
         },
         {
-          "category": "plant_other",
+          "category": "plant-other",
           "contents": [
             {
               "codepoint": "U+1F331",
               "name": "seedling",
-              "keywords": ["seedling", "young"]
+              "keywords": ["plant", "sapling", "seedling", "sprout", "young"]
             },
             {
               "codepoint": "U+1FAB4",
               "name": "potted plant",
-              "keywords": ["boring", "grow", "house", "nurturing", "plant", "potted plant", "useless"]
+              "keywords": [
+                "decor",
+                "grow",
+                "house",
+                "nurturing",
+                "plant",
+                "pot",
+                "potted"
+              ]
             },
             {
               "codepoint": "U+1F332",
               "name": "evergreen tree",
-              "keywords": ["evergreen tree", "tree"]
+              "keywords": ["christmas", "evergreen", "forest", "pine", "tree"]
             },
             {
               "codepoint": "U+1F333",
               "name": "deciduous tree",
-              "keywords": ["deciduous", "shedding", "tree"]
+              "keywords": [
+                "deciduous",
+                "forest",
+                "green",
+                "habitat",
+                "shedding",
+                "tree"
+              ]
             },
             {
               "codepoint": "U+1F334",
               "name": "palm tree",
-              "keywords": ["palm", "tree"]
+              "keywords": ["beach", "palm", "plant", "tree", "tropical"]
             },
             {
               "codepoint": "U+1F335",
               "name": "cactus",
-              "keywords": ["cactus", "plant"]
+              "keywords": ["cactus", "desert", "drought", "nature", "plant"]
             },
             {
               "codepoint": "U+1F33E",
               "name": "sheaf of rice",
-              "keywords": ["ear", "grain", "rice", "sheaf of rice"]
+              "keywords": ["ear", "grain", "grains", "plant", "rice", "sheaf"]
             },
             {
               "codepoint": "U+1F33F",
               "name": "herb",
-              "keywords": ["herb", "leaf"]
+              "keywords": ["herb", "leaf", "plant"]
             },
             {
               "codepoint": "U+2618",
               "name": "shamrock",
-              "keywords": ["plant", "shamrock"]
+              "keywords": ["irish", "plant", "shamrock"]
             },
             {
               "codepoint": "U+1F340",
               "name": "four leaf clover",
-              "keywords": ["4", "clover", "four", "four-leaf clover", "leaf"]
+              "keywords": [
+                "4",
+                "clover",
+                "four",
+                "four-leaf",
+                "irish",
+                "leaf",
+                "lucky",
+                "plant"
+              ]
             },
             {
               "codepoint": "U+1F341",
@@ -3633,22 +8557,43 @@
             {
               "codepoint": "U+1F342",
               "name": "fallen leaf",
-              "keywords": ["fallen leaf", "falling", "leaf"]
+              "keywords": ["autumn", "fall", "fallen", "falling", "leaf"]
             },
             {
               "codepoint": "U+1F343",
               "name": "leaf fluttering in wind",
-              "keywords": ["blow", "flutter", "leaf", "leaf fluttering in wind", "wind"]
+              "keywords": ["blow", "flutter", "fluttering", "leaf", "wind"]
             },
             {
               "codepoint": "U+1FAB9",
               "name": "empty nest",
-              "keywords": ["nesting"]
+              "keywords": ["branch", "empty", "home", "nest", "nesting"]
             },
             {
               "codepoint": "U+1FABA",
               "name": "nest with eggs",
-              "keywords": ["nesting"]
+              "keywords": ["bird", "branch", "egg", "eggs", "nest", "nesting"]
+            },
+            {
+              "codepoint": "U+1F344",
+              "name": "mushroom",
+              "keywords": ["fungus", "mushroom", "toadstool"]
+            },
+            {
+              "codepoint": "U+1FABE",
+              "name": "leafless tree",
+              "keywords": [
+                "bare",
+                "barren",
+                "branches",
+                "dead",
+                "drought",
+                "leafless",
+                "tree",
+                "trunk",
+                "winter",
+                "wood"
+              ]
             }
           ]
         }
@@ -3658,17 +8603,17 @@
       "category": "Food & Drink",
       "contents": [
         {
-          "category": "food_fruit",
+          "category": "food-fruit",
           "contents": [
             {
               "codepoint": "U+1F347",
               "name": "grapes",
-              "keywords": ["fruit", "grape", "grapes"]
+              "keywords": ["Dionysus", "fruit", "grape", "grapes"]
             },
             {
               "codepoint": "U+1F348",
               "name": "melon",
-              "keywords": ["fruit", "melon"]
+              "keywords": ["cantaloupe", "fruit", "melon"]
             },
             {
               "codepoint": "U+1F349",
@@ -3678,32 +8623,70 @@
             {
               "codepoint": "U+1F34A",
               "name": "tangerine",
-              "keywords": ["fruit", "orange", "tangerine"]
+              "keywords": [
+                "c",
+                "citrus",
+                "fruit",
+                "nectarine",
+                "orange",
+                "tangerine",
+                "vitamin"
+              ]
             },
             {
               "codepoint": "U+1F34B",
               "name": "lemon",
-              "keywords": ["citrus", "fruit", "lemon"]
+              "keywords": ["citrus", "fruit", "lemon", "sour"]
+            },
+            {
+              "codepoint": "U+1F34B U+200D U+1F7E9",
+              "name": "lime",
+              "keywords": [
+                "acidity",
+                "citrus",
+                "cocktail",
+                "fruit",
+                "garnish",
+                "key",
+                "lime",
+                "margarita",
+                "mojito",
+                "refreshing",
+                "salsa",
+                "sour",
+                "tangy",
+                "tequila",
+                "tropical",
+                "zest"
+              ]
             },
             {
               "codepoint": "U+1F34C",
               "name": "banana",
-              "keywords": ["banana", "fruit"]
+              "keywords": ["banana", "fruit", "potassium"]
             },
             {
               "codepoint": "U+1F34D",
               "name": "pineapple",
-              "keywords": ["fruit", "pineapple"]
+              "keywords": ["colada", "fruit", "pina", "pineapple", "tropical"]
             },
             {
               "codepoint": "U+1F96D",
               "name": "mango",
-              "keywords": ["fruit", "mango", "tropical"]
+              "keywords": ["food", "fruit", "mango", "tropical"]
             },
             {
               "codepoint": "U+1F34E",
               "name": "red apple",
-              "keywords": ["apple", "fruit", "red"]
+              "keywords": [
+                "apple",
+                "diet",
+                "food",
+                "fruit",
+                "health",
+                "red",
+                "ripe"
+              ]
             },
             {
               "codepoint": "U+1F34F",
@@ -3733,7 +8716,16 @@
             {
               "codepoint": "U+1FAD0",
               "name": "blueberries",
-              "keywords": ["berry", "bilberry", "blue", "blueberries", "blueberry"]
+              "keywords": [
+                "berries",
+                "berry",
+                "bilberry",
+                "blue",
+                "blueberries",
+                "blueberry",
+                "food",
+                "fruit"
+              ]
             },
             {
               "codepoint": "U+1F95D",
@@ -3743,7 +8735,7 @@
             {
               "codepoint": "U+1F345",
               "name": "tomato",
-              "keywords": ["fruit", "tomato", "vegetable"]
+              "keywords": ["food", "fruit", "tomato", "vegetable"]
             },
             {
               "codepoint": "U+1FAD2",
@@ -3753,12 +8745,12 @@
             {
               "codepoint": "U+1F965",
               "name": "coconut",
-              "keywords": ["coconut", "palm", "piña colada"]
+              "keywords": ["coconut", "colada", "palm", "piña"]
             }
           ]
         },
         {
-          "category": "food_vegetable",
+          "category": "food-vegetable",
           "contents": [
             {
               "codepoint": "U+1F951",
@@ -3783,7 +8775,7 @@
             {
               "codepoint": "U+1F33D",
               "name": "ear of corn",
-              "keywords": ["corn", "ear", "ear of corn", "maize", "maze"]
+              "keywords": ["corn", "crops", "ear", "farm", "maize", "maze"]
             },
             {
               "codepoint": "U+1F336",
@@ -3793,7 +8785,7 @@
             {
               "codepoint": "U+1FAD1",
               "name": "bell pepper",
-              "keywords": ["bell pepper", "capsicum", "pepper", "vegetable"]
+              "keywords": ["bell", "capsicum", "food", "pepper", "vegetable"]
             },
             {
               "codepoint": "U+1F952",
@@ -3803,12 +8795,22 @@
             {
               "codepoint": "U+1F96C",
               "name": "leafy green",
-              "keywords": ["bok choy", "cabbage", "kale", "leafy green", "lettuce"]
+              "keywords": [
+                "bok",
+                "burgers",
+                "cabbage",
+                "choy",
+                "green",
+                "kale",
+                "leafy",
+                "lettuce",
+                "salad"
+              ]
             },
             {
               "codepoint": "U+1F966",
               "name": "broccoli",
-              "keywords": ["broccoli", "wild cabbage"]
+              "keywords": ["broccoli", "cabbage", "wild"]
             },
             {
               "codepoint": "U+1F9C4",
@@ -3821,11 +8823,6 @@
               "keywords": ["flavoring", "onion"]
             },
             {
-              "codepoint": "U+1F344",
-              "name": "mushroom",
-              "keywords": ["mushroom", "toadstool"]
-            },
-            {
               "codepoint": "U+1F95C",
               "name": "peanuts",
               "keywords": ["food", "nut", "peanut", "peanuts", "vegetable"]
@@ -3833,37 +8830,109 @@
             {
               "codepoint": "U+1FAD8",
               "name": "beans",
-              "keywords": ["food", "kidney", "legume"]
+              "keywords": ["beans", "food", "kidney", "legume", "small"]
             },
             {
               "codepoint": "U+1F330",
               "name": "chestnut",
-              "keywords": ["chestnut", "plant"]
+              "keywords": ["almond", "chestnut", "plant"]
             },
             {
               "codepoint": "U+1FADA",
               "name": "ginger root",
-              "keywords": ["beer", "ginger root", "root", "spice"]
+              "keywords": [
+                "beer",
+                "ginger",
+                "health",
+                "herb",
+                "natural",
+                "root",
+                "spice"
+              ]
             },
             {
               "codepoint": "U+1FADB",
               "name": "pea pod",
-              "keywords": ["beans", "edamame", "legume", "pea", "pod", "vegetable"]
+              "keywords": [
+                "beans",
+                "beanstalk",
+                "edamame",
+                "legume",
+                "pea",
+                "pod",
+                "soybean",
+                "vegetable",
+                "veggie"
+              ]
+            },
+            {
+              "codepoint": "U+1F344 U+200D U+1F7EB",
+              "name": "brown mushroom",
+              "keywords": [
+                "food",
+                "fungi",
+                "fungus",
+                "mushroom",
+                "nature",
+                "pizza",
+                "portobello",
+                "shiitake",
+                "shroom",
+                "spore",
+                "sprout",
+                "toppings",
+                "truffle",
+                "vegetable",
+                "vegetarian",
+                "veggie"
+              ]
+            },
+            {
+              "codepoint": "U+1FADC",
+              "name": "root vegetable",
+              "keywords": [
+                "beet",
+                "food",
+                "garden",
+                "radish",
+                "root",
+                "salad",
+                "turnip",
+                "vegetable",
+                "vegetarian"
+              ]
             }
           ]
         },
         {
-          "category": "food_prepared",
+          "category": "food-prepared",
           "contents": [
             {
               "codepoint": "U+1F35E",
               "name": "bread",
-              "keywords": ["bread", "loaf"]
+              "keywords": [
+                "bread",
+                "carbs",
+                "food",
+                "grain",
+                "loaf",
+                "restaurant",
+                "toast",
+                "wheat"
+              ]
             },
             {
               "codepoint": "U+1F950",
               "name": "croissant",
-              "keywords": ["bread", "breakfast", "croissant", "food", "french", "roll"]
+              "keywords": [
+                "bread",
+                "breakfast",
+                "crescent",
+                "croissant",
+                "food",
+                "french",
+                "roll"
+              ]
             },
             {
               "codepoint": "U+1F956",
@@ -3873,22 +8942,38 @@
             {
               "codepoint": "U+1FAD3",
               "name": "flatbread",
-              "keywords": ["arepa", "flatbread", "lavash", "naan", "pita"]
+              "keywords": [
+                "arepa",
+                "bread",
+                "flatbread",
+                "food",
+                "gordita",
+                "lavash",
+                "naan",
+                "pita"
+              ]
             },
             {
               "codepoint": "U+1F968",
               "name": "pretzel",
-              "keywords": ["pretzel", "twisted", "convoluted"]
+              "keywords": ["convoluted", "pretzel", "twisted"]
             },
             {
               "codepoint": "U+1F96F",
               "name": "bagel",
-              "keywords": ["bagel", "bakery", "breakfast", "schmear"]
+              "keywords": ["bagel", "bakery", "bread", "breakfast", "schmear"]
             },
             {
               "codepoint": "U+1F95E",
               "name": "pancakes",
-              "keywords": ["breakfast", "crêpe", "food", "hotcake", "pancake", "pancakes"]
+              "keywords": [
+                "breakfast",
+                "crêpe",
+                "food",
+                "hotcake",
+                "pancake",
+                "pancakes"
+              ]
             },
             {
               "codepoint": "U+1F9C7",
@@ -3898,22 +8983,38 @@
             {
               "codepoint": "U+1F9C0",
               "name": "cheese wedge",
-              "keywords": ["cheese", "cheese wedge"]
+              "keywords": ["cheese", "wedge"]
             },
             {
               "codepoint": "U+1F356",
               "name": "meat on bone",
-              "keywords": ["bone", "meat", "meat on bone"]
+              "keywords": ["bone", "meat"]
             },
             {
               "codepoint": "U+1F357",
               "name": "poultry leg",
-              "keywords": ["bone", "chicken", "drumstick", "leg", "poultry"]
+              "keywords": [
+                "bone",
+                "chicken",
+                "drumstick",
+                "hungry",
+                "leg",
+                "poultry",
+                "turkey"
+              ]
             },
             {
               "codepoint": "U+1F969",
               "name": "cut of meat",
-              "keywords": ["chop", "cut of meat", "lambchop", "porkchop", "steak"]
+              "keywords": [
+                "chop",
+                "cut",
+                "lambchop",
+                "meat",
+                "porkchop",
+                "red",
+                "steak"
+              ]
             },
             {
               "codepoint": "U+1F953",
@@ -3923,22 +9024,36 @@
             {
               "codepoint": "U+1F354",
               "name": "hamburger",
-              "keywords": ["burger", "hamburger"]
+              "keywords": [
+                "burger",
+                "eat",
+                "fast",
+                "food",
+                "hamburger",
+                "hungry"
+              ]
             },
             {
               "codepoint": "U+1F35F",
               "name": "french fries",
-              "keywords": ["french", "fries"]
+              "keywords": ["fast", "food", "french", "fries"]
             },
             {
               "codepoint": "U+1F355",
               "name": "pizza",
-              "keywords": ["cheese", "pizza", "slice"]
+              "keywords": [
+                "cheese",
+                "food",
+                "hungry",
+                "pepperoni",
+                "pizza",
+                "slice"
+              ]
             },
             {
               "codepoint": "U+1F32D",
               "name": "hot dog",
-              "keywords": ["frankfurter", "hot dog", "hotdog", "sausage"]
+              "keywords": ["dog", "frankfurter", "hot", "hotdog", "sausage"]
             },
             {
               "codepoint": "U+1F96A",
@@ -3958,12 +9073,19 @@
             {
               "codepoint": "U+1FAD4",
               "name": "tamale",
-              "keywords": ["mexican", "tamale", "wrapped"]
+              "keywords": ["food", "mexican", "pamonha", "tamale", "wrapped"]
             },
             {
               "codepoint": "U+1F959",
               "name": "stuffed flatbread",
-              "keywords": ["falafel", "flatbread", "food", "gyro", "kebab", "stuffed"]
+              "keywords": [
+                "falafel",
+                "flatbread",
+                "food",
+                "gyro",
+                "kebab",
+                "stuffed"
+              ]
             },
             {
               "codepoint": "U+1F9C6",
@@ -3978,27 +9100,56 @@
             {
               "codepoint": "U+1F373",
               "name": "cooking",
-              "keywords": ["breakfast", "cooking", "egg", "frying", "pan"]
+              "keywords": [
+                "breakfast",
+                "cooking",
+                "easy",
+                "egg",
+                "fry",
+                "frying",
+                "over",
+                "pan",
+                "restaurant",
+                "side",
+                "sunny",
+                "up"
+              ]
             },
             {
               "codepoint": "U+1F958",
               "name": "shallow pan of food",
-              "keywords": ["casserole", "food", "paella", "pan", "shallow", "shallow pan of food"]
+              "keywords": ["casserole", "food", "paella", "pan", "shallow"]
             },
             {
               "codepoint": "U+1F372",
               "name": "pot of food",
-              "keywords": ["pot", "pot of food", "stew"]
+              "keywords": ["food", "pot", "soup", "stew"]
             },
             {
               "codepoint": "U+1FAD5",
               "name": "fondue",
-              "keywords": ["cheese", "chocolate", "fondue", "melted", "pot", "Swiss"]
+              "keywords": [
+                "cheese",
+                "chocolate",
+                "fondue",
+                "food",
+                "melted",
+                "pot",
+                "ski"
+              ]
             },
             {
               "codepoint": "U+1F963",
               "name": "bowl with spoon",
-              "keywords": ["bowl with spoon", "breakfast", "cereal", "congee", "oatmeal", "porridge"]
+              "keywords": [
+                "bowl",
+                "breakfast",
+                "cereal",
+                "congee",
+                "oatmeal",
+                "porridge",
+                "spoon"
+              ]
             },
             {
               "codepoint": "U+1F957",
@@ -4008,7 +9159,7 @@
             {
               "codepoint": "U+1F37F",
               "name": "popcorn",
-              "keywords": ["popcorn"]
+              "keywords": ["corn", "movie", "pop", "popcorn"]
             },
             {
               "codepoint": "U+1F9C8",
@@ -4018,67 +9169,99 @@
             {
               "codepoint": "U+1F9C2",
               "name": "salt",
-              "keywords": ["condiment", "salt", "shaker"]
+              "keywords": [
+                "condiment",
+                "flavor",
+                "mad",
+                "salt",
+                "salty",
+                "shaker",
+                "taste",
+                "upset"
+              ]
             },
             {
               "codepoint": "U+1F96B",
               "name": "canned food",
-              "keywords": ["can", "canned food"]
+              "keywords": ["can", "canned", "food"]
             }
           ]
         },
         {
-          "category": "food_asian",
+          "category": "food-asian",
           "contents": [
             {
               "codepoint": "U+1F371",
               "name": "bento box",
-              "keywords": ["bento", "box"]
+              "keywords": ["bento", "box", "food"]
             },
             {
               "codepoint": "U+1F358",
               "name": "rice cracker",
-              "keywords": ["cracker", "rice"]
+              "keywords": ["cracker", "food", "rice"]
             },
             {
               "codepoint": "U+1F359",
               "name": "rice ball",
-              "keywords": ["ball", "Japanese", "rice"]
+              "keywords": ["ball", "food", "Japanese", "rice"]
             },
             {
               "codepoint": "U+1F35A",
               "name": "cooked rice",
-              "keywords": ["cooked", "rice"]
+              "keywords": ["cooked", "food", "rice"]
             },
             {
               "codepoint": "U+1F35B",
               "name": "curry rice",
-              "keywords": ["curry", "rice"]
+              "keywords": ["curry", "food", "rice"]
             },
             {
               "codepoint": "U+1F35C",
               "name": "steaming bowl",
-              "keywords": ["bowl", "noodle", "ramen", "steaming"]
+              "keywords": [
+                "bowl",
+                "chopsticks",
+                "food",
+                "noodle",
+                "pho",
+                "ramen",
+                "soup",
+                "steaming"
+              ]
             },
             {
               "codepoint": "U+1F35D",
               "name": "spaghetti",
-              "keywords": ["pasta", "spaghetti"]
+              "keywords": [
+                "food",
+                "meatballs",
+                "pasta",
+                "restaurant",
+                "spaghetti"
+              ]
             },
             {
               "codepoint": "U+1F360",
               "name": "roasted sweet potato",
-              "keywords": ["potato", "roasted", "sweet"]
+              "keywords": ["food", "potato", "roasted", "sweet"]
             },
             {
               "codepoint": "U+1F362",
               "name": "oden",
-              "keywords": ["kebab", "oden", "seafood", "skewer", "stick"]
+              "keywords": [
+                "food",
+                "kebab",
+                "oden",
+                "restaurant",
+                "seafood",
+                "skewer",
+                "stick"
+              ]
             },
             {
               "codepoint": "U+1F363",
               "name": "sushi",
-              "keywords": ["sushi"]
+              "keywords": ["food", "sushi"]
             },
             {
               "codepoint": "U+1F364",
@@ -4088,127 +9271,207 @@
             {
               "codepoint": "U+1F365",
               "name": "fish cake with swirl",
-              "keywords": ["cake", "fish", "fish cake with swirl", "pastry", "swirl"]
+              "keywords": [
+                "cake",
+                "fish",
+                "food",
+                "pastry",
+                "restaurant",
+                "swirl"
+              ]
             },
             {
               "codepoint": "U+1F96E",
               "name": "moon cake",
-              "keywords": ["autumn", "festival", "moon cake", "yuèbǐng"]
+              "keywords": ["autumn", "cake", "festival", "moon", "yuèbǐng"]
             },
             {
               "codepoint": "U+1F361",
               "name": "dango",
-              "keywords": ["dango", "dessert", "Japanese", "skewer", "stick", "sweet"]
+              "keywords": [
+                "dango",
+                "dessert",
+                "Japanese",
+                "skewer",
+                "stick",
+                "sweet"
+              ]
             },
             {
               "codepoint": "U+1F95F",
               "name": "dumpling",
-              "keywords": ["dumpling", "empanada", "gyōza", "jiaozi", "pierogi", "potsticker"]
+              "keywords": [
+                "dumpling",
+                "empanada",
+                "gyōza",
+                "jiaozi",
+                "pierogi",
+                "potsticker"
+              ]
             },
             {
               "codepoint": "U+1F960",
               "name": "fortune cookie",
-              "keywords": ["fortune cookie", "prophecy"]
+              "keywords": ["cookie", "fortune", "prophecy"]
             },
             {
               "codepoint": "U+1F961",
               "name": "takeout box",
-              "keywords": ["oyster pail", "takeout box"]
+              "keywords": [
+                "box",
+                "chopsticks",
+                "delivery",
+                "food",
+                "oyster",
+                "pail",
+                "takeout"
+              ]
             }
           ]
         },
         {
-          "category": "food_marine",
-          "contents": [
-            {
-              "codepoint": "U+1F980",
-              "name": "crab",
-              "keywords": ["Cancer", "crab", "zodiac"]
-            },
-            {
-              "codepoint": "U+1F99E",
-              "name": "lobster",
-              "keywords": ["bisque", "claws", "lobster", "seafood"]
-            },
-            {
-              "codepoint": "U+1F990",
-              "name": "shrimp",
-              "keywords": ["food", "shellfish", "shrimp", "small"]
-            },
-            {
-              "codepoint": "U+1F991",
-              "name": "squid",
-              "keywords": ["food", "molusc", "squid"]
-            },
-            {
-              "codepoint": "U+1F9AA",
-              "name": "oyster",
-              "keywords": ["diving", "oyster", "pearl"]
-            }
-          ]
-        },
-        {
-          "category": "food_sweet",
+          "category": "food-sweet",
           "contents": [
             {
               "codepoint": "U+1F366",
               "name": "soft ice cream",
-              "keywords": ["cream", "dessert", "ice", "icecream", "soft", "sweet"]
+              "keywords": [
+                "cream",
+                "dessert",
+                "food",
+                "ice",
+                "icecream",
+                "restaurant",
+                "serve",
+                "soft",
+                "sweet"
+              ]
             },
             {
               "codepoint": "U+1F367",
               "name": "shaved ice",
-              "keywords": ["dessert", "ice", "shaved", "sweet"]
+              "keywords": ["dessert", "ice", "restaurant", "shaved", "sweet"]
             },
             {
               "codepoint": "U+1F368",
               "name": "ice cream",
-              "keywords": ["cream", "dessert", "ice", "sweet"]
+              "keywords": [
+                "cream",
+                "dessert",
+                "food",
+                "ice",
+                "restaurant",
+                "sweet"
+              ]
             },
             {
               "codepoint": "U+1F369",
               "name": "doughnut",
-              "keywords": ["breakfast", "dessert", "donut", "doughnut", "sweet"]
+              "keywords": [
+                "breakfast",
+                "dessert",
+                "donut",
+                "doughnut",
+                "food",
+                "sweet"
+              ]
             },
             {
               "codepoint": "U+1F36A",
               "name": "cookie",
-              "keywords": ["cookie", "dessert", "sweet"]
+              "keywords": ["chip", "chocolate", "cookie", "dessert", "sweet"]
             },
             {
               "codepoint": "U+1F382",
               "name": "birthday cake",
-              "keywords": ["birthday", "cake", "celebration", "dessert", "pastry", "sweet"]
+              "keywords": [
+                "bday",
+                "birthday",
+                "cake",
+                "celebration",
+                "dessert",
+                "happy",
+                "pastry",
+                "sweet"
+              ]
             },
             {
               "codepoint": "U+1F370",
               "name": "shortcake",
-              "keywords": ["cake", "dessert", "pastry", "shortcake", "slice", "sweet"]
+              "keywords": [
+                "cake",
+                "dessert",
+                "pastry",
+                "shortcake",
+                "slice",
+                "sweet"
+              ]
             },
             {
               "codepoint": "U+1F9C1",
               "name": "cupcake",
-              "keywords": ["bakery", "cupcake", "sweet"]
+              "keywords": [
+                "bakery",
+                "cupcake",
+                "dessert",
+                "sprinkles",
+                "sugar",
+                "sweet",
+                "treat"
+              ]
             },
             {
               "codepoint": "U+1F967",
               "name": "pie",
-              "keywords": ["filling", "pastry", "pie", "fruit", "meat"]
+              "keywords": [
+                "apple",
+                "filling",
+                "fruit",
+                "meat",
+                "pastry",
+                "pie",
+                "pumpkin",
+                "slice"
+              ]
             },
             {
               "codepoint": "U+1F36B",
               "name": "chocolate bar",
-              "keywords": ["bar", "chocolate", "dessert", "sweet"]
+              "keywords": [
+                "bar",
+                "candy",
+                "chocolate",
+                "dessert",
+                "halloween",
+                "sweet",
+                "tooth"
+              ]
             },
             {
               "codepoint": "U+1F36C",
               "name": "candy",
-              "keywords": ["candy", "dessert", "sweet"]
+              "keywords": [
+                "candy",
+                "cavities",
+                "dessert",
+                "halloween",
+                "restaurant",
+                "sweet",
+                "tooth",
+                "wrapper"
+              ]
             },
             {
               "codepoint": "U+1F36D",
               "name": "lollipop",
-              "keywords": ["candy", "dessert", "lollipop", "sweet"]
+              "keywords": [
+                "candy",
+                "dessert",
+                "food",
+                "lollipop",
+                "restaurant",
+                "sweet"
+              ]
             },
             {
               "codepoint": "U+1F36E",
@@ -4218,7 +9481,16 @@
             {
               "codepoint": "U+1F36F",
               "name": "honey pot",
-              "keywords": ["honey", "honeypot", "pot", "sweet"]
+              "keywords": [
+                "barrel",
+                "bear",
+                "food",
+                "honey",
+                "honeypot",
+                "jar",
+                "pot",
+                "sweet"
+              ]
             }
           ]
         },
@@ -4228,87 +9500,226 @@
             {
               "codepoint": "U+1F37C",
               "name": "baby bottle",
-              "keywords": ["baby", "bottle", "drink", "milk"]
+              "keywords": [
+                "babies",
+                "baby",
+                "birth",
+                "born",
+                "bottle",
+                "drink",
+                "infant",
+                "milk",
+                "newborn"
+              ]
             },
             {
               "codepoint": "U+1F95B",
               "name": "glass of milk",
-              "keywords": ["drink", "glass", "glass of milk", "milk"]
+              "keywords": ["drink", "glass", "milk"]
             },
             {
               "codepoint": "U+2615",
               "name": "hot beverage",
-              "keywords": ["beverage", "coffee", "drink", "hot", "steaming", "tea"]
+              "keywords": [
+                "beverage",
+                "cafe",
+                "caffeine",
+                "chai",
+                "coffee",
+                "drink",
+                "hot",
+                "morning",
+                "steaming",
+                "tea"
+              ]
             },
             {
               "codepoint": "U+1FAD6",
               "name": "teapot",
-              "keywords": ["drink", "pot", "tea", "teapot"]
+              "keywords": ["brew", "drink", "food", "pot", "tea", "teapot"]
             },
             {
               "codepoint": "U+1F375",
               "name": "teacup without handle",
-              "keywords": ["beverage", "cup", "drink", "tea", "teacup", "teacup without handle"]
+              "keywords": [
+                "beverage",
+                "cup",
+                "drink",
+                "handle",
+                "oolong",
+                "tea",
+                "teacup"
+              ]
             },
             {
               "codepoint": "U+1F376",
               "name": "sake",
-              "keywords": ["bar", "beverage", "bottle", "cup", "drink", "sake"]
+              "keywords": [
+                "bar",
+                "beverage",
+                "bottle",
+                "cup",
+                "drink",
+                "restaurant",
+                "sake"
+              ]
             },
             {
               "codepoint": "U+1F37E",
               "name": "bottle with popping cork",
-              "keywords": ["bar", "bottle", "bottle with popping cork", "cork", "drink", "popping"]
+              "keywords": ["bar", "bottle", "cork", "drink", "popping"]
             },
             {
               "codepoint": "U+1F377",
               "name": "wine glass",
-              "keywords": ["bar", "beverage", "drink", "glass", "wine"]
+              "keywords": [
+                "alcohol",
+                "bar",
+                "beverage",
+                "booze",
+                "club",
+                "drink",
+                "drinking",
+                "drinks",
+                "glass",
+                "restaurant",
+                "wine"
+              ]
             },
             {
               "codepoint": "U+1F378",
               "name": "cocktail glass",
-              "keywords": ["bar", "cocktail", "drink", "glass"]
+              "keywords": [
+                "alcohol",
+                "bar",
+                "booze",
+                "club",
+                "cocktail",
+                "drink",
+                "drinking",
+                "drinks",
+                "glass",
+                "mad",
+                "martini",
+                "men"
+              ]
             },
             {
               "codepoint": "U+1F379",
               "name": "tropical drink",
-              "keywords": ["bar", "drink", "tropical"]
+              "keywords": [
+                "alcohol",
+                "bar",
+                "booze",
+                "club",
+                "cocktail",
+                "drink",
+                "drinking",
+                "drinks",
+                "drunk",
+                "mai",
+                "party",
+                "tai",
+                "tropical",
+                "tropics"
+              ]
             },
             {
               "codepoint": "U+1F37A",
               "name": "beer mug",
-              "keywords": ["bar", "beer", "drink", "mug"]
+              "keywords": [
+                "alcohol",
+                "ale",
+                "bar",
+                "beer",
+                "booze",
+                "drink",
+                "drinking",
+                "drinks",
+                "mug",
+                "octoberfest",
+                "oktoberfest",
+                "pint",
+                "stein",
+                "summer"
+              ]
             },
             {
               "codepoint": "U+1F37B",
               "name": "clinking beer mugs",
-              "keywords": ["bar", "beer", "clink", "clinking beer mugs", "drink", "mug"]
+              "keywords": [
+                "alcohol",
+                "bar",
+                "beer",
+                "booze",
+                "bottoms",
+                "cheers",
+                "clink",
+                "clinking",
+                "drinking",
+                "drinks",
+                "mugs"
+              ]
             },
             {
               "codepoint": "U+1F942",
               "name": "clinking glasses",
-              "keywords": ["celebrate", "clink", "clinking glasses", "drink", "glass"]
+              "keywords": [
+                "celebrate",
+                "clink",
+                "clinking",
+                "drink",
+                "glass",
+                "glasses"
+              ]
             },
             {
               "codepoint": "U+1F943",
               "name": "tumbler glass",
-              "keywords": ["glass", "liquor", "shot", "tumbler", "whisky"]
+              "keywords": [
+                "glass",
+                "liquor",
+                "scotch",
+                "shot",
+                "tumbler",
+                "whiskey",
+                "whisky"
+              ]
             },
             {
               "codepoint": "U+1FAD7",
               "name": "pouring liquid",
-              "keywords": ["drink", "empty", "glass", "spill"]
+              "keywords": [
+                "accident",
+                "drink",
+                "empty",
+                "glass",
+                "liquid",
+                "oops",
+                "pour",
+                "pouring",
+                "spill",
+                "water"
+              ]
             },
             {
               "codepoint": "U+1F964",
               "name": "cup with straw",
-              "keywords": ["cup with straw", "juice", "soda", "malt", "soft drink", "water"]
+              "keywords": [
+                "cup",
+                "drink",
+                "juice",
+                "malt",
+                "soda",
+                "soft",
+                "straw",
+                "water"
+              ]
             },
             {
               "codepoint": "U+1F9CB",
               "name": "bubble tea",
-              "keywords": ["bubble", "milk", "pearl", "tea"]
+              "keywords": ["boba", "bubble", "food", "milk", "pearl", "tea"]
             },
             {
               "codepoint": "U+1F9C3",
@@ -4323,7 +9734,7 @@
             {
               "codepoint": "U+1F9CA",
               "name": "ice",
-              "keywords": ["cold", "ice", "ice cube", "iceberg"]
+              "keywords": ["cold", "cube", "ice", "iceberg"]
             }
           ]
         },
@@ -4338,32 +9749,74 @@
             {
               "codepoint": "U+1F37D",
               "name": "fork and knife with plate",
-              "keywords": ["cooking", "fork", "fork and knife with plate", "knife", "plate"]
+              "keywords": ["cooking", "dinner", "eat", "fork", "knife", "plate"]
             },
             {
               "codepoint": "U+1F374",
               "name": "fork and knife",
-              "keywords": ["cooking", "cutlery", "fork", "fork and knife", "knife"]
+              "keywords": [
+                "breakfast",
+                "breaky",
+                "cooking",
+                "cutlery",
+                "delicious",
+                "dinner",
+                "eat",
+                "feed",
+                "food",
+                "fork",
+                "hungry",
+                "knife",
+                "lunch",
+                "restaurant",
+                "yum",
+                "yummy"
+              ]
             },
             {
               "codepoint": "U+1F944",
               "name": "spoon",
-              "keywords": ["spoon", "tableware"]
+              "keywords": ["eat", "spoon", "tableware"]
             },
             {
               "codepoint": "U+1F52A",
               "name": "kitchen knife",
-              "keywords": ["cooking", "hocho", "kitchen knife", "knife", "tool", "weapon"]
+              "keywords": [
+                "chef",
+                "cooking",
+                "hocho",
+                "kitchen",
+                "knife",
+                "tool",
+                "weapon"
+              ]
             },
             {
               "codepoint": "U+1FAD9",
               "name": "jar",
-              "keywords": ["condiment", "container", "empty", "sauce", "store"]
+              "keywords": [
+                "condiment",
+                "container",
+                "empty",
+                "jar",
+                "nothing",
+                "sauce",
+                "store"
+              ]
             },
             {
               "codepoint": "U+1F3FA",
               "name": "amphora",
-              "keywords": ["amphora", "Aquarius", "cooking", "drink", "jug", "zodiac"]
+              "keywords": [
+                "amphora",
+                "Aquarius",
+                "cooking",
+                "drink",
+                "jug",
+                "tool",
+                "weapon",
+                "zodiac"
+              ]
             }
           ]
         }
@@ -4373,27 +9826,51 @@
       "category": "Travel & Places",
       "contents": [
         {
-          "category": "place_map",
+          "category": "place-map",
           "contents": [
             {
               "codepoint": "U+1F30D",
               "name": "globe showing Europe-Africa",
-              "keywords": ["Africa", "earth", "Europe", "globe", "globe showing Europe-Africa", "world"]
+              "keywords": [
+                "Africa",
+                "earth",
+                "Europe",
+                "Europe-Africa",
+                "globe",
+                "showing",
+                "world"
+              ]
             },
             {
               "codepoint": "U+1F30E",
               "name": "globe showing Americas",
-              "keywords": ["Americas", "earth", "globe", "globe showing Americas", "world"]
+              "keywords": ["Americas", "earth", "globe", "showing", "world"]
             },
             {
               "codepoint": "U+1F30F",
               "name": "globe showing Asia-Australia",
-              "keywords": ["Asia", "Australia", "earth", "globe", "globe showing Asia-Australia", "world"]
+              "keywords": [
+                "Asia",
+                "Asia-Australia",
+                "Australia",
+                "earth",
+                "globe",
+                "showing",
+                "world"
+              ]
             },
             {
               "codepoint": "U+1F310",
               "name": "globe with meridians",
-              "keywords": ["earth", "globe", "globe with meridians", "meridians", "world"]
+              "keywords": [
+                "earth",
+                "globe",
+                "internet",
+                "meridians",
+                "web",
+                "world",
+                "worldwide"
+              ]
             },
             {
               "codepoint": "U+1F5FA",
@@ -4403,22 +9880,28 @@
             {
               "codepoint": "U+1F5FE",
               "name": "map of Japan",
-              "keywords": ["Japan", "map", "map of Japan"]
+              "keywords": ["Japan", "map"]
             },
             {
               "codepoint": "U+1F9ED",
               "name": "compass",
-              "keywords": ["compass", "magnetic", "navigation", "orienteering"]
+              "keywords": [
+                "compass",
+                "direction",
+                "magnetic",
+                "navigation",
+                "orienteering"
+              ]
             }
           ]
         },
         {
-          "category": "place_geographic",
+          "category": "place-geographic",
           "contents": [
             {
               "codepoint": "U+1F3D4",
               "name": "snow-capped mountain",
-              "keywords": ["cold", "mountain", "snow", "snow-capped mountain"]
+              "keywords": ["cold", "mountain", "snow", "snow-capped"]
             },
             {
               "codepoint": "U+26F0",
@@ -4428,12 +9911,12 @@
             {
               "codepoint": "U+1F30B",
               "name": "volcano",
-              "keywords": ["eruption", "mountain", "volcano"]
+              "keywords": ["eruption", "mountain", "nature", "volcano"]
             },
             {
               "codepoint": "U+1F5FB",
               "name": "mount fuji",
-              "keywords": ["fuji", "mount fuji", "mountain"]
+              "keywords": ["fuji", "mount", "mountain", "nature"]
             },
             {
               "codepoint": "U+1F3D5",
@@ -4443,7 +9926,7 @@
             {
               "codepoint": "U+1F3D6",
               "name": "beach with umbrella",
-              "keywords": ["beach", "beach with umbrella", "umbrella"]
+              "keywords": ["beach", "umbrella"]
             },
             {
               "codepoint": "U+1F3DC",
@@ -4458,12 +9941,12 @@
             {
               "codepoint": "U+1F3DE",
               "name": "national park",
-              "keywords": ["national park", "park"]
+              "keywords": ["national", "park"]
             }
           ]
         },
         {
-          "category": "place_building",
+          "category": "place-building",
           "contents": [
             {
               "codepoint": "U+1F3DF",
@@ -4473,12 +9956,12 @@
             {
               "codepoint": "U+1F3DB",
               "name": "classical building",
-              "keywords": ["classical", "classical building"]
+              "keywords": ["building", "classical"]
             },
             {
               "codepoint": "U+1F3D7",
               "name": "building construction",
-              "keywords": ["building construction", "construction"]
+              "keywords": ["building", "construction", "crane"]
             },
             {
               "codepoint": "U+1F9F1",
@@ -4488,7 +9971,14 @@
             {
               "codepoint": "U+1FAA8",
               "name": "rock",
-              "keywords": ["boulder", "heavy", "rock", "solid", "stone"]
+              "keywords": [
+                "boulder",
+                "heavy",
+                "rock",
+                "solid",
+                "stone",
+                "tough"
+              ]
             },
             {
               "codepoint": "U+1FAB5",
@@ -4498,47 +9988,79 @@
             {
               "codepoint": "U+1F6D6",
               "name": "hut",
-              "keywords": ["house", "hut", "roundhouse", "yurt"]
+              "keywords": [
+                "home",
+                "house",
+                "hut",
+                "roundhouse",
+                "shelter",
+                "yurt"
+              ]
             },
             {
               "codepoint": "U+1F3D8",
               "name": "houses",
-              "keywords": ["houses"]
+              "keywords": ["house", "houses"]
             },
             {
               "codepoint": "U+1F3DA",
               "name": "derelict house",
-              "keywords": ["derelict", "house"]
+              "keywords": ["derelict", "home", "house"]
             },
             {
               "codepoint": "U+1F3E0",
               "name": "house",
-              "keywords": ["home", "house"]
+              "keywords": [
+                "building",
+                "country",
+                "heart",
+                "home",
+                "house",
+                "ranch",
+                "settle",
+                "simple",
+                "suburban",
+                "suburbia",
+                "where"
+              ]
             },
             {
               "codepoint": "U+1F3E1",
               "name": "house with garden",
-              "keywords": ["garden", "home", "house", "house with garden"]
+              "keywords": [
+                "building",
+                "country",
+                "garden",
+                "heart",
+                "home",
+                "house",
+                "ranch",
+                "settle",
+                "simple",
+                "suburban",
+                "suburbia",
+                "where"
+              ]
             },
             {
               "codepoint": "U+1F3E2",
               "name": "office building",
-              "keywords": ["building", "office building"]
+              "keywords": ["building", "city", "cubical", "job", "office"]
             },
             {
               "codepoint": "U+1F3E3",
               "name": "Japanese post office",
-              "keywords": ["Japanese", "Japanese post office", "post"]
+              "keywords": ["building", "Japanese", "office", "post"]
             },
             {
               "codepoint": "U+1F3E4",
               "name": "post office",
-              "keywords": ["European", "post", "post office"]
+              "keywords": ["building", "European", "office", "post"]
             },
             {
               "codepoint": "U+1F3E5",
               "name": "hospital",
-              "keywords": ["doctor", "hospital", "medicine"]
+              "keywords": ["building", "doctor", "hospital", "medicine"]
             },
             {
               "codepoint": "U+1F3E6",
@@ -4553,12 +10075,12 @@
             {
               "codepoint": "U+1F3E9",
               "name": "love hotel",
-              "keywords": ["hotel", "love"]
+              "keywords": ["building", "hotel", "love"]
             },
             {
               "codepoint": "U+1F3EA",
               "name": "convenience store",
-              "keywords": ["convenience", "store"]
+              "keywords": ["24", "building", "convenience", "hours", "store"]
             },
             {
               "codepoint": "U+1F3EB",
@@ -4568,7 +10090,7 @@
             {
               "codepoint": "U+1F3EC",
               "name": "department store",
-              "keywords": ["department", "store"]
+              "keywords": ["building", "department", "store"]
             },
             {
               "codepoint": "U+1F3ED",
@@ -4578,17 +10100,23 @@
             {
               "codepoint": "U+1F3EF",
               "name": "Japanese castle",
-              "keywords": ["castle", "Japanese"]
+              "keywords": ["building", "castle", "Japanese"]
             },
             {
               "codepoint": "U+1F3F0",
               "name": "castle",
-              "keywords": ["castle", "European"]
+              "keywords": ["building", "castle", "European"]
             },
             {
               "codepoint": "U+1F492",
               "name": "wedding",
-              "keywords": ["chapel", "romance", "wedding"]
+              "keywords": [
+                "chapel",
+                "hitched",
+                "nuptials",
+                "romance",
+                "wedding"
+              ]
             },
             {
               "codepoint": "U+1F5FC",
@@ -4598,22 +10126,38 @@
             {
               "codepoint": "U+1F5FD",
               "name": "Statue of Liberty",
-              "keywords": ["liberty", "statue", "Statue of Liberty"]
+              "keywords": [
+                "liberty",
+                "Liberty",
+                "new",
+                "ny",
+                "nyc",
+                "statue",
+                "Statue",
+                "york"
+              ]
             }
           ]
         },
         {
-          "category": "place_religious",
+          "category": "place-religious",
           "contents": [
             {
               "codepoint": "U+26EA",
               "name": "church",
-              "keywords": ["Christian", "church", "cross", "religion"]
+              "keywords": [
+                "bless",
+                "chapel",
+                "Christian",
+                "church",
+                "cross",
+                "religion"
+              ]
             },
             {
               "codepoint": "U+1F54C",
               "name": "mosque",
-              "keywords": ["islam", "mosque", "Muslim", "religion"]
+              "keywords": ["islam", "masjid", "mosque", "Muslim", "religion"]
             },
             {
               "codepoint": "U+1F6D5",
@@ -4623,7 +10167,14 @@
             {
               "codepoint": "U+1F54D",
               "name": "synagogue",
-              "keywords": ["Jew", "Jewish", "religion", "synagogue", "temple"]
+              "keywords": [
+                "Jew",
+                "Jewish",
+                "judaism",
+                "religion",
+                "synagogue",
+                "temple"
+              ]
             },
             {
               "codepoint": "U+26E9",
@@ -4633,12 +10184,19 @@
             {
               "codepoint": "U+1F54B",
               "name": "kaaba",
-              "keywords": ["islam", "kaaba", "Muslim", "religion"]
+              "keywords": [
+                "hajj",
+                "islam",
+                "kaaba",
+                "Muslim",
+                "religion",
+                "umrah"
+              ]
             }
           ]
         },
         {
-          "category": "place_other",
+          "category": "place-other",
           "contents": [
             {
               "codepoint": "U+26F2",
@@ -4658,7 +10216,7 @@
             {
               "codepoint": "U+1F303",
               "name": "night with stars",
-              "keywords": ["night", "night with stars", "star"]
+              "keywords": ["night", "star", "stars"]
             },
             {
               "codepoint": "U+1F3D9",
@@ -4668,27 +10226,37 @@
             {
               "codepoint": "U+1F304",
               "name": "sunrise over mountains",
-              "keywords": ["morning", "mountain", "sun", "sunrise", "sunrise over mountains"]
+              "keywords": ["morning", "mountains", "over", "sun", "sunrise"]
             },
             {
               "codepoint": "U+1F305",
               "name": "sunrise",
-              "keywords": ["morning", "sun", "sunrise"]
+              "keywords": ["morning", "nature", "sun", "sunrise"]
             },
             {
               "codepoint": "U+1F306",
               "name": "cityscape at dusk",
-              "keywords": ["city", "cityscape at dusk", "dusk", "evening", "landscape", "sunset"]
+              "keywords": [
+                "at",
+                "building",
+                "city",
+                "cityscape",
+                "dusk",
+                "evening",
+                "landscape",
+                "sun",
+                "sunset"
+              ]
             },
             {
               "codepoint": "U+1F307",
               "name": "sunset",
-              "keywords": ["dusk", "sun", "sunset"]
+              "keywords": ["building", "dusk", "sun", "sunset"]
             },
             {
               "codepoint": "U+1F309",
               "name": "bridge at night",
-              "keywords": ["bridge", "bridge at night", "night"]
+              "keywords": ["at", "bridge", "night"]
             },
             {
               "codepoint": "U+2668",
@@ -4698,27 +10266,36 @@
             {
               "codepoint": "U+1F3A0",
               "name": "carousel horse",
-              "keywords": ["carousel", "horse"]
+              "keywords": ["carousel", "entertainment", "horse"]
             },
             {
               "codepoint": "U+1F6DD",
               "name": "playground slide",
-              "keywords": ["amusement park", "play"]
+              "keywords": [
+                "amusement",
+                "park",
+                "play",
+                "playground",
+                "playing",
+                "slide",
+                "sliding",
+                "theme"
+              ]
             },
             {
               "codepoint": "U+1F3A1",
               "name": "ferris wheel",
-              "keywords": ["amusement park", "ferris", "wheel"]
+              "keywords": ["amusement", "ferris", "park", "theme", "wheel"]
             },
             {
               "codepoint": "U+1F3A2",
               "name": "roller coaster",
-              "keywords": ["amusement park", "coaster", "roller"]
+              "keywords": ["amusement", "coaster", "park", "roller", "theme"]
             },
             {
               "codepoint": "U+1F488",
               "name": "barber pole",
-              "keywords": ["barber", "haircut", "pole"]
+              "keywords": ["barber", "cut", "fresh", "haircut", "pole", "shave"]
             },
             {
               "codepoint": "U+1F3AA",
@@ -4728,42 +10305,74 @@
           ]
         },
         {
-          "category": "transport_ground",
+          "category": "transport-ground",
           "contents": [
             {
               "codepoint": "U+1F682",
               "name": "locomotive",
-              "keywords": ["engine", "locomotive", "railway", "steam", "train"]
+              "keywords": [
+                "caboose",
+                "engine",
+                "locomotive",
+                "railway",
+                "steam",
+                "train",
+                "trains",
+                "travel"
+              ]
             },
             {
               "codepoint": "U+1F683",
               "name": "railway car",
-              "keywords": ["car", "electric", "railway", "train", "tram", "trolleybus"]
+              "keywords": [
+                "car",
+                "electric",
+                "railway",
+                "train",
+                "tram",
+                "travel",
+                "trolleybus"
+              ]
             },
             {
               "codepoint": "U+1F684",
               "name": "high-speed train",
-              "keywords": ["high-speed train", "railway", "shinkansen", "speed", "train"]
+              "keywords": [
+                "high-speed",
+                "railway",
+                "shinkansen",
+                "speed",
+                "train"
+              ]
             },
             {
               "codepoint": "U+1F685",
               "name": "bullet train",
-              "keywords": ["bullet", "railway", "shinkansen", "speed", "train"]
+              "keywords": [
+                "bullet",
+                "high-speed",
+                "nose",
+                "railway",
+                "shinkansen",
+                "speed",
+                "train",
+                "travel"
+              ]
             },
             {
               "codepoint": "U+1F686",
               "name": "train",
-              "keywords": ["railway", "train"]
+              "keywords": ["arrived", "choo", "railway", "train"]
             },
             {
               "codepoint": "U+1F687",
               "name": "metro",
-              "keywords": ["metro", "subway"]
+              "keywords": ["metro", "subway", "travel"]
             },
             {
               "codepoint": "U+1F688",
               "name": "light rail",
-              "keywords": ["light rail", "railway"]
+              "keywords": ["arrived", "light", "monorail", "rail", "railway"]
             },
             {
               "codepoint": "U+1F689",
@@ -4783,22 +10392,22 @@
             {
               "codepoint": "U+1F69E",
               "name": "mountain railway",
-              "keywords": ["car", "mountain", "railway"]
+              "keywords": ["car", "mountain", "railway", "trip"]
             },
             {
               "codepoint": "U+1F68B",
               "name": "tram car",
-              "keywords": ["car", "tram", "trolleybus"]
+              "keywords": ["bus", "car", "tram", "trolley", "trolleybus"]
             },
             {
               "codepoint": "U+1F68C",
               "name": "bus",
-              "keywords": ["bus", "vehicle"]
+              "keywords": ["bus", "school", "vehicle"]
             },
             {
               "codepoint": "U+1F68D",
               "name": "oncoming bus",
-              "keywords": ["bus", "oncoming"]
+              "keywords": ["bus", "cars", "oncoming"]
             },
             {
               "codepoint": "U+1F68E",
@@ -4808,12 +10417,12 @@
             {
               "codepoint": "U+1F690",
               "name": "minibus",
-              "keywords": ["bus", "minibus"]
+              "keywords": ["bus", "drive", "minibus", "van", "vehicle"]
             },
             {
               "codepoint": "U+1F691",
               "name": "ambulance",
-              "keywords": ["ambulance", "vehicle"]
+              "keywords": ["ambulance", "emergency", "vehicle"]
             },
             {
               "codepoint": "U+1F692",
@@ -4823,7 +10432,7 @@
             {
               "codepoint": "U+1F693",
               "name": "police car",
-              "keywords": ["car", "patrol", "police"]
+              "keywords": ["5–0", "car", "cops", "patrol", "police"]
             },
             {
               "codepoint": "U+1F694",
@@ -4833,42 +10442,91 @@
             {
               "codepoint": "U+1F695",
               "name": "taxi",
-              "keywords": ["taxi", "vehicle"]
+              "keywords": [
+                "cab",
+                "cabbie",
+                "car",
+                "drive",
+                "taxi",
+                "vehicle",
+                "yellow"
+              ]
             },
             {
               "codepoint": "U+1F696",
               "name": "oncoming taxi",
-              "keywords": ["oncoming", "taxi"]
+              "keywords": [
+                "cab",
+                "cabbie",
+                "cars",
+                "drove",
+                "hail",
+                "oncoming",
+                "taxi",
+                "yellow"
+              ]
             },
             {
               "codepoint": "U+1F697",
               "name": "automobile",
-              "keywords": ["automobile", "car"]
+              "keywords": ["automobile", "car", "driving", "vehicle"]
             },
             {
               "codepoint": "U+1F698",
               "name": "oncoming automobile",
-              "keywords": ["automobile", "car", "oncoming"]
+              "keywords": [
+                "automobile",
+                "car",
+                "cars",
+                "drove",
+                "oncoming",
+                "vehicle"
+              ]
             },
             {
               "codepoint": "U+1F699",
               "name": "sport utility vehicle",
-              "keywords": ["recreational", "sport utility", "sport utility vehicle"]
+              "keywords": [
+                "car",
+                "drive",
+                "recreational",
+                "sport",
+                "sportutility",
+                "utility",
+                "vehicle"
+              ]
             },
             {
               "codepoint": "U+1F6FB",
               "name": "pickup truck",
-              "keywords": ["pick-up", "pickup", "truck"]
+              "keywords": [
+                "automobile",
+                "car",
+                "flatbed",
+                "pick-up",
+                "pickup",
+                "transportation",
+                "truck"
+              ]
             },
             {
               "codepoint": "U+1F69A",
               "name": "delivery truck",
-              "keywords": ["delivery", "truck"]
+              "keywords": ["car", "delivery", "drive", "truck", "vehicle"]
             },
             {
               "codepoint": "U+1F69B",
               "name": "articulated lorry",
-              "keywords": ["articulated lorry", "lorry", "semi", "truck"]
+              "keywords": [
+                "articulated",
+                "car",
+                "drive",
+                "lorry",
+                "move",
+                "semi",
+                "truck",
+                "vehicle"
+              ]
             },
             {
               "codepoint": "U+1F69C",
@@ -4878,7 +10536,7 @@
             {
               "codepoint": "U+1F3CE",
               "name": "racing car",
-              "keywords": ["car", "racing"]
+              "keywords": ["car", "racing", "zoom"]
             },
             {
               "codepoint": "U+1F3CD",
@@ -4893,22 +10551,33 @@
             {
               "codepoint": "U+1F9BD",
               "name": "manual wheelchair",
-              "keywords": ["accessibility", "manual wheelchair"]
+              "keywords": ["accessibility", "manual", "wheelchair"]
             },
             {
               "codepoint": "U+1F9BC",
               "name": "motorized wheelchair",
-              "keywords": ["accessibility", "motorized wheelchair"]
+              "keywords": ["accessibility", "motorized", "wheelchair"]
             },
             {
               "codepoint": "U+1F6FA",
               "name": "auto rickshaw",
-              "keywords": ["auto rickshaw", "tuk tuk"]
+              "keywords": ["auto", "rickshaw", "tuk"]
             },
             {
               "codepoint": "U+1F6B2",
               "name": "bicycle",
-              "keywords": ["bicycle", "bike"]
+              "keywords": [
+                "bicycle",
+                "bike",
+                "class",
+                "cycle",
+                "cycling",
+                "cyclist",
+                "gang",
+                "ride",
+                "spin",
+                "spinning"
+              ]
             },
             {
               "codepoint": "U+1F6F4",
@@ -4918,17 +10587,17 @@
             {
               "codepoint": "U+1F6F9",
               "name": "skateboard",
-              "keywords": ["board", "skateboard"]
+              "keywords": ["board", "skate", "skateboard", "skater", "wheels"]
             },
             {
               "codepoint": "U+1F6FC",
               "name": "roller skate",
-              "keywords": ["roller", "skate"]
+              "keywords": ["blades", "roller", "skate", "skates", "sport"]
             },
             {
               "codepoint": "U+1F68F",
               "name": "bus stop",
-              "keywords": ["bus", "stop"]
+              "keywords": ["bus", "busstop", "stop"]
             },
             {
               "codepoint": "U+1F6E3",
@@ -4938,7 +10607,7 @@
             {
               "codepoint": "U+1F6E4",
               "name": "railway track",
-              "keywords": ["railway", "railway track", "train"]
+              "keywords": ["railway", "track", "train"]
             },
             {
               "codepoint": "U+1F6E2",
@@ -4948,27 +10617,62 @@
             {
               "codepoint": "U+26FD",
               "name": "fuel pump",
-              "keywords": ["diesel", "fuel", "fuelpump", "gas", "pump", "station"]
+              "keywords": [
+                "diesel",
+                "fuel",
+                "fuelpump",
+                "gas",
+                "gasoline",
+                "pump",
+                "station"
+              ]
             },
             {
               "codepoint": "U+1F6DE",
               "name": "wheel",
-              "keywords": ["circle", "tire", "turn"]
+              "keywords": ["car", "circle", "tire", "turn", "vehicle", "wheel"]
             },
             {
               "codepoint": "U+1F6A8",
               "name": "police car light",
-              "keywords": ["beacon", "car", "light", "police", "revolving"]
+              "keywords": [
+                "alarm",
+                "alert",
+                "beacon",
+                "car",
+                "emergency",
+                "light",
+                "police",
+                "revolving",
+                "siren"
+              ]
             },
             {
               "codepoint": "U+1F6A5",
               "name": "horizontal traffic light",
-              "keywords": ["horizontal traffic light", "light", "signal", "traffic"]
+              "keywords": [
+                "horizontal",
+                "intersection",
+                "light",
+                "signal",
+                "stop",
+                "stoplight",
+                "traffic"
+              ]
             },
             {
               "codepoint": "U+1F6A6",
               "name": "vertical traffic light",
-              "keywords": ["light", "signal", "traffic", "vertical traffic light"]
+              "keywords": [
+                "drove",
+                "intersection",
+                "light",
+                "signal",
+                "stop",
+                "stoplight",
+                "traffic",
+                "vertical"
+              ]
             },
             {
               "codepoint": "U+1F6D1",
@@ -4983,7 +10687,7 @@
           ]
         },
         {
-          "category": "transport_water",
+          "category": "transport-water",
           "contents": [
             {
               "codepoint": "U+2693",
@@ -4993,12 +10697,31 @@
             {
               "codepoint": "U+1F6DF",
               "name": "ring buoy",
-              "keywords": ["float", "life preserver", "life saver", "rescue", "safety"]
+              "keywords": [
+                "buoy",
+                "float",
+                "life",
+                "lifesaver",
+                "preserver",
+                "rescue",
+                "ring",
+                "safety",
+                "save",
+                "saver",
+                "swim"
+              ]
             },
             {
               "codepoint": "U+26F5",
               "name": "sailboat",
-              "keywords": ["boat", "resort", "sailboat", "sea", "yacht"]
+              "keywords": [
+                "boat",
+                "resort",
+                "sailboat",
+                "sailing",
+                "sea",
+                "yacht"
+              ]
             },
             {
               "codepoint": "U+1F6F6",
@@ -5008,7 +10731,16 @@
             {
               "codepoint": "U+1F6A4",
               "name": "speedboat",
-              "keywords": ["boat", "speedboat"]
+              "keywords": [
+                "billionaire",
+                "boat",
+                "lake",
+                "luxury",
+                "millionaire",
+                "speedboat",
+                "summer",
+                "travel"
+              ]
             },
             {
               "codepoint": "U+1F6F3",
@@ -5023,37 +10755,60 @@
             {
               "codepoint": "U+1F6E5",
               "name": "motor boat",
-              "keywords": ["boat", "motor boat", "motorboat"]
+              "keywords": ["boat", "motor", "motorboat"]
             },
             {
               "codepoint": "U+1F6A2",
               "name": "ship",
-              "keywords": ["boat", "passenger", "ship"]
+              "keywords": ["boat", "passenger", "ship", "travel"]
             }
           ]
         },
         {
-          "category": "transport_air",
+          "category": "transport-air",
           "contents": [
             {
               "codepoint": "U+2708",
               "name": "airplane",
-              "keywords": ["aeroplane", "airplane"]
+              "keywords": [
+                "aeroplane",
+                "airplane",
+                "fly",
+                "flying",
+                "jet",
+                "plane",
+                "travel"
+              ]
             },
             {
               "codepoint": "U+1F6E9",
               "name": "small airplane",
-              "keywords": ["aeroplane", "airplane", "small airplane"]
+              "keywords": ["aeroplane", "airplane", "plane", "small"]
             },
             {
               "codepoint": "U+1F6EB",
               "name": "airplane departure",
-              "keywords": ["aeroplane", "airplane", "check-in", "departure", "departures"]
+              "keywords": [
+                "aeroplane",
+                "airplane",
+                "check-in",
+                "departure",
+                "departures",
+                "plane"
+              ]
             },
             {
               "codepoint": "U+1F6EC",
               "name": "airplane arrival",
-              "keywords": ["aeroplane", "airplane", "airplane arrival", "arrivals", "arriving", "landing"]
+              "keywords": [
+                "aeroplane",
+                "airplane",
+                "arrival",
+                "arrivals",
+                "arriving",
+                "landing",
+                "plane"
+              ]
             },
             {
               "codepoint": "U+1FA82",
@@ -5068,7 +10823,13 @@
             {
               "codepoint": "U+1F681",
               "name": "helicopter",
-              "keywords": ["helicopter", "vehicle"]
+              "keywords": [
+                "copter",
+                "helicopter",
+                "roflcopter",
+                "travel",
+                "vehicle"
+              ]
             },
             {
               "codepoint": "U+1F69F",
@@ -5078,12 +10839,26 @@
             {
               "codepoint": "U+1F6A0",
               "name": "mountain cableway",
-              "keywords": ["cable", "gondola", "mountain", "mountain cableway"]
+              "keywords": [
+                "cable",
+                "cableway",
+                "gondola",
+                "lift",
+                "mountain",
+                "ski"
+              ]
             },
             {
               "codepoint": "U+1F6A1",
               "name": "aerial tramway",
-              "keywords": ["aerial", "cable", "car", "gondola", "tramway"]
+              "keywords": [
+                "aerial",
+                "cable",
+                "car",
+                "gondola",
+                "ropeway",
+                "tramway"
+              ]
             },
             {
               "codepoint": "U+1F6F0",
@@ -5093,12 +10868,19 @@
             {
               "codepoint": "U+1F680",
               "name": "rocket",
-              "keywords": ["rocket", "space"]
+              "keywords": ["launch", "rocket", "rockets", "space", "travel"]
             },
             {
               "codepoint": "U+1F6F8",
               "name": "flying saucer",
-              "keywords": ["flying saucer", "UFO"]
+              "keywords": [
+                "aliens",
+                "extra",
+                "flying",
+                "saucer",
+                "terrestrial",
+                "UFO"
+              ]
             }
           ]
         },
@@ -5113,7 +10895,14 @@
             {
               "codepoint": "U+1F9F3",
               "name": "luggage",
-              "keywords": ["luggage", "packing", "travel"]
+              "keywords": [
+                "bag",
+                "luggage",
+                "packing",
+                "roller",
+                "suitcase",
+                "travel"
+              ]
             }
           ]
         },
@@ -5123,27 +10912,45 @@
             {
               "codepoint": "U+231B",
               "name": "hourglass done",
-              "keywords": ["hourglass done", "sand", "timer"]
+              "keywords": ["done", "hourglass", "sand", "time", "timer"]
             },
             {
               "codepoint": "U+23F3",
               "name": "hourglass not done",
-              "keywords": ["hourglass", "hourglass not done", "sand", "timer"]
+              "keywords": [
+                "done",
+                "flowing",
+                "hourglass",
+                "hours",
+                "not",
+                "sand",
+                "timer",
+                "waiting",
+                "yolo"
+              ]
             },
             {
               "codepoint": "U+231A",
               "name": "watch",
-              "keywords": ["clock", "watch"]
+              "keywords": ["clock", "time", "watch"]
             },
             {
               "codepoint": "U+23F0",
               "name": "alarm clock",
-              "keywords": ["alarm", "clock"]
+              "keywords": [
+                "alarm",
+                "clock",
+                "hours",
+                "hrs",
+                "late",
+                "time",
+                "waiting"
+              ]
             },
             {
               "codepoint": "U+23F1",
               "name": "stopwatch",
-              "keywords": ["clock", "stopwatch"]
+              "keywords": ["clock", "stopwatch", "time"]
             },
             {
               "codepoint": "U+23F2",
@@ -5153,127 +10960,233 @@
             {
               "codepoint": "U+1F570",
               "name": "mantelpiece clock",
-              "keywords": ["clock", "mantelpiece clock"]
+              "keywords": ["clock", "mantelpiece", "time"]
             },
             {
               "codepoint": "U+1F55B",
               "name": "twelve o’clock",
-              "keywords": ["00", "12", "12:00", "clock", "o’clock", "twelve"]
+              "keywords": ["12", "12:00", "clock", "o’clock", "time", "twelve"]
             },
             {
               "codepoint": "U+1F567",
               "name": "twelve-thirty",
-              "keywords": ["12", "12:30", "clock", "thirty", "twelve", "twelve-thirty"]
+              "keywords": [
+                "12",
+                "12:30",
+                "30",
+                "clock",
+                "thirty",
+                "time",
+                "twelve",
+                "twelve-thirty"
+              ]
             },
             {
               "codepoint": "U+1F550",
               "name": "one o’clock",
-              "keywords": ["00", "1", "1:00", "clock", "o’clock", "one"]
+              "keywords": ["1", "1:00", "clock", "o’clock", "one", "time"]
             },
             {
               "codepoint": "U+1F55C",
               "name": "one-thirty",
-              "keywords": ["1", "1:30", "clock", "one", "one-thirty", "thirty"]
+              "keywords": [
+                "1",
+                "1:30",
+                "30",
+                "clock",
+                "one",
+                "one-thirty",
+                "thirty",
+                "time"
+              ]
             },
             {
               "codepoint": "U+1F551",
               "name": "two o’clock",
-              "keywords": ["00", "2", "2:00", "clock", "o’clock", "two"]
+              "keywords": ["2", "2:00", "clock", "o’clock", "time", "two"]
             },
             {
               "codepoint": "U+1F55D",
               "name": "two-thirty",
-              "keywords": ["2", "2:30", "clock", "thirty", "two", "two-thirty"]
+              "keywords": [
+                "2",
+                "2:30",
+                "30",
+                "clock",
+                "thirty",
+                "time",
+                "two",
+                "two-thirty"
+              ]
             },
             {
               "codepoint": "U+1F552",
               "name": "three o’clock",
-              "keywords": ["00", "3", "3:00", "clock", "o’clock", "three"]
+              "keywords": ["3", "3:00", "clock", "o’clock", "three", "time"]
             },
             {
               "codepoint": "U+1F55E",
               "name": "three-thirty",
-              "keywords": ["3", "3:30", "clock", "thirty", "three", "three-thirty"]
+              "keywords": [
+                "3",
+                "3:30",
+                "30",
+                "clock",
+                "thirty",
+                "three",
+                "three-thirty",
+                "time"
+              ]
             },
             {
               "codepoint": "U+1F553",
               "name": "four o’clock",
-              "keywords": ["00", "4", "4:00", "clock", "four", "o’clock"]
+              "keywords": ["4", "4:00", "clock", "four", "o’clock", "time"]
             },
             {
               "codepoint": "U+1F55F",
               "name": "four-thirty",
-              "keywords": ["4", "4:30", "clock", "four", "four-thirty", "thirty"]
+              "keywords": [
+                "30",
+                "4",
+                "4:30",
+                "clock",
+                "four",
+                "four-thirty",
+                "thirty",
+                "time"
+              ]
             },
             {
               "codepoint": "U+1F554",
               "name": "five o’clock",
-              "keywords": ["00", "5", "5:00", "clock", "five", "o’clock"]
+              "keywords": ["5", "5:00", "clock", "five", "o’clock", "time"]
             },
             {
               "codepoint": "U+1F560",
               "name": "five-thirty",
-              "keywords": ["5", "5:30", "clock", "five", "five-thirty", "thirty"]
+              "keywords": [
+                "30",
+                "5",
+                "5:30",
+                "clock",
+                "five",
+                "five-thirty",
+                "thirty",
+                "time"
+              ]
             },
             {
               "codepoint": "U+1F555",
               "name": "six o’clock",
-              "keywords": ["00", "6", "6:00", "clock", "o’clock", "six"]
+              "keywords": ["6", "6:00", "clock", "o’clock", "six", "time"]
             },
             {
               "codepoint": "U+1F561",
               "name": "six-thirty",
-              "keywords": ["6", "6:30", "clock", "six", "six-thirty", "thirty"]
+              "keywords": [
+                "30",
+                "6",
+                "6:30",
+                "clock",
+                "six",
+                "six-thirty",
+                "thirty"
+              ]
             },
             {
               "codepoint": "U+1F556",
               "name": "seven o’clock",
-              "keywords": ["00", "7", "7:00", "clock", "o’clock", "seven"]
+              "keywords": ["0", "7", "7:00", "clock", "o’clock", "seven"]
             },
             {
               "codepoint": "U+1F562",
               "name": "seven-thirty",
-              "keywords": ["7", "7:30", "clock", "seven", "seven-thirty", "thirty"]
+              "keywords": [
+                "30",
+                "7",
+                "7:30",
+                "clock",
+                "seven",
+                "seven-thirty",
+                "thirty"
+              ]
             },
             {
               "codepoint": "U+1F557",
               "name": "eight o’clock",
-              "keywords": ["00", "8", "8:00", "clock", "eight", "o’clock"]
+              "keywords": ["8", "8:00", "clock", "eight", "o’clock", "time"]
             },
             {
               "codepoint": "U+1F563",
               "name": "eight-thirty",
-              "keywords": ["8", "8:30", "clock", "eight", "eight-thirty", "thirty"]
+              "keywords": [
+                "30",
+                "8",
+                "8:30",
+                "clock",
+                "eight",
+                "eight-thirty",
+                "thirty",
+                "time"
+              ]
             },
             {
               "codepoint": "U+1F558",
               "name": "nine o’clock",
-              "keywords": ["00", "9", "9:00", "clock", "nine", "o’clock"]
+              "keywords": ["9", "9:00", "clock", "nine", "o’clock", "time"]
             },
             {
               "codepoint": "U+1F564",
               "name": "nine-thirty",
-              "keywords": ["9", "9:30", "clock", "nine", "nine-thirty", "thirty"]
+              "keywords": [
+                "30",
+                "9",
+                "9:30",
+                "clock",
+                "nine",
+                "nine-thirty",
+                "thirty",
+                "time"
+              ]
             },
             {
               "codepoint": "U+1F559",
               "name": "ten o’clock",
-              "keywords": ["00", "10", "10:00", "clock", "o’clock", "ten"]
+              "keywords": ["0", "10", "10:00", "clock", "o’clock", "ten"]
             },
             {
               "codepoint": "U+1F565",
               "name": "ten-thirty",
-              "keywords": ["10", "10:30", "clock", "ten", "ten-thirty", "thirty"]
+              "keywords": [
+                "10",
+                "10:30",
+                "30",
+                "clock",
+                "ten",
+                "ten-thirty",
+                "thirty",
+                "time"
+              ]
             },
             {
               "codepoint": "U+1F55A",
               "name": "eleven o’clock",
-              "keywords": ["00", "11", "11:00", "clock", "eleven", "o’clock"]
+              "keywords": ["11", "11:00", "clock", "eleven", "o’clock", "time"]
             },
             {
               "codepoint": "U+1F566",
               "name": "eleven-thirty",
-              "keywords": ["11", "11:30", "clock", "eleven", "eleven-thirty", "thirty"]
+              "keywords": [
+                "11",
+                "11:30",
+                "30",
+                "clock",
+                "eleven",
+                "eleven-thirty",
+                "thirty",
+                "time"
+              ]
             }
           ]
         },
@@ -5283,62 +11196,62 @@
             {
               "codepoint": "U+1F311",
               "name": "new moon",
-              "keywords": ["dark", "moon", "new moon"]
+              "keywords": ["dark", "moon", "new", "space"]
             },
             {
               "codepoint": "U+1F312",
               "name": "waxing crescent moon",
-              "keywords": ["crescent", "moon", "waxing"]
+              "keywords": ["crescent", "dreams", "moon", "space", "waxing"]
             },
             {
               "codepoint": "U+1F313",
               "name": "first quarter moon",
-              "keywords": ["first quarter moon", "moon", "quarter"]
+              "keywords": ["first", "moon", "quarter", "space"]
             },
             {
               "codepoint": "U+1F314",
               "name": "waxing gibbous moon",
-              "keywords": ["gibbous", "moon", "waxing"]
+              "keywords": ["gibbous", "moon", "space", "waxing"]
             },
             {
               "codepoint": "U+1F315",
               "name": "full moon",
-              "keywords": ["full", "moon"]
+              "keywords": ["full", "moon", "space"]
             },
             {
               "codepoint": "U+1F316",
               "name": "waning gibbous moon",
-              "keywords": ["gibbous", "moon", "waning"]
+              "keywords": ["gibbous", "moon", "space", "waning"]
             },
             {
               "codepoint": "U+1F317",
               "name": "last quarter moon",
-              "keywords": ["last quarter moon", "moon", "quarter"]
+              "keywords": ["last", "moon", "quarter", "space"]
             },
             {
               "codepoint": "U+1F318",
               "name": "waning crescent moon",
-              "keywords": ["crescent", "moon", "waning"]
+              "keywords": ["crescent", "moon", "space", "waning"]
             },
             {
               "codepoint": "U+1F319",
               "name": "crescent moon",
-              "keywords": ["crescent", "moon"]
+              "keywords": ["crescent", "moon", "ramadan", "space"]
             },
             {
               "codepoint": "U+1F31A",
               "name": "new moon face",
-              "keywords": ["face", "moon", "new moon face"]
+              "keywords": ["face", "moon", "new", "space"]
             },
             {
               "codepoint": "U+1F31B",
               "name": "first quarter moon face",
-              "keywords": ["face", "first quarter moon face", "moon", "quarter"]
+              "keywords": ["face", "first", "moon", "quarter", "space"]
             },
             {
               "codepoint": "U+1F31C",
               "name": "last quarter moon face",
-              "keywords": ["face", "last quarter moon face", "moon", "quarter"]
+              "keywords": ["dreams", "face", "last", "moon", "quarter"]
             },
             {
               "codepoint": "U+1F321",
@@ -5348,7 +11261,7 @@
             {
               "codepoint": "U+2600",
               "name": "sun",
-              "keywords": ["bright", "rays", "sun", "sunny"]
+              "keywords": ["bright", "rays", "space", "sun", "sunny", "weather"]
             },
             {
               "codepoint": "U+1F31D",
@@ -5358,32 +11271,52 @@
             {
               "codepoint": "U+1F31E",
               "name": "sun with face",
-              "keywords": ["bright", "face", "sun", "sun with face"]
+              "keywords": [
+                "beach",
+                "bright",
+                "day",
+                "face",
+                "heat",
+                "shine",
+                "sun",
+                "sunny",
+                "sunshine",
+                "weather"
+              ]
             },
             {
               "codepoint": "U+1FA90",
               "name": "ringed planet",
-              "keywords": ["ringed planet", "saturn", "saturnine"]
+              "keywords": ["planet", "ringed", "saturn", "saturnine"]
             },
             {
               "codepoint": "U+2B50",
               "name": "star",
-              "keywords": ["star"]
+              "keywords": ["astronomy", "medium", "star", "stars", "white"]
             },
             {
               "codepoint": "U+1F31F",
               "name": "glowing star",
-              "keywords": ["glittery", "glow", "glowing star", "shining", "sparkle", "star"]
+              "keywords": [
+                "glittery",
+                "glow",
+                "glowing",
+                "night",
+                "shining",
+                "sparkle",
+                "star",
+                "win"
+              ]
             },
             {
               "codepoint": "U+1F320",
               "name": "shooting star",
-              "keywords": ["falling", "shooting", "star"]
+              "keywords": ["falling", "night", "shooting", "space", "star"]
             },
             {
               "codepoint": "U+1F30C",
               "name": "milky way",
-              "keywords": ["milky way", "space"]
+              "keywords": ["milky", "space", "way"]
             },
             {
               "codepoint": "U+2601",
@@ -5393,52 +11326,58 @@
             {
               "codepoint": "U+26C5",
               "name": "sun behind cloud",
-              "keywords": ["cloud", "sun", "sun behind cloud"]
+              "keywords": ["behind", "cloud", "cloudy", "sun", "weather"]
             },
             {
               "codepoint": "U+26C8",
               "name": "cloud with lightning and rain",
-              "keywords": ["cloud", "cloud with lightning and rain", "rain", "thunder"]
+              "keywords": [
+                "cloud",
+                "lightning",
+                "rain",
+                "thunder",
+                "thunderstorm"
+              ]
             },
             {
               "codepoint": "U+1F324",
               "name": "sun behind small cloud",
-              "keywords": ["cloud", "sun", "sun behind small cloud"]
+              "keywords": ["behind", "cloud", "sun", "weather"]
             },
             {
               "codepoint": "U+1F325",
               "name": "sun behind large cloud",
-              "keywords": ["cloud", "sun", "sun behind large cloud"]
+              "keywords": ["behind", "cloud", "sun", "weather"]
             },
             {
               "codepoint": "U+1F326",
               "name": "sun behind rain cloud",
-              "keywords": ["cloud", "rain", "sun", "sun behind rain cloud"]
+              "keywords": ["behind", "cloud", "rain", "sun", "weather"]
             },
             {
               "codepoint": "U+1F327",
               "name": "cloud with rain",
-              "keywords": ["cloud", "cloud with rain", "rain"]
+              "keywords": ["cloud", "rain", "weather"]
             },
             {
               "codepoint": "U+1F328",
               "name": "cloud with snow",
-              "keywords": ["cloud", "cloud with snow", "cold", "snow"]
+              "keywords": ["cloud", "cold", "snow", "weather"]
             },
             {
               "codepoint": "U+1F329",
               "name": "cloud with lightning",
-              "keywords": ["cloud", "cloud with lightning", "lightning"]
+              "keywords": ["cloud", "lightning", "weather"]
             },
             {
               "codepoint": "U+1F32A",
               "name": "tornado",
-              "keywords": ["cloud", "tornado", "whirlwind"]
+              "keywords": ["cloud", "tornado", "weather", "whirlwind"]
             },
             {
               "codepoint": "U+1F32B",
               "name": "fog",
-              "keywords": ["cloud", "fog"]
+              "keywords": ["cloud", "fog", "weather"]
             },
             {
               "codepoint": "U+1F32C",
@@ -5448,17 +11387,41 @@
             {
               "codepoint": "U+1F300",
               "name": "cyclone",
-              "keywords": ["cyclone", "dizzy", "hurricane", "twister", "typhoon"]
+              "keywords": [
+                "cyclone",
+                "dizzy",
+                "hurricane",
+                "twister",
+                "typhoon",
+                "weather"
+              ]
             },
             {
               "codepoint": "U+1F308",
               "name": "rainbow",
-              "keywords": ["rain", "rainbow"]
+              "keywords": [
+                "gay",
+                "genderqueer",
+                "glbt",
+                "glbtq",
+                "lesbian",
+                "lgbt",
+                "lgbtq",
+                "lgbtqia",
+                "nature",
+                "pride",
+                "queer",
+                "rain",
+                "rainbow",
+                "trans",
+                "transgender",
+                "weather"
+              ]
             },
             {
               "codepoint": "U+1F302",
               "name": "closed umbrella",
-              "keywords": ["closed umbrella", "clothing", "rain", "umbrella"]
+              "keywords": ["closed", "clothing", "rain", "umbrella"]
             },
             {
               "codepoint": "U+2602",
@@ -5468,32 +11431,50 @@
             {
               "codepoint": "U+2614",
               "name": "umbrella with rain drops",
-              "keywords": ["clothing", "drop", "rain", "umbrella", "umbrella with rain drops"]
+              "keywords": [
+                "clothing",
+                "drop",
+                "drops",
+                "rain",
+                "umbrella",
+                "weather"
+              ]
             },
             {
               "codepoint": "U+26F1",
               "name": "umbrella on ground",
-              "keywords": ["rain", "sun", "umbrella", "umbrella on ground"]
+              "keywords": ["ground", "rain", "sun", "umbrella"]
             },
             {
               "codepoint": "U+26A1",
               "name": "high voltage",
-              "keywords": ["danger", "electric", "high voltage", "lightning", "voltage", "zap"]
+              "keywords": [
+                "danger",
+                "electric",
+                "electricity",
+                "high",
+                "lightning",
+                "nature",
+                "thunder",
+                "thunderbolt",
+                "voltage",
+                "zap"
+              ]
             },
             {
               "codepoint": "U+2744",
               "name": "snowflake",
-              "keywords": ["cold", "snow", "snowflake"]
+              "keywords": ["cold", "snow", "snowflake", "weather"]
             },
             {
               "codepoint": "U+2603",
               "name": "snowman",
-              "keywords": ["cold", "snow", "snowman"]
+              "keywords": ["cold", "man", "snow", "snowman"]
             },
             {
               "codepoint": "U+26C4",
               "name": "snowman without snow",
-              "keywords": ["cold", "snow", "snowman", "snowman without snow"]
+              "keywords": ["cold", "man", "snow", "snowman"]
             },
             {
               "codepoint": "U+2604",
@@ -5503,17 +11484,45 @@
             {
               "codepoint": "U+1F525",
               "name": "fire",
-              "keywords": ["fire", "flame", "tool"]
+              "keywords": [
+                "af",
+                "burn",
+                "fire",
+                "flame",
+                "hot",
+                "lit",
+                "litaf",
+                "tool"
+              ]
             },
             {
               "codepoint": "U+1F4A7",
               "name": "droplet",
-              "keywords": ["cold", "comic", "drop", "droplet", "sweat"]
+              "keywords": [
+                "cold",
+                "comic",
+                "drop",
+                "droplet",
+                "nature",
+                "sad",
+                "sweat",
+                "tear",
+                "water",
+                "weather"
+              ]
             },
             {
               "codepoint": "U+1F30A",
               "name": "water wave",
-              "keywords": ["ocean", "water", "wave"]
+              "keywords": [
+                "nature",
+                "ocean",
+                "surf",
+                "surfer",
+                "surfing",
+                "water",
+                "wave"
+              ]
             }
           ]
         }
@@ -5528,7 +11537,14 @@
             {
               "codepoint": "U+1F383",
               "name": "jack-o-lantern",
-              "keywords": ["celebration", "halloween", "jack", "jack-o-lantern", "lantern"]
+              "keywords": [
+                "celebration",
+                "halloween",
+                "jack",
+                "jack-o-lantern",
+                "lantern",
+                "pumpkin"
+              ]
             },
             {
               "codepoint": "U+1F384",
@@ -5538,52 +11554,111 @@
             {
               "codepoint": "U+1F386",
               "name": "fireworks",
-              "keywords": ["celebration", "fireworks"]
+              "keywords": [
+                "boom",
+                "celebration",
+                "entertainment",
+                "fireworks",
+                "yolo"
+              ]
             },
             {
               "codepoint": "U+1F387",
               "name": "sparkler",
-              "keywords": ["celebration", "fireworks", "sparkle", "sparkler"]
+              "keywords": [
+                "boom",
+                "celebration",
+                "fireworks",
+                "sparkle",
+                "sparkler"
+              ]
             },
             {
               "codepoint": "U+1F9E8",
               "name": "firecracker",
-              "keywords": ["dynamite", "explosive", "firecracker", "fireworks"]
+              "keywords": [
+                "dynamite",
+                "explosive",
+                "fire",
+                "firecracker",
+                "fireworks",
+                "light",
+                "pop",
+                "popping",
+                "spark"
+              ]
             },
             {
               "codepoint": "U+2728",
               "name": "sparkles",
-              "keywords": ["*", "sparkle", "sparkles", "star"]
+              "keywords": ["*", "magic", "sparkle", "sparkles", "star"]
             },
             {
               "codepoint": "U+1F388",
               "name": "balloon",
-              "keywords": ["balloon", "celebration"]
+              "keywords": ["balloon", "birthday", "celebrate", "celebration"]
             },
             {
               "codepoint": "U+1F389",
               "name": "party popper",
-              "keywords": ["celebration", "party", "popper", "tada"]
+              "keywords": [
+                "awesome",
+                "birthday",
+                "celebrate",
+                "celebration",
+                "excited",
+                "hooray",
+                "party",
+                "popper",
+                "tada",
+                "woohoo"
+              ]
             },
             {
               "codepoint": "U+1F38A",
               "name": "confetti ball",
-              "keywords": ["ball", "celebration", "confetti"]
+              "keywords": [
+                "ball",
+                "celebrate",
+                "celebration",
+                "confetti",
+                "party",
+                "woohoo"
+              ]
             },
             {
               "codepoint": "U+1F38B",
               "name": "tanabata tree",
-              "keywords": ["banner", "celebration", "Japanese", "tanabata tree", "tree"]
+              "keywords": [
+                "banner",
+                "celebration",
+                "Japanese",
+                "tanabata",
+                "tree"
+              ]
             },
             {
               "codepoint": "U+1F38D",
               "name": "pine decoration",
-              "keywords": ["bamboo", "celebration", "Japanese", "pine", "pine decoration"]
+              "keywords": [
+                "bamboo",
+                "celebration",
+                "decoration",
+                "Japanese",
+                "pine",
+                "plant"
+              ]
             },
             {
               "codepoint": "U+1F38E",
               "name": "Japanese dolls",
-              "keywords": ["celebration", "doll", "festival", "Japanese", "Japanese dolls"]
+              "keywords": [
+                "celebration",
+                "doll",
+                "dolls",
+                "festival",
+                "Japanese"
+              ]
             },
             {
               "codepoint": "U+1F38F",
@@ -5598,12 +11673,22 @@
             {
               "codepoint": "U+1F391",
               "name": "moon viewing ceremony",
-              "keywords": ["celebration", "ceremony", "moon", "moon viewing ceremony"]
+              "keywords": ["celebration", "ceremony", "moon", "viewing"]
             },
             {
               "codepoint": "U+1F9E7",
               "name": "red envelope",
-              "keywords": ["gift", "good luck", "hóngbāo", "lai see", "money", "red envelope"]
+              "keywords": [
+                "envelope",
+                "gift",
+                "good",
+                "hóngbāo",
+                "lai",
+                "luck",
+                "money",
+                "red",
+                "see"
+              ]
             },
             {
               "codepoint": "U+1F380",
@@ -5613,7 +11698,17 @@
             {
               "codepoint": "U+1F381",
               "name": "wrapped gift",
-              "keywords": ["box", "celebration", "gift", "present", "wrapped"]
+              "keywords": [
+                "birthday",
+                "bow",
+                "box",
+                "celebration",
+                "christmas",
+                "gift",
+                "present",
+                "surprise",
+                "wrapped"
+              ]
             },
             {
               "codepoint": "U+1F397",
@@ -5623,47 +11718,57 @@
             {
               "codepoint": "U+1F39F",
               "name": "admission tickets",
-              "keywords": ["admission", "admission tickets", "ticket"]
+              "keywords": ["admission", "ticket", "tickets"]
             },
             {
               "codepoint": "U+1F3AB",
               "name": "ticket",
-              "keywords": ["admission", "ticket"]
+              "keywords": ["admission", "stub", "ticket"]
             }
           ]
         },
         {
-          "category": "award_medal",
+          "category": "award-medal",
           "contents": [
             {
               "codepoint": "U+1F396",
               "name": "military medal",
-              "keywords": ["celebration", "medal", "military"]
+              "keywords": ["award", "celebration", "medal", "military"]
             },
             {
               "codepoint": "U+1F3C6",
               "name": "trophy",
-              "keywords": ["prize", "trophy"]
+              "keywords": [
+                "champion",
+                "champs",
+                "prize",
+                "slay",
+                "sport",
+                "trophy",
+                "victory",
+                "win",
+                "winning"
+              ]
             },
             {
               "codepoint": "U+1F3C5",
               "name": "sports medal",
-              "keywords": ["medal", "sports medal"]
+              "keywords": ["award", "gold", "medal", "sports", "winner"]
             },
             {
               "codepoint": "U+1F947",
               "name": "1st place medal",
-              "keywords": ["1st place medal", "first", "gold", "medal"]
+              "keywords": ["1st", "first", "gold", "medal", "place"]
             },
             {
               "codepoint": "U+1F948",
               "name": "2nd place medal",
-              "keywords": ["2nd place medal", "medal", "second", "silver"]
+              "keywords": ["2nd", "medal", "place", "second", "silver"]
             },
             {
               "codepoint": "U+1F949",
               "name": "3rd place medal",
-              "keywords": ["3rd place medal", "bronze", "medal", "third"]
+              "keywords": ["3rd", "bronze", "medal", "place", "third"]
             }
           ]
         },
@@ -5673,22 +11778,22 @@
             {
               "codepoint": "U+26BD",
               "name": "soccer ball",
-              "keywords": ["ball", "football", "soccer"]
+              "keywords": ["ball", "football", "futbol", "soccer", "sport"]
             },
             {
               "codepoint": "U+26BE",
               "name": "baseball",
-              "keywords": ["ball", "baseball"]
+              "keywords": ["ball", "baseball", "sport"]
             },
             {
               "codepoint": "U+1F94E",
               "name": "softball",
-              "keywords": ["ball", "glove", "softball", "underarm"]
+              "keywords": ["ball", "glove", "softball", "sports", "underarm"]
             },
             {
               "codepoint": "U+1F3C0",
               "name": "basketball",
-              "keywords": ["ball", "basketball", "hoop"]
+              "keywords": ["ball", "basketball", "hoop", "sport"]
             },
             {
               "codepoint": "U+1F3D0",
@@ -5698,32 +11803,39 @@
             {
               "codepoint": "U+1F3C8",
               "name": "american football",
-              "keywords": ["american", "ball", "football"]
+              "keywords": [
+                "american",
+                "ball",
+                "bowl",
+                "football",
+                "sport",
+                "super"
+              ]
             },
             {
               "codepoint": "U+1F3C9",
               "name": "rugby football",
-              "keywords": ["ball", "football", "rugby"]
+              "keywords": ["ball", "football", "rugby", "sport"]
             },
             {
               "codepoint": "U+1F3BE",
               "name": "tennis",
-              "keywords": ["ball", "racquet", "tennis"]
+              "keywords": ["ball", "racquet", "sport", "tennis"]
             },
             {
               "codepoint": "U+1F94F",
               "name": "flying disc",
-              "keywords": ["flying disc", "ultimate"]
+              "keywords": ["disc", "flying", "ultimate"]
             },
             {
               "codepoint": "U+1F3B3",
               "name": "bowling",
-              "keywords": ["ball", "bowling", "game"]
+              "keywords": ["ball", "bowling", "game", "sport", "strike"]
             },
             {
               "codepoint": "U+1F3CF",
               "name": "cricket game",
-              "keywords": ["ball", "bat", "cricket game", "game"]
+              "keywords": ["ball", "bat", "cricket", "game"]
             },
             {
               "codepoint": "U+1F3D1",
@@ -5738,17 +11850,33 @@
             {
               "codepoint": "U+1F94D",
               "name": "lacrosse",
-              "keywords": ["ball", "goal", "lacrosse", "stick"]
+              "keywords": ["ball", "goal", "lacrosse", "sports", "stick"]
             },
             {
               "codepoint": "U+1F3D3",
               "name": "ping pong",
-              "keywords": ["ball", "bat", "game", "paddle", "ping pong", "table tennis"]
+              "keywords": [
+                "ball",
+                "bat",
+                "game",
+                "paddle",
+                "ping",
+                "pingpong",
+                "pong",
+                "table",
+                "tennis"
+              ]
             },
             {
               "codepoint": "U+1F3F8",
               "name": "badminton",
-              "keywords": ["badminton", "birdie", "game", "racquet", "shuttlecock"]
+              "keywords": [
+                "badminton",
+                "birdie",
+                "game",
+                "racquet",
+                "shuttlecock"
+              ]
             },
             {
               "codepoint": "U+1F94A",
@@ -5758,7 +11886,14 @@
             {
               "codepoint": "U+1F94B",
               "name": "martial arts uniform",
-              "keywords": ["judo", "karate", "martial arts", "martial arts uniform", "taekwondo", "uniform"]
+              "keywords": [
+                "arts",
+                "judo",
+                "karate",
+                "martial",
+                "taekwondo",
+                "uniform"
+              ]
             },
             {
               "codepoint": "U+1F945",
@@ -5768,22 +11903,22 @@
             {
               "codepoint": "U+26F3",
               "name": "flag in hole",
-              "keywords": ["flag in hole", "golf", "hole"]
+              "keywords": ["flag", "golf", "hole", "sport"]
             },
             {
               "codepoint": "U+26F8",
               "name": "ice skate",
-              "keywords": ["ice", "skate"]
+              "keywords": ["ice", "skate", "skating"]
             },
             {
               "codepoint": "U+1F3A3",
               "name": "fishing pole",
-              "keywords": ["fish", "fishing pole", "pole"]
+              "keywords": ["entertainment", "fish", "fishing", "pole", "sport"]
             },
             {
               "codepoint": "U+1F93F",
               "name": "diving mask",
-              "keywords": ["diving", "diving mask", "scuba", "snorkeling"]
+              "keywords": ["diving", "mask", "scuba", "snorkeling"]
             },
             {
               "codepoint": "U+1F3BD",
@@ -5793,17 +11928,24 @@
             {
               "codepoint": "U+1F3BF",
               "name": "skis",
-              "keywords": ["ski", "skis", "snow"]
+              "keywords": ["ski", "skis", "snow", "sport"]
             },
             {
               "codepoint": "U+1F6F7",
               "name": "sled",
-              "keywords": ["sled", "sledge", "sleigh", "luge", "toboggan"]
+              "keywords": [
+                "luge",
+                "sled",
+                "sledge",
+                "sleigh",
+                "snow",
+                "toboggan"
+              ]
             },
             {
               "codepoint": "U+1F94C",
               "name": "curling stone",
-              "keywords": ["curling stone", "game", "rock"]
+              "keywords": ["curling", "game", "rock", "stone"]
             }
           ]
         },
@@ -5813,7 +11955,16 @@
             {
               "codepoint": "U+1F3AF",
               "name": "bullseye",
-              "keywords": ["bullseye", "dart", "direct hit", "game", "hit", "target"]
+              "keywords": [
+                "bull",
+                "bullseye",
+                "dart",
+                "direct",
+                "entertainment",
+                "game",
+                "hit",
+                "target"
+              ]
             },
             {
               "codepoint": "U+1FA80",
@@ -5828,52 +11979,77 @@
             {
               "codepoint": "U+1F52B",
               "name": "water pistol",
-              "keywords": ["gun", "handgun", "pistol", "revolver", "tool", "water", "weapon"]
+              "keywords": [
+                "gun",
+                "handgun",
+                "pistol",
+                "revolver",
+                "tool",
+                "water",
+                "weapon"
+              ]
             },
             {
               "codepoint": "U+1F3B1",
               "name": "pool 8 ball",
-              "keywords": ["8", "ball", "billiard", "eight", "game", "pool 8 ball"]
+              "keywords": [
+                "8",
+                "8ball",
+                "ball",
+                "billiard",
+                "eight",
+                "game",
+                "pool"
+              ]
             },
             {
               "codepoint": "U+1F52E",
               "name": "crystal ball",
-              "keywords": ["ball", "crystal", "fairy tale", "fantasy", "fortune", "tool"]
+              "keywords": [
+                "ball",
+                "crystal",
+                "fairy",
+                "fairytale",
+                "fantasy",
+                "fortune",
+                "future",
+                "magic",
+                "tale",
+                "tool"
+              ]
             },
             {
               "codepoint": "U+1FA84",
               "name": "magic wand",
-              "keywords": ["magic", "magic wand", "witch", "wizard"]
-            },
-            {
-              "codepoint": "U+1F9FF",
-              "name": "nazar amulet",
-              "keywords": ["bead", "charm", "evil-eye", "nazar", "nazar amulet", "talisman"]
-            },
-            {
-              "codepoint": "U+1FAAC",
-              "name": "hamsa",
-              "keywords": ["amulet", "Fatima", "hand", "Mary", "Miriam", "protection"]
+              "keywords": ["magic", "magician", "wand", "witch", "wizard"]
             },
             {
               "codepoint": "U+1F3AE",
               "name": "video game",
-              "keywords": ["controller", "game", "video game"]
+              "keywords": ["controller", "entertainment", "game", "video"]
             },
             {
               "codepoint": "U+1F579",
               "name": "joystick",
-              "keywords": ["game", "joystick", "video game"]
+              "keywords": ["game", "joystick", "video", "videogame"]
             },
             {
               "codepoint": "U+1F3B0",
               "name": "slot machine",
-              "keywords": ["game", "slot", "slot machine"]
+              "keywords": [
+                "casino",
+                "gamble",
+                "gambling",
+                "game",
+                "machine",
+                "slot",
+                "slots"
+              ]
             },
             {
               "codepoint": "U+1F3B2",
               "name": "game die",
-              "keywords": ["dice", "die", "game"]
+              "keywords": ["dice", "die", "entertainment", "game"]
             },
             {
               "codepoint": "U+1F9E9",
@@ -5883,47 +12059,82 @@
             {
               "codepoint": "U+1F9F8",
               "name": "teddy bear",
-              "keywords": ["plaything", "plush", "stuffed", "teddy bear", "toy"]
+              "keywords": [
+                "bear",
+                "plaything",
+                "plush",
+                "stuffed",
+                "teddy",
+                "toy"
+              ]
             },
             {
               "codepoint": "U+1FA85",
               "name": "piñata",
-              "keywords": ["celebration", "party", "piñata"]
+              "keywords": [
+                "candy",
+                "celebrate",
+                "celebration",
+                "cinco",
+                "de",
+                "festive",
+                "mayo",
+                "party",
+                "pinada",
+                "pinata",
+                "piñata"
+              ]
             },
             {
               "codepoint": "U+1FAA9",
               "name": "mirror ball",
-              "keywords": ["dance", "disco", "glitter", "party"]
+              "keywords": [
+                "ball",
+                "dance",
+                "disco",
+                "glitter",
+                "mirror",
+                "party"
+              ]
             },
             {
               "codepoint": "U+1FA86",
               "name": "nesting dolls",
-              "keywords": ["doll", "nesting", "nesting dolls", "russia"]
+              "keywords": [
+                "babooshka",
+                "baboushka",
+                "babushka",
+                "doll",
+                "dolls",
+                "matryoshka",
+                "nesting",
+                "russia"
+              ]
             },
             {
               "codepoint": "U+2660",
               "name": "spade suit",
-              "keywords": ["card", "game", "spade suit"]
+              "keywords": ["card", "game", "spade", "suit"]
             },
             {
               "codepoint": "U+2665",
               "name": "heart suit",
-              "keywords": ["card", "game", "heart suit"]
+              "keywords": ["card", "emotion", "game", "heart", "hearts", "suit"]
             },
             {
               "codepoint": "U+2666",
               "name": "diamond suit",
-              "keywords": ["card", "diamond suit", "game"]
+              "keywords": ["card", "diamond", "game", "suit"]
             },
             {
               "codepoint": "U+2663",
               "name": "club suit",
-              "keywords": ["card", "club suit", "game"]
+              "keywords": ["card", "club", "clubs", "game", "suit"]
             },
             {
               "codepoint": "U+265F",
               "name": "chess pawn",
-              "keywords": ["chess", "chess pawn", "dupe", "expendable"]
+              "keywords": ["chess", "dupe", "expendable", "pawn"]
             },
             {
               "codepoint": "U+1F0CF",
@@ -5933,12 +12144,19 @@
             {
               "codepoint": "U+1F004",
               "name": "mahjong red dragon",
-              "keywords": ["game", "mahjong", "mahjong red dragon", "red"]
+              "keywords": ["dragon", "game", "mahjong", "red"]
             },
             {
               "codepoint": "U+1F3B4",
               "name": "flower playing cards",
-              "keywords": ["card", "flower", "flower playing cards", "game", "Japanese", "playing"]
+              "keywords": [
+                "card",
+                "cards",
+                "flower",
+                "game",
+                "Japanese",
+                "playing"
+              ]
             }
           ]
         },
@@ -5948,17 +12166,47 @@
             {
               "codepoint": "U+1F3AD",
               "name": "performing arts",
-              "keywords": ["art", "mask", "performing", "performing arts", "theater", "theatre"]
+              "keywords": [
+                "actor",
+                "actress",
+                "art",
+                "arts",
+                "entertainment",
+                "mask",
+                "performing",
+                "theater",
+                "theatre",
+                "thespian"
+              ]
             },
             {
               "codepoint": "U+1F5BC",
               "name": "framed picture",
-              "keywords": ["art", "frame", "framed picture", "museum", "painting", "picture"]
+              "keywords": [
+                "art",
+                "frame",
+                "framed",
+                "museum",
+                "painting",
+                "picture"
+              ]
             },
             {
               "codepoint": "U+1F3A8",
               "name": "artist palette",
-              "keywords": ["art", "artist palette", "museum", "painting", "palette"]
+              "keywords": [
+                "art",
+                "artist",
+                "artsy",
+                "arty",
+                "colorful",
+                "creative",
+                "entertainment",
+                "museum",
+                "painter",
+                "painting",
+                "palette"
+              ]
             },
             {
               "codepoint": "U+1F9F5",
@@ -5968,7 +12216,16 @@
             {
               "codepoint": "U+1FAA1",
               "name": "sewing needle",
-              "keywords": ["embroidery", "needle", "sewing", "stitches", "sutures", "tailoring"]
+              "keywords": [
+                "embroidery",
+                "needle",
+                "sew",
+                "sewing",
+                "stitches",
+                "sutures",
+                "tailoring",
+                "thread"
+              ]
             },
             {
               "codepoint": "U+1F9F6",
@@ -5978,7 +12235,15 @@
             {
               "codepoint": "U+1FAA2",
               "name": "knot",
-              "keywords": ["knot", "rope", "tangled", "tie", "twine", "twist"]
+              "keywords": [
+                "cord",
+                "knot",
+                "rope",
+                "tangled",
+                "tie",
+                "twine",
+                "twist"
+              ]
             }
           ]
         }
@@ -5993,7 +12258,13 @@
             {
               "codepoint": "U+1F453",
               "name": "glasses",
-              "keywords": ["clothing", "eye", "eyeglasses", "eyewear", "glasses"]
+              "keywords": [
+                "clothing",
+                "eye",
+                "eyeglasses",
+                "eyewear",
+                "glasses"
+              ]
             },
             {
               "codepoint": "U+1F576",
@@ -6003,12 +12274,30 @@
             {
               "codepoint": "U+1F97D",
               "name": "goggles",
-              "keywords": ["eye protection", "goggles", "swimming", "welding"]
+              "keywords": [
+                "dive",
+                "eye",
+                "goggles",
+                "protection",
+                "scuba",
+                "swimming",
+                "welding"
+              ]
             },
             {
               "codepoint": "U+1F97C",
               "name": "lab coat",
-              "keywords": ["doctor", "experiment", "lab coat", "scientist"]
+              "keywords": [
+                "clothes",
+                "coat",
+                "doctor",
+                "dr",
+                "experiment",
+                "jacket",
+                "lab",
+                "scientist",
+                "white"
+              ]
             },
             {
               "codepoint": "U+1F9BA",
@@ -6018,22 +12307,53 @@
             {
               "codepoint": "U+1F454",
               "name": "necktie",
-              "keywords": ["clothing", "necktie", "tie"]
+              "keywords": [
+                "clothing",
+                "employed",
+                "necktie",
+                "serious",
+                "shirt",
+                "tie"
+              ]
             },
             {
               "codepoint": "U+1F455",
               "name": "t-shirt",
-              "keywords": ["clothing", "shirt", "t-shirt", "tshirt"]
+              "keywords": [
+                "blue",
+                "casual",
+                "clothes",
+                "clothing",
+                "collar",
+                "dressed",
+                "shirt",
+                "shopping",
+                "t-shirt",
+                "tshirt",
+                "weekend"
+              ]
             },
             {
               "codepoint": "U+1F456",
               "name": "jeans",
-              "keywords": ["clothing", "jeans", "pants", "trousers"]
+              "keywords": [
+                "blue",
+                "casual",
+                "clothes",
+                "clothing",
+                "denim",
+                "dressed",
+                "jeans",
+                "pants",
+                "shopping",
+                "trousers",
+                "weekend"
+              ]
             },
             {
               "codepoint": "U+1F9E3",
               "name": "scarf",
-              "keywords": ["neck", "scarf"]
+              "keywords": ["bundle", "cold", "neck", "scarf", "up"]
             },
             {
               "codepoint": "U+1F9E4",
@@ -6043,7 +12363,7 @@
             {
               "codepoint": "U+1F9E5",
               "name": "coat",
-              "keywords": ["coat", "jacket"]
+              "keywords": ["brr", "bundle", "coat", "cold", "jacket", "up"]
             },
             {
               "codepoint": "U+1F9E6",
@@ -6053,12 +12373,19 @@
             {
               "codepoint": "U+1F457",
               "name": "dress",
-              "keywords": ["clothing", "dress"]
+              "keywords": [
+                "clothes",
+                "clothing",
+                "dress",
+                "dressed",
+                "fancy",
+                "shopping"
+              ]
             },
             {
               "codepoint": "U+1F458",
               "name": "kimono",
-              "keywords": ["clothing", "kimono"]
+              "keywords": ["clothing", "comfortable", "kimono"]
             },
             {
               "codepoint": "U+1F97B",
@@ -6068,162 +12395,394 @@
             {
               "codepoint": "U+1FA71",
               "name": "one-piece swimsuit",
-              "keywords": ["bathing suit", "one-piece swimsuit"]
+              "keywords": ["bathing", "one-piece", "suit", "swimsuit"]
             },
             {
               "codepoint": "U+1FA72",
               "name": "briefs",
-              "keywords": ["bathing suit", "briefs", "one-piece", "swimsuit", "underwear"]
+              "keywords": [
+                "bathing",
+                "briefs",
+                "one-piece",
+                "suit",
+                "swimsuit",
+                "underwear"
+              ]
             },
             {
               "codepoint": "U+1FA73",
               "name": "shorts",
-              "keywords": ["bathing suit", "pants", "shorts", "underwear"]
+              "keywords": [
+                "bathing",
+                "pants",
+                "shorts",
+                "suit",
+                "swimsuit",
+                "underwear"
+              ]
             },
             {
               "codepoint": "U+1F459",
               "name": "bikini",
-              "keywords": ["bikini", "clothing", "swim"]
+              "keywords": [
+                "bathing",
+                "beach",
+                "bikini",
+                "clothing",
+                "pool",
+                "suit",
+                "swim"
+              ]
             },
             {
               "codepoint": "U+1F45A",
               "name": "woman’s clothes",
-              "keywords": ["clothing", "woman", "woman’s clothes"]
+              "keywords": [
+                "blouse",
+                "clothes",
+                "clothing",
+                "collar",
+                "dress",
+                "dressed",
+                "lady",
+                "shirt",
+                "shopping",
+                "woman",
+                "woman’s"
+              ]
             },
             {
               "codepoint": "U+1FAAD",
               "name": "folding hand fan",
-              "keywords": ["cooling", "dance", "fan", "flutter", "folding hand fan", "hot", "shy"]
+              "keywords": [
+                "clack",
+                "clap",
+                "cool",
+                "cooling",
+                "dance",
+                "fan",
+                "flirt",
+                "flutter",
+                "folding",
+                "hand",
+                "hot",
+                "shy"
+              ]
             },
             {
               "codepoint": "U+1F45B",
               "name": "purse",
-              "keywords": ["clothing", "coin", "purse"]
+              "keywords": [
+                "clothes",
+                "clothing",
+                "coin",
+                "dress",
+                "fancy",
+                "handbag",
+                "purse",
+                "shopping"
+              ]
             },
             {
               "codepoint": "U+1F45C",
               "name": "handbag",
-              "keywords": ["bag", "clothing", "handbag", "purse"]
+              "keywords": [
+                "bag",
+                "clothes",
+                "clothing",
+                "dress",
+                "handbag",
+                "lady",
+                "purse",
+                "shopping"
+              ]
             },
             {
               "codepoint": "U+1F45D",
               "name": "clutch bag",
-              "keywords": ["bag", "clothing", "clutch bag", "pouch"]
+              "keywords": [
+                "bag",
+                "clothes",
+                "clothing",
+                "clutch",
+                "dress",
+                "handbag",
+                "pouch",
+                "purse"
+              ]
             },
             {
               "codepoint": "U+1F6CD",
               "name": "shopping bags",
-              "keywords": ["bag", "hotel", "shopping", "shopping bags"]
+              "keywords": ["bag", "bags", "hotel", "shopping"]
             },
             {
               "codepoint": "U+1F392",
               "name": "backpack",
-              "keywords": ["backpack", "bag", "rucksack", "satchel", "school"]
+              "keywords": [
+                "backpack",
+                "backpacking",
+                "bag",
+                "bookbag",
+                "education",
+                "rucksack",
+                "satchel",
+                "school"
+              ]
             },
             {
               "codepoint": "U+1FA74",
               "name": "thong sandal",
-              "keywords": ["beach sandals", "sandals", "thong sandal", "thong sandals", "thongs", "zōri"]
+              "keywords": [
+                "beach",
+                "flip",
+                "flop",
+                "sandal",
+                "sandals",
+                "shoe",
+                "thong",
+                "thongs",
+                "zōri"
+              ]
             },
             {
               "codepoint": "U+1F45E",
               "name": "man’s shoe",
-              "keywords": ["clothing", "man", "man’s shoe", "shoe"]
+              "keywords": [
+                "brown",
+                "clothes",
+                "clothing",
+                "feet",
+                "foot",
+                "kick",
+                "man",
+                "man’s",
+                "shoe",
+                "shoes",
+                "shopping"
+              ]
             },
             {
               "codepoint": "U+1F45F",
               "name": "running shoe",
-              "keywords": ["athletic", "clothing", "running shoe", "shoe", "sneaker"]
+              "keywords": [
+                "athletic",
+                "clothes",
+                "clothing",
+                "fast",
+                "kick",
+                "running",
+                "shoe",
+                "shoes",
+                "shopping",
+                "sneaker",
+                "tennis"
+              ]
             },
             {
               "codepoint": "U+1F97E",
               "name": "hiking boot",
-              "keywords": ["backpacking", "boot", "camping", "hiking"]
+              "keywords": [
+                "backpacking",
+                "boot",
+                "brown",
+                "camping",
+                "hiking",
+                "outdoors",
+                "shoe"
+              ]
             },
             {
               "codepoint": "U+1F97F",
               "name": "flat shoe",
-              "keywords": ["ballet flat", "flat shoe", "slip-on", "slipper"]
+              "keywords": [
+                "ballet",
+                "comfy",
+                "flat",
+                "flats",
+                "shoe",
+                "slip-on",
+                "slipper"
+              ]
             },
             {
               "codepoint": "U+1F460",
               "name": "high-heeled shoe",
-              "keywords": ["clothing", "heel", "high-heeled shoe", "shoe", "woman"]
+              "keywords": [
+                "clothes",
+                "clothing",
+                "dress",
+                "fashion",
+                "heel",
+                "heels",
+                "high-heeled",
+                "shoe",
+                "shoes",
+                "shopping",
+                "stiletto",
+                "woman"
+              ]
             },
             {
               "codepoint": "U+1F461",
               "name": "woman’s sandal",
-              "keywords": ["clothing", "sandal", "shoe", "woman", "woman’s sandal"]
+              "keywords": ["clothing", "sandal", "shoe", "woman", "woman’s"]
             },
             {
               "codepoint": "U+1FA70",
               "name": "ballet shoes",
-              "keywords": ["ballet", "ballet shoes", "dance"]
+              "keywords": ["ballet", "dance", "shoes"]
             },
             {
               "codepoint": "U+1F462",
               "name": "woman’s boot",
-              "keywords": ["boot", "clothing", "shoe", "woman", "woman’s boot"]
+              "keywords": [
+                "boot",
+                "clothes",
+                "clothing",
+                "dress",
+                "shoe",
+                "shoes",
+                "shopping",
+                "woman",
+                "woman’s"
+              ]
             },
             {
               "codepoint": "U+1FAAE",
               "name": "hair pick",
-              "keywords": ["Afro", "comb", "hair", "pick"]
+              "keywords": ["Afro", "comb", "groom", "hair", "pick"]
             },
             {
               "codepoint": "U+1F451",
               "name": "crown",
-              "keywords": ["clothing", "crown", "king", "queen"]
+              "keywords": [
+                "clothing",
+                "crown",
+                "family",
+                "king",
+                "medieval",
+                "queen",
+                "royal",
+                "royalty",
+                "win"
+              ]
             },
             {
               "codepoint": "U+1F452",
               "name": "woman’s hat",
-              "keywords": ["clothing", "hat", "woman", "woman’s hat"]
+              "keywords": [
+                "clothes",
+                "clothing",
+                "garden",
+                "hat",
+                "hats",
+                "party",
+                "woman",
+                "woman’s"
+              ]
             },
             {
               "codepoint": "U+1F3A9",
               "name": "top hat",
-              "keywords": ["clothing", "hat", "top", "tophat"]
+              "keywords": [
+                "clothes",
+                "clothing",
+                "fancy",
+                "formal",
+                "hat",
+                "magic",
+                "top",
+                "tophat"
+              ]
             },
             {
               "codepoint": "U+1F393",
               "name": "graduation cap",
-              "keywords": ["cap", "celebration", "clothing", "graduation", "hat"]
+              "keywords": [
+                "cap",
+                "celebration",
+                "clothing",
+                "education",
+                "graduation",
+                "hat",
+                "scholar"
+              ]
             },
             {
               "codepoint": "U+1F9E2",
               "name": "billed cap",
-              "keywords": ["baseball cap", "billed cap"]
+              "keywords": ["baseball", "bent", "billed", "cap", "dad", "hat"]
             },
             {
               "codepoint": "U+1FA96",
               "name": "military helmet",
-              "keywords": ["army", "helmet", "military", "soldier", "warrior"]
+              "keywords": [
+                "army",
+                "helmet",
+                "military",
+                "soldier",
+                "war",
+                "warrior"
+              ]
             },
             {
               "codepoint": "U+26D1",
               "name": "rescue worker’s helmet",
-              "keywords": ["aid", "cross", "face", "hat", "helmet", "rescue worker’s helmet"]
+              "keywords": [
+                "aid",
+                "cross",
+                "face",
+                "hat",
+                "helmet",
+                "rescue",
+                "worker’s"
+              ]
             },
             {
               "codepoint": "U+1F4FF",
               "name": "prayer beads",
-              "keywords": ["beads", "clothing", "necklace", "prayer", "religion"]
+              "keywords": [
+                "beads",
+                "clothing",
+                "necklace",
+                "prayer",
+                "religion"
+              ]
             },
             {
               "codepoint": "U+1F484",
               "name": "lipstick",
-              "keywords": ["cosmetics", "lipstick", "makeup"]
+              "keywords": ["cosmetics", "date", "lipstick", "makeup"]
             },
             {
               "codepoint": "U+1F48D",
               "name": "ring",
-              "keywords": ["diamond", "ring"]
+              "keywords": [
+                "diamond",
+                "engaged",
+                "engagement",
+                "married",
+                "ring",
+                "romance",
+                "shiny",
+                "sparkling",
+                "wedding"
+              ]
             },
             {
               "codepoint": "U+1F48E",
               "name": "gem stone",
-              "keywords": ["diamond", "gem", "gem stone", "jewel"]
+              "keywords": [
+                "diamond",
+                "engagement",
+                "gem",
+                "jewel",
+                "money",
+                "romance",
+                "stone",
+                "wedding"
+              ]
             }
           ]
         },
@@ -6233,32 +12792,53 @@
             {
               "codepoint": "U+1F507",
               "name": "muted speaker",
-              "keywords": ["mute", "muted speaker", "quiet", "silent", "speaker"]
+              "keywords": [
+                "mute",
+                "muted",
+                "quiet",
+                "silent",
+                "sound",
+                "speaker"
+              ]
             },
             {
               "codepoint": "U+1F508",
               "name": "speaker low volume",
-              "keywords": ["soft", "speaker low volume"]
+              "keywords": ["low", "soft", "sound", "speaker", "volume"]
             },
             {
               "codepoint": "U+1F509",
               "name": "speaker medium volume",
-              "keywords": ["medium", "speaker medium volume"]
+              "keywords": ["medium", "sound", "speaker", "volume"]
             },
             {
               "codepoint": "U+1F50A",
               "name": "speaker high volume",
-              "keywords": ["loud", "speaker high volume"]
+              "keywords": [
+                "high",
+                "loud",
+                "music",
+                "sound",
+                "speaker",
+                "volume"
+              ]
             },
             {
               "codepoint": "U+1F4E2",
               "name": "loudspeaker",
-              "keywords": ["loud", "loudspeaker", "public address"]
+              "keywords": [
+                "address",
+                "communication",
+                "loud",
+                "loudspeaker",
+                "public",
+                "sound"
+              ]
             },
             {
               "codepoint": "U+1F4E3",
               "name": "megaphone",
-              "keywords": ["cheering", "megaphone"]
+              "keywords": ["cheering", "megaphone", "sound"]
             },
             {
               "codepoint": "U+1F4EF",
@@ -6268,12 +12848,23 @@
             {
               "codepoint": "U+1F514",
               "name": "bell",
-              "keywords": ["bell"]
+              "keywords": ["bell", "break", "church", "sound"]
             },
             {
               "codepoint": "U+1F515",
               "name": "bell with slash",
-              "keywords": ["bell", "bell with slash", "forbidden", "mute", "quiet", "silent"]
+              "keywords": [
+                "bell",
+                "forbidden",
+                "mute",
+                "no",
+                "not",
+                "prohibited",
+                "quiet",
+                "silent",
+                "slash",
+                "sound"
+              ]
             }
           ]
         },
@@ -6283,17 +12874,17 @@
             {
               "codepoint": "U+1F3BC",
               "name": "musical score",
-              "keywords": ["music", "musical score", "score"]
+              "keywords": ["music", "musical", "note", "score"]
             },
             {
               "codepoint": "U+1F3B5",
               "name": "musical note",
-              "keywords": ["music", "musical note", "note"]
+              "keywords": ["music", "musical", "note", "sound"]
             },
             {
               "codepoint": "U+1F3B6",
               "name": "musical notes",
-              "keywords": ["music", "musical notes", "note", "notes"]
+              "keywords": ["music", "musical", "note", "notes", "sound"]
             },
             {
               "codepoint": "U+1F399",
@@ -6313,22 +12904,29 @@
             {
               "codepoint": "U+1F3A4",
               "name": "microphone",
-              "keywords": ["karaoke", "mic", "microphone"]
+              "keywords": [
+                "karaoke",
+                "mic",
+                "microphone",
+                "music",
+                "sing",
+                "sound"
+              ]
             },
             {
               "codepoint": "U+1F3A7",
               "name": "headphone",
-              "keywords": ["earbud", "headphone"]
+              "keywords": ["earbud", "headphone", "sound"]
             },
             {
               "codepoint": "U+1F4FB",
               "name": "radio",
-              "keywords": ["radio", "video"]
+              "keywords": ["entertainment", "radio", "tbt", "video"]
             }
           ]
         },
         {
-          "category": "musical_instrument",
+          "category": "musical-instrument",
           "contents": [
             {
               "codepoint": "U+1F3B7",
@@ -6338,17 +12936,31 @@
             {
               "codepoint": "U+1FA97",
               "name": "accordion",
-              "keywords": ["accordion", "concertina", "squeeze box"]
+              "keywords": [
+                "accordion",
+                "box",
+                "concertina",
+                "instrument",
+                "music",
+                "squeeze",
+                "squeezebox"
+              ]
             },
             {
               "codepoint": "U+1F3B8",
               "name": "guitar",
-              "keywords": ["guitar", "instrument", "music"]
+              "keywords": ["guitar", "instrument", "music", "strat"]
             },
             {
               "codepoint": "U+1F3B9",
               "name": "musical keyboard",
-              "keywords": ["instrument", "keyboard", "music", "musical keyboard", "piano"]
+              "keywords": [
+                "instrument",
+                "keyboard",
+                "music",
+                "musical",
+                "piano"
+              ]
             },
             {
               "codepoint": "U+1F3BA",
@@ -6373,17 +12985,60 @@
             {
               "codepoint": "U+1FA98",
               "name": "long drum",
-              "keywords": ["beat", "conga", "drum", "long drum", "rhythm"]
+              "keywords": [
+                "beat",
+                "conga",
+                "drum",
+                "instrument",
+                "long",
+                "rhythm"
+              ]
             },
             {
               "codepoint": "U+1FA87",
               "name": "maracas",
-              "keywords": ["instrument", "maracas", "music", "percussion", "rattle", "shake"]
+              "keywords": [
+                "cha",
+                "dance",
+                "instrument",
+                "maracas",
+                "music",
+                "party",
+                "percussion",
+                "rattle",
+                "shake",
+                "shaker"
+              ]
             },
             {
               "codepoint": "U+1FA88",
               "name": "flute",
-              "keywords": ["fife", "flute", "music", "pipe", "recorder", "woodwind"]
+              "keywords": [
+                "band",
+                "fife",
+                "flautist",
+                "flute",
+                "instrument",
+                "marching",
+                "music",
+                "orchestra",
+                "piccolo",
+                "pipe",
+                "recorder",
+                "woodwind"
+              ]
+            },
+            {
+              "codepoint": "U+1FA89",
+              "name": "harp",
+              "keywords": [
+                "cupid",
+                "harp",
+                "instrument",
+                "love",
+                "music",
+                "orchestra"
+              ]
             }
           ]
         },
@@ -6393,12 +13048,28 @@
             {
               "codepoint": "U+1F4F1",
               "name": "mobile phone",
-              "keywords": ["cell", "mobile", "phone", "telephone"]
+              "keywords": [
+                "cell",
+                "communication",
+                "mobile",
+                "phone",
+                "telephone"
+              ]
             },
             {
               "codepoint": "U+1F4F2",
               "name": "mobile phone with arrow",
-              "keywords": ["arrow", "cell", "mobile", "mobile phone with arrow", "phone", "receive"]
+              "keywords": [
+                "arrow",
+                "build",
+                "call",
+                "cell",
+                "communication",
+                "mobile",
+                "phone",
+                "receive",
+                "telephone"
+              ]
             },
             {
               "codepoint": "U+260E",
@@ -6408,17 +13079,23 @@
             {
               "codepoint": "U+1F4DE",
               "name": "telephone receiver",
-              "keywords": ["phone", "receiver", "telephone"]
+              "keywords": [
+                "communication",
+                "phone",
+                "receiver",
+                "telephone",
+                "voip"
+              ]
             },
             {
               "codepoint": "U+1F4DF",
               "name": "pager",
-              "keywords": ["pager"]
+              "keywords": ["communication", "pager"]
             },
             {
               "codepoint": "U+1F4E0",
               "name": "fax machine",
-              "keywords": ["fax", "fax machine"]
+              "keywords": ["communication", "fax", "machine"]
             }
           ]
         },
@@ -6433,7 +13110,14 @@
             {
               "codepoint": "U+1FAAB",
               "name": "low battery",
-              "keywords": ["electronic", "low energy"]
+              "keywords": [
+                "battery",
+                "drained",
+                "electronic",
+                "energy",
+                "low",
+                "power"
+              ]
             },
             {
               "codepoint": "U+1F50C",
@@ -6443,12 +13127,12 @@
             {
               "codepoint": "U+1F4BB",
               "name": "laptop",
-              "keywords": ["computer", "laptop", "pc", "personal"]
+              "keywords": ["computer", "laptop", "office", "pc", "personal"]
             },
             {
               "codepoint": "U+1F5A5",
               "name": "desktop computer",
-              "keywords": ["computer", "desktop"]
+              "keywords": ["computer", "desktop", "monitor"]
             },
             {
               "codepoint": "U+1F5A8",
@@ -6463,7 +13147,7 @@
             {
               "codepoint": "U+1F5B1",
               "name": "computer mouse",
-              "keywords": ["computer", "computer mouse"]
+              "keywords": ["computer", "mouse"]
             },
             {
               "codepoint": "U+1F5B2",
@@ -6483,17 +13167,31 @@
             {
               "codepoint": "U+1F4BF",
               "name": "optical disk",
-              "keywords": ["cd", "computer", "disk", "optical"]
+              "keywords": [
+                "blu-ray",
+                "CD",
+                "computer",
+                "disk",
+                "dvd",
+                "optical"
+              ]
             },
             {
               "codepoint": "U+1F4C0",
               "name": "dvd",
-              "keywords": ["blu-ray", "computer", "disk", "dvd", "optical"]
+              "keywords": [
+                "Blu-ray",
+                "cd",
+                "computer",
+                "disk",
+                "DVD",
+                "optical"
+              ]
             },
             {
               "codepoint": "U+1F9EE",
               "name": "abacus",
-              "keywords": ["abacus", "calculation"]
+              "keywords": ["abacus", "calculation", "calculator"]
             }
           ]
         },
@@ -6503,7 +13201,15 @@
             {
               "codepoint": "U+1F3A5",
               "name": "movie camera",
-              "keywords": ["camera", "cinema", "movie"]
+              "keywords": [
+                "bollywood",
+                "camera",
+                "cinema",
+                "film",
+                "hollywood",
+                "movie",
+                "record"
+              ]
             },
             {
               "codepoint": "U+1F39E",
@@ -6518,7 +13224,7 @@
             {
               "codepoint": "U+1F3AC",
               "name": "clapper board",
-              "keywords": ["clapper", "clapper board", "movie"]
+              "keywords": ["action", "board", "clapper", "movie"]
             },
             {
               "codepoint": "U+1F4FA",
@@ -6528,32 +13234,69 @@
             {
               "codepoint": "U+1F4F7",
               "name": "camera",
-              "keywords": ["camera", "video"]
+              "keywords": [
+                "camera",
+                "photo",
+                "selfie",
+                "snap",
+                "tbt",
+                "trip",
+                "video"
+              ]
             },
             {
               "codepoint": "U+1F4F8",
               "name": "camera with flash",
-              "keywords": ["camera", "camera with flash", "flash", "video"]
+              "keywords": ["camera", "flash", "video"]
             },
             {
               "codepoint": "U+1F4F9",
               "name": "video camera",
-              "keywords": ["camera", "video"]
+              "keywords": ["camcorder", "camera", "tbt", "video"]
             },
             {
               "codepoint": "U+1F4FC",
               "name": "videocassette",
-              "keywords": ["tape", "vhs", "video", "videocassette"]
+              "keywords": [
+                "old",
+                "school",
+                "tape",
+                "vcr",
+                "vhs",
+                "video",
+                "videocassette"
+              ]
             },
             {
               "codepoint": "U+1F50D",
               "name": "magnifying glass tilted left",
-              "keywords": ["glass", "magnifying", "magnifying glass tilted left", "search", "tool"]
+              "keywords": [
+                "glass",
+                "lab",
+                "left",
+                "left-pointing",
+                "magnifying",
+                "science",
+                "search",
+                "tilted",
+                "tool"
+              ]
             },
             {
               "codepoint": "U+1F50E",
               "name": "magnifying glass tilted right",
-              "keywords": ["glass", "magnifying", "magnifying glass tilted right", "search", "tool"]
+              "keywords": [
+                "contact",
+                "glass",
+                "lab",
+                "magnifying",
+                "right",
+                "right-pointing",
+                "science",
+                "search",
+                "tilted",
+                "tool"
+              ]
             },
             {
               "codepoint": "U+1F56F",
@@ -6573,52 +13316,109 @@
             {
               "codepoint": "U+1F3EE",
               "name": "red paper lantern",
-              "keywords": ["bar", "lantern", "light", "red", "red paper lantern"]
+              "keywords": [
+                "bar",
+                "lantern",
+                "light",
+                "paper",
+                "red",
+                "restaurant"
+              ]
             },
             {
               "codepoint": "U+1FA94",
               "name": "diya lamp",
-              "keywords": ["diya", "lamp", "oil"]
+              "keywords": ["diya", "lamp", "light", "oil"]
             }
           ]
         },
         {
-          "category": "book_paper",
+          "category": "book-paper",
           "contents": [
             {
               "codepoint": "U+1F4D4",
               "name": "notebook with decorative cover",
-              "keywords": ["book", "cover", "decorated", "notebook", "notebook with decorative cover"]
+              "keywords": [
+                "book",
+                "cover",
+                "decorated",
+                "decorative",
+                "education",
+                "notebook",
+                "school",
+                "writing"
+              ]
             },
             {
               "codepoint": "U+1F4D5",
               "name": "closed book",
-              "keywords": ["book", "closed"]
+              "keywords": ["book", "closed", "education"]
             },
             {
               "codepoint": "U+1F4D6",
               "name": "open book",
-              "keywords": ["book", "open"]
+              "keywords": [
+                "book",
+                "education",
+                "fantasy",
+                "knowledge",
+                "library",
+                "novels",
+                "open",
+                "reading"
+              ]
             },
             {
               "codepoint": "U+1F4D7",
               "name": "green book",
-              "keywords": ["book", "green"]
+              "keywords": [
+                "book",
+                "education",
+                "fantasy",
+                "green",
+                "library",
+                "reading"
+              ]
             },
             {
               "codepoint": "U+1F4D8",
               "name": "blue book",
-              "keywords": ["blue", "book"]
+              "keywords": [
+                "blue",
+                "book",
+                "education",
+                "fantasy",
+                "library",
+                "reading"
+              ]
             },
             {
               "codepoint": "U+1F4D9",
               "name": "orange book",
-              "keywords": ["book", "orange"]
+              "keywords": [
+                "book",
+                "education",
+                "fantasy",
+                "library",
+                "orange",
+                "reading"
+              ]
             },
             {
               "codepoint": "U+1F4DA",
               "name": "books",
-              "keywords": ["book", "books"]
+              "keywords": [
+                "book",
+                "books",
+                "education",
+                "fantasy",
+                "knowledge",
+                "library",
+                "novels",
+                "reading",
+                "school",
+                "study"
+              ]
             },
             {
               "codepoint": "U+1F4D3",
@@ -6633,7 +13433,7 @@
             {
               "codepoint": "U+1F4C3",
               "name": "page with curl",
-              "keywords": ["curl", "document", "page", "page with curl"]
+              "keywords": ["curl", "document", "page", "paper"]
             },
             {
               "codepoint": "U+1F4DC",
@@ -6643,17 +13443,17 @@
             {
               "codepoint": "U+1F4C4",
               "name": "page facing up",
-              "keywords": ["document", "page", "page facing up"]
+              "keywords": ["document", "facing", "page", "paper", "up"]
             },
             {
               "codepoint": "U+1F4F0",
               "name": "newspaper",
-              "keywords": ["news", "newspaper", "paper"]
+              "keywords": ["communication", "news", "newspaper", "paper"]
             },
             {
               "codepoint": "U+1F5DE",
               "name": "rolled-up newspaper",
-              "keywords": ["news", "newspaper", "paper", "rolled", "rolled-up newspaper"]
+              "keywords": ["news", "newspaper", "paper", "rolled", "rolled-up"]
             },
             {
               "codepoint": "U+1F4D1",
@@ -6668,7 +13468,7 @@
             {
               "codepoint": "U+1F3F7",
               "name": "label",
-              "keywords": ["label"]
+              "keywords": ["label", "tag"]
             }
           ]
         },
@@ -6678,52 +13478,157 @@
             {
               "codepoint": "U+1F4B0",
               "name": "money bag",
-              "keywords": ["bag", "dollar", "money", "moneybag"]
+              "keywords": [
+                "bag",
+                "bank",
+                "bet",
+                "billion",
+                "cash",
+                "cost",
+                "dollar",
+                "gold",
+                "million",
+                "money",
+                "moneybag",
+                "paid",
+                "paying",
+                "pot",
+                "rich",
+                "win"
+              ]
             },
             {
               "codepoint": "U+1FA99",
               "name": "coin",
-              "keywords": ["coin", "gold", "metal", "money", "silver", "treasure"]
+              "keywords": [
+                "coin",
+                "dollar",
+                "euro",
+                "gold",
+                "metal",
+                "money",
+                "rich",
+                "silver",
+                "treasure"
+              ]
             },
             {
               "codepoint": "U+1F4B4",
               "name": "yen banknote",
-              "keywords": ["banknote", "bill", "currency", "money", "note", "yen"]
+              "keywords": [
+                "bank",
+                "banknote",
+                "bill",
+                "currency",
+                "money",
+                "note",
+                "yen"
+              ]
             },
             {
               "codepoint": "U+1F4B5",
               "name": "dollar banknote",
-              "keywords": ["banknote", "bill", "currency", "dollar", "money", "note"]
+              "keywords": [
+                "bank",
+                "banknote",
+                "bill",
+                "currency",
+                "dollar",
+                "money",
+                "note"
+              ]
             },
             {
               "codepoint": "U+1F4B6",
               "name": "euro banknote",
-              "keywords": ["banknote", "bill", "currency", "euro", "money", "note"]
+              "keywords": [
+                "100",
+                "bank",
+                "banknote",
+                "bill",
+                "currency",
+                "euro",
+                "money",
+                "note",
+                "rich"
+              ]
             },
             {
               "codepoint": "U+1F4B7",
               "name": "pound banknote",
-              "keywords": ["banknote", "bill", "currency", "money", "note", "pound"]
+              "keywords": [
+                "bank",
+                "banknote",
+                "bill",
+                "billion",
+                "cash",
+                "currency",
+                "money",
+                "note",
+                "pound",
+                "pounds"
+              ]
             },
             {
               "codepoint": "U+1F4B8",
               "name": "money with wings",
-              "keywords": ["banknote", "bill", "fly", "money", "money with wings", "wings"]
+              "keywords": [
+                "bank",
+                "banknote",
+                "bill",
+                "billion",
+                "cash",
+                "dollar",
+                "fly",
+                "million",
+                "money",
+                "note",
+                "pay",
+                "wings"
+              ]
             },
             {
               "codepoint": "U+1F4B3",
               "name": "credit card",
-              "keywords": ["card", "credit", "money"]
+              "keywords": [
+                "bank",
+                "card",
+                "cash",
+                "charge",
+                "credit",
+                "money",
+                "pay"
+              ]
             },
             {
               "codepoint": "U+1F9FE",
               "name": "receipt",
-              "keywords": ["accounting", "bookkeeping", "evidence", "proof", "receipt"]
+              "keywords": [
+                "accounting",
+                "bookkeeping",
+                "evidence",
+                "invoice",
+                "proof",
+                "receipt"
+              ]
             },
             {
               "codepoint": "U+1F4B9",
               "name": "chart increasing with yen",
-              "keywords": ["chart", "chart increasing with yen", "graph", "growth", "money", "yen"]
+              "keywords": [
+                "bank",
+                "chart",
+                "currency",
+                "graph",
+                "growth",
+                "increasing",
+                "market",
+                "money",
+                "rise",
+                "trend",
+                "upward",
+                "yen"
+              ]
             }
           ]
         },
@@ -6733,7 +13638,7 @@
             {
               "codepoint": "U+2709",
               "name": "envelope",
-              "keywords": ["email", "envelope", "letter"]
+              "keywords": ["e-mail", "email", "envelope", "letter"]
             },
             {
               "codepoint": "U+1F4E7",
@@ -6743,47 +13648,122 @@
             {
               "codepoint": "U+1F4E8",
               "name": "incoming envelope",
-              "keywords": ["e-mail", "email", "envelope", "incoming", "letter", "receive"]
+              "keywords": [
+                "delivering",
+                "e-mail",
+                "email",
+                "envelope",
+                "incoming",
+                "letter",
+                "mail",
+                "receive",
+                "sent"
+              ]
             },
             {
               "codepoint": "U+1F4E9",
               "name": "envelope with arrow",
-              "keywords": ["arrow", "e-mail", "email", "envelope", "envelope with arrow", "outgoing"]
+              "keywords": [
+                "arrow",
+                "communication",
+                "down",
+                "e-mail",
+                "email",
+                "envelope",
+                "letter",
+                "mail",
+                "outgoing",
+                "send",
+                "sent"
+              ]
             },
             {
               "codepoint": "U+1F4E4",
               "name": "outbox tray",
-              "keywords": ["box", "letter", "mail", "outbox", "sent", "tray"]
+              "keywords": [
+                "box",
+                "email",
+                "letter",
+                "mail",
+                "outbox",
+                "sent",
+                "tray"
+              ]
             },
             {
               "codepoint": "U+1F4E5",
               "name": "inbox tray",
-              "keywords": ["box", "inbox", "letter", "mail", "receive", "tray"]
+              "keywords": [
+                "box",
+                "email",
+                "inbox",
+                "letter",
+                "mail",
+                "receive",
+                "tray",
+                "zero"
+              ]
             },
             {
               "codepoint": "U+1F4E6",
               "name": "package",
-              "keywords": ["box", "package", "parcel"]
+              "keywords": [
+                "box",
+                "communication",
+                "delivery",
+                "package",
+                "parcel",
+                "shipping"
+              ]
             },
             {
               "codepoint": "U+1F4EB",
               "name": "closed mailbox with raised flag",
-              "keywords": ["closed", "closed mailbox with raised flag", "mail", "mailbox", "postbox"]
+              "keywords": [
+                "closed",
+                "communication",
+                "flag",
+                "mail",
+                "mailbox",
+                "postbox",
+                "raised"
+              ]
             },
             {
               "codepoint": "U+1F4EA",
               "name": "closed mailbox with lowered flag",
-              "keywords": ["closed", "closed mailbox with lowered flag", "lowered", "mail", "mailbox", "postbox"]
+              "keywords": [
+                "closed",
+                "flag",
+                "lowered",
+                "mail",
+                "mailbox",
+                "postbox"
+              ]
             },
             {
               "codepoint": "U+1F4EC",
               "name": "open mailbox with raised flag",
-              "keywords": ["mail", "mailbox", "open", "open mailbox with raised flag", "postbox"]
+              "keywords": [
+                "flag",
+                "mail",
+                "mailbox",
+                "open",
+                "postbox",
+                "raised"
+              ]
             },
             {
               "codepoint": "U+1F4ED",
               "name": "open mailbox with lowered flag",
-              "keywords": ["lowered", "mail", "mailbox", "open", "open mailbox with lowered flag", "postbox"]
+              "keywords": [
+                "flag",
+                "lowered",
+                "mail",
+                "mailbox",
+                "open",
+                "postbox"
+              ]
             },
             {
               "codepoint": "U+1F4EE",
@@ -6793,22 +13773,18 @@
             {
               "codepoint": "U+1F5F3",
               "name": "ballot box with ballot",
-              "keywords": ["ballot", "ballot box with ballot", "box"]
+              "keywords": ["ballot", "box"]
             }
           ]
         },
         {
           "category": "writing",
           "contents": [
-            {
-              "codepoint": "U+270F",
-              "name": "pencil",
-              "keywords": ["pencil"]
-            },
+            { "codepoint": "U+270F", "name": "pencil", "keywords": ["pencil"] },
             {
               "codepoint": "U+2712",
               "name": "black nib",
-              "keywords": ["black nib", "nib", "pen"]
+              "keywords": ["black", "nib", "pen"]
             },
             {
               "codepoint": "U+1F58B",
@@ -6833,7 +13809,7 @@
             {
               "codepoint": "U+1F4DD",
               "name": "memo",
-              "keywords": ["memo", "pencil"]
+              "keywords": ["communication", "media", "memo", "notes", "pencil"]
             }
           ]
         },
@@ -6843,7 +13819,7 @@
             {
               "codepoint": "U+1F4BC",
               "name": "briefcase",
-              "keywords": ["briefcase"]
+              "keywords": ["briefcase", "office"]
             },
             {
               "codepoint": "U+1F4C1",
@@ -6868,12 +13844,12 @@
             {
               "codepoint": "U+1F4C6",
               "name": "tear-off calendar",
-              "keywords": ["calendar", "tear-off calendar"]
+              "keywords": ["calendar", "tear-off"]
             },
             {
               "codepoint": "U+1F5D2",
               "name": "spiral notepad",
-              "keywords": ["note", "pad", "spiral", "spiral notepad"]
+              "keywords": ["note", "notepad", "pad", "spiral"]
             },
             {
               "codepoint": "U+1F5D3",
@@ -6883,37 +13859,56 @@
             {
               "codepoint": "U+1F4C7",
               "name": "card index",
-              "keywords": ["card", "index", "rolodex"]
+              "keywords": ["card", "index", "old", "rolodex", "school"]
             },
             {
               "codepoint": "U+1F4C8",
               "name": "chart increasing",
-              "keywords": ["chart", "chart increasing", "graph", "growth", "trend", "upward"]
+              "keywords": [
+                "chart",
+                "data",
+                "graph",
+                "growth",
+                "increasing",
+                "right",
+                "trend",
+                "up",
+                "upward"
+              ]
             },
             {
               "codepoint": "U+1F4C9",
               "name": "chart decreasing",
-              "keywords": ["chart", "chart decreasing", "down", "graph", "trend"]
+              "keywords": [
+                "chart",
+                "data",
+                "decreasing",
+                "down",
+                "downward",
+                "graph",
+                "negative",
+                "trend"
+              ]
             },
             {
               "codepoint": "U+1F4CA",
               "name": "bar chart",
-              "keywords": ["bar", "chart", "graph"]
+              "keywords": ["bar", "chart", "data", "graph"]
             },
             {
               "codepoint": "U+1F4CB",
               "name": "clipboard",
-              "keywords": ["clipboard"]
+              "keywords": ["clipboard", "do", "list", "notes"]
             },
             {
               "codepoint": "U+1F4CC",
               "name": "pushpin",
-              "keywords": ["pin", "pushpin"]
+              "keywords": ["collage", "pin", "pushpin"]
             },
             {
               "codepoint": "U+1F4CD",
               "name": "round pushpin",
-              "keywords": ["pin", "pushpin", "round pushpin"]
+              "keywords": ["location", "map", "pin", "pushpin", "round"]
             },
             {
               "codepoint": "U+1F4CE",
@@ -6923,22 +13918,38 @@
             {
               "codepoint": "U+1F587",
               "name": "linked paperclips",
-              "keywords": ["link", "linked paperclips", "paperclip"]
+              "keywords": ["link", "linked", "paperclip", "paperclips"]
             },
             {
               "codepoint": "U+1F4CF",
               "name": "straight ruler",
-              "keywords": ["ruler", "straight edge", "straight ruler"]
+              "keywords": [
+                "angle",
+                "edge",
+                "math",
+                "ruler",
+                "straight",
+                "straightedge"
+              ]
             },
             {
               "codepoint": "U+1F4D0",
               "name": "triangular ruler",
-              "keywords": ["ruler", "set", "triangle", "triangular ruler"]
+              "keywords": [
+                "angle",
+                "math",
+                "rule",
+                "ruler",
+                "set",
+                "slide",
+                "triangle",
+                "triangular"
+              ]
             },
             {
               "codepoint": "U+2702",
               "name": "scissors",
-              "keywords": ["cutting", "scissors", "tool"]
+              "keywords": ["cut", "cutting", "paper", "scissors", "tool"]
             },
             {
               "codepoint": "U+1F5C3",
@@ -6948,12 +13959,12 @@
             {
               "codepoint": "U+1F5C4",
               "name": "file cabinet",
-              "keywords": ["cabinet", "file", "filing"]
+              "keywords": ["cabinet", "file", "filing", "paper"]
             },
             {
               "codepoint": "U+1F5D1",
               "name": "wastebasket",
-              "keywords": ["wastebasket"]
+              "keywords": ["can", "garbage", "trash", "waste", "wastebasket"]
             }
           ]
         },
@@ -6963,27 +13974,27 @@
             {
               "codepoint": "U+1F512",
               "name": "locked",
-              "keywords": ["closed", "locked"]
+              "keywords": ["closed", "lock", "locked", "private"]
             },
             {
               "codepoint": "U+1F513",
               "name": "unlocked",
-              "keywords": ["lock", "open", "unlock", "unlocked"]
+              "keywords": ["cracked", "lock", "open", "unlock", "unlocked"]
             },
             {
               "codepoint": "U+1F50F",
               "name": "locked with pen",
-              "keywords": ["ink", "lock", "locked with pen", "nib", "pen", "privacy"]
+              "keywords": ["ink", "lock", "locked", "nib", "pen", "privacy"]
             },
             {
               "codepoint": "U+1F510",
               "name": "locked with key",
-              "keywords": ["closed", "key", "lock", "locked with key", "secure"]
+              "keywords": ["bike", "closed", "key", "lock", "locked", "secure"]
             },
             {
               "codepoint": "U+1F511",
               "name": "key",
-              "keywords": ["key", "lock", "password"]
+              "keywords": ["key", "keys", "lock", "major", "password", "unlock"]
             },
             {
               "codepoint": "U+1F5DD",
@@ -6998,27 +14009,27 @@
             {
               "codepoint": "U+1F528",
               "name": "hammer",
-              "keywords": ["hammer", "tool"]
+              "keywords": ["hammer", "home", "improvement", "repairs", "tool"]
             },
             {
               "codepoint": "U+1FA93",
               "name": "axe",
-              "keywords": ["axe", "chop", "hatchet", "split", "wood"]
+              "keywords": ["ax", "axe", "chop", "hatchet", "split", "wood"]
             },
             {
               "codepoint": "U+26CF",
               "name": "pick",
-              "keywords": ["mining", "pick", "tool"]
+              "keywords": ["hammer", "mining", "pick", "tool"]
             },
             {
               "codepoint": "U+2692",
               "name": "hammer and pick",
-              "keywords": ["hammer", "hammer and pick", "pick", "tool"]
+              "keywords": ["hammer", "pick", "tool"]
             },
             {
               "codepoint": "U+1F6E0",
               "name": "hammer and wrench",
-              "keywords": ["hammer", "hammer and wrench", "spanner", "tool", "wrench"]
+              "keywords": ["hammer", "spanner", "tool", "wrench"]
             },
             {
               "codepoint": "U+1F5E1",
@@ -7033,17 +14044,33 @@
             {
               "codepoint": "U+1F4A3",
               "name": "bomb",
-              "keywords": ["bomb", "comic"]
+              "keywords": [
+                "bomb",
+                "boom",
+                "comic",
+                "dangerous",
+                "explosion",
+                "hot"
+              ]
             },
             {
               "codepoint": "U+1FA83",
               "name": "boomerang",
-              "keywords": ["australia", "boomerang", "rebound", "repercussion"]
+              "keywords": ["boomerang", "rebound", "repercussion", "weapon"]
             },
             {
               "codepoint": "U+1F3F9",
               "name": "bow and arrow",
-              "keywords": ["archer", "arrow", "bow", "bow and arrow", "Sagittarius", "zodiac"]
+              "keywords": [
+                "archer",
+                "archery",
+                "arrow",
+                "bow",
+                "Sagittarius",
+                "tool",
+                "weapon",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+1F6E1",
@@ -7053,22 +14080,30 @@
             {
               "codepoint": "U+1FA9A",
               "name": "carpentry saw",
-              "keywords": ["carpenter", "carpentry saw", "lumber", "saw", "tool"]
+              "keywords": [
+                "carpenter",
+                "carpentry",
+                "cut",
+                "lumber",
+                "saw",
+                "tool",
+                "trim"
+              ]
             },
             {
               "codepoint": "U+1F527",
               "name": "wrench",
-              "keywords": ["spanner", "tool", "wrench"]
+              "keywords": ["home", "improvement", "spanner", "tool", "wrench"]
             },
             {
               "codepoint": "U+1FA9B",
               "name": "screwdriver",
-              "keywords": ["screw", "screwdriver", "tool"]
+              "keywords": ["flathead", "handy", "screw", "screwdriver", "tool"]
             },
             {
               "codepoint": "U+1F529",
               "name": "nut and bolt",
-              "keywords": ["bolt", "nut", "nut and bolt", "tool"]
+              "keywords": ["bolt", "home", "improvement", "nut", "tool"]
             },
             {
               "codepoint": "U+2699",
@@ -7083,17 +14118,38 @@
             {
               "codepoint": "U+2696",
               "name": "balance scale",
-              "keywords": ["balance", "justice", "Libra", "scale", "zodiac"]
+              "keywords": [
+                "balance",
+                "justice",
+                "Libra",
+                "scale",
+                "scales",
+                "tool",
+                "weight",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+1F9AF",
               "name": "white cane",
-              "keywords": ["accessibility", "blind", "white cane"]
+              "keywords": ["accessibility", "blind", "cane", "probing", "white"]
             },
             {
               "codepoint": "U+1F517",
               "name": "link",
-              "keywords": ["link"]
+              "keywords": ["link", "links"]
+            },
+            {
+              "codepoint": "U+26D3 U+FE0F U+200D U+1F4A5",
+              "name": "broken chain",
+              "keywords": [
+                "break",
+                "breaking",
+                "broken",
+                "chain",
+                "cuffs",
+                "freedom"
+              ]
             },
             {
               "codepoint": "U+26D3",
@@ -7103,22 +14159,54 @@
             {
               "codepoint": "U+1FA9D",
               "name": "hook",
-              "keywords": ["catch", "crook", "curve", "ensnare", "hook", "selling point"]
+              "keywords": [
+                "catch",
+                "crook",
+                "curve",
+                "ensnare",
+                "hook",
+                "point",
+                "selling"
+              ]
             },
             {
               "codepoint": "U+1F9F0",
               "name": "toolbox",
-              "keywords": ["chest", "mechanic", "tool", "toolbox"]
+              "keywords": ["box", "chest", "mechanic", "red", "tool", "toolbox"]
             },
             {
               "codepoint": "U+1F9F2",
               "name": "magnet",
-              "keywords": ["attraction", "horseshoe", "magnet", "magnetic"]
+              "keywords": [
+                "attraction",
+                "horseshoe",
+                "magnet",
+                "magnetic",
+                "negative",
+                "positive",
+                "shape",
+                "u"
+              ]
             },
             {
               "codepoint": "U+1FA9C",
               "name": "ladder",
               "keywords": ["climb", "ladder", "rung", "step"]
+            },
+            {
+              "codepoint": "U+1FA8F",
+              "name": "shovel",
+              "keywords": [
+                "bury",
+                "dig",
+                "garden",
+                "hole",
+                "plant",
+                "scoop",
+                "shovel",
+                "snow",
+                "spade"
+              ]
             }
           ]
         },
@@ -7133,32 +14221,68 @@
             {
               "codepoint": "U+1F9EA",
               "name": "test tube",
-              "keywords": ["chemist", "chemistry", "experiment", "lab", "science", "test tube"]
+              "keywords": [
+                "chemist",
+                "chemistry",
+                "experiment",
+                "lab",
+                "science",
+                "test",
+                "tube"
+              ]
             },
             {
               "codepoint": "U+1F9EB",
               "name": "petri dish",
-              "keywords": ["bacteria", "biologist", "biology", "culture", "lab", "petri dish"]
+              "keywords": [
+                "bacteria",
+                "biologist",
+                "biology",
+                "culture",
+                "dish",
+                "lab",
+                "petri"
+              ]
             },
             {
               "codepoint": "U+1F9EC",
               "name": "dna",
-              "keywords": ["biologist", "dna", "evolution", "gene", "genetics", "life"]
+              "keywords": [
+                "biologist",
+                "dna",
+                "evolution",
+                "gene",
+                "genetics",
+                "life"
+              ]
             },
             {
               "codepoint": "U+1F52C",
               "name": "microscope",
-              "keywords": ["microscope", "science", "tool"]
+              "keywords": ["experiment", "lab", "microscope", "science", "tool"]
             },
             {
               "codepoint": "U+1F52D",
               "name": "telescope",
-              "keywords": ["science", "telescope", "tool"]
+              "keywords": [
+                "contact",
+                "extraterrestrial",
+                "science",
+                "telescope",
+                "tool"
+              ]
             },
             {
               "codepoint": "U+1F4E1",
               "name": "satellite antenna",
-              "keywords": ["antenna", "dish", "satellite"]
+              "keywords": [
+                "aliens",
+                "antenna",
+                "contact",
+                "dish",
+                "satellite",
+                "science"
+              ]
             }
           ]
         },
@@ -7168,27 +14292,64 @@
             {
               "codepoint": "U+1F489",
               "name": "syringe",
-              "keywords": ["medicine", "needle", "shot", "sick", "syringe"]
+              "keywords": [
+                "doctor",
+                "flu",
+                "medicine",
+                "needle",
+                "shot",
+                "sick",
+                "syringe",
+                "tool",
+                "vaccination"
+              ]
             },
             {
               "codepoint": "U+1FA78",
               "name": "drop of blood",
-              "keywords": ["bleed", "blood donation", "drop of blood", "injury", "medicine", "menstruation"]
+              "keywords": [
+                "bleed",
+                "blood",
+                "donation",
+                "drop",
+                "injury",
+                "medicine",
+                "menstruation"
+              ]
             },
             {
               "codepoint": "U+1F48A",
               "name": "pill",
-              "keywords": ["doctor", "medicine", "pill", "sick"]
+              "keywords": [
+                "doctor",
+                "drugs",
+                "medicated",
+                "medicine",
+                "pill",
+                "pills",
+                "sick",
+                "vitamin"
+              ]
             },
             {
               "codepoint": "U+1FA79",
               "name": "adhesive bandage",
-              "keywords": ["adhesive bandage", "bandage"]
+              "keywords": ["adhesive", "bandage"]
             },
             {
               "codepoint": "U+1FA7C",
               "name": "crutch",
-              "keywords": ["cane", "disability", "hurt", "mobility aid", "stick"]
+              "keywords": [
+                "aid",
+                "cane",
+                "crutch",
+                "disability",
+                "help",
+                "hurt",
+                "injured",
+                "mobility",
+                "stick"
+              ]
             },
             {
               "codepoint": "U+1FA7A",
@@ -7198,7 +14359,15 @@
             {
               "codepoint": "U+1FA7B",
               "name": "x-ray",
-              "keywords": ["bones", "doctor", "medical", "skeleton"]
+              "keywords": [
+                "bones",
+                "doctor",
+                "medical",
+                "skeleton",
+                "skull",
+                "x-ray",
+                "xray"
+              ]
             }
           ]
         },
@@ -7208,7 +14377,7 @@
             {
               "codepoint": "U+1F6AA",
               "name": "door",
-              "keywords": ["door"]
+              "keywords": ["back", "closet", "door", "front"]
             },
             {
               "codepoint": "U+1F6D7",
@@ -7218,12 +14387,26 @@
             {
               "codepoint": "U+1FA9E",
               "name": "mirror",
-              "keywords": ["mirror", "reflection", "reflector", "speculum"]
+              "keywords": [
+                "makeup",
+                "mirror",
+                "reflection",
+                "reflector",
+                "speculum"
+              ]
             },
             {
               "codepoint": "U+1FA9F",
               "name": "window",
-              "keywords": ["frame", "fresh air", "opening", "transparent", "view", "window"]
+              "keywords": [
+                "air",
+                "frame",
+                "fresh",
+                "opening",
+                "transparent",
+                "view",
+                "window"
+              ]
             },
             {
               "codepoint": "U+1F6CF",
@@ -7233,7 +14416,7 @@
             {
               "codepoint": "U+1F6CB",
               "name": "couch and lamp",
-              "keywords": ["couch", "couch and lamp", "hotel", "lamp"]
+              "keywords": ["couch", "hotel", "lamp"]
             },
             {
               "codepoint": "U+1FA91",
@@ -7243,12 +14426,20 @@
             {
               "codepoint": "U+1F6BD",
               "name": "toilet",
-              "keywords": ["toilet"]
+              "keywords": ["bathroom", "toilet"]
             },
             {
               "codepoint": "U+1FAA0",
               "name": "plunger",
-              "keywords": ["force cup", "plumber", "plunger", "suction", "toilet"]
+              "keywords": [
+                "cup",
+                "force",
+                "plumber",
+                "plunger",
+                "poop",
+                "suction",
+                "toilet"
+              ]
             },
             {
               "codepoint": "U+1F6BF",
@@ -7263,7 +14454,15 @@
             {
               "codepoint": "U+1FAA4",
               "name": "mouse trap",
-              "keywords": ["bait", "mouse trap", "mousetrap", "snare", "trap"]
+              "keywords": [
+                "bait",
+                "cheese",
+                "lure",
+                "mouse",
+                "mousetrap",
+                "snare",
+                "trap"
+              ]
             },
             {
               "codepoint": "U+1FA92",
@@ -7273,12 +14472,18 @@
             {
               "codepoint": "U+1F9F4",
               "name": "lotion bottle",
-              "keywords": ["lotion", "lotion bottle", "moisturizer", "shampoo", "sunscreen"]
+              "keywords": [
+                "bottle",
+                "lotion",
+                "moisturizer",
+                "shampoo",
+                "sunscreen"
+              ]
             },
             {
               "codepoint": "U+1F9F7",
               "name": "safety pin",
-              "keywords": ["diaper", "punk rock", "safety pin"]
+              "keywords": ["diaper", "pin", "punk", "rock", "safety"]
             },
             {
               "codepoint": "U+1F9F9",
@@ -7293,7 +14498,7 @@
             {
               "codepoint": "U+1F9FB",
               "name": "roll of paper",
-              "keywords": ["paper towels", "roll of paper", "toilet paper"]
+              "keywords": ["paper", "roll", "toilet", "towels"]
             },
             {
               "codepoint": "U+1FAA3",
@@ -7303,27 +14508,53 @@
             {
               "codepoint": "U+1F9FC",
               "name": "soap",
-              "keywords": ["bar", "bathing", "cleaning", "lather", "soap", "soapdish"]
+              "keywords": [
+                "bar",
+                "bathing",
+                "clean",
+                "cleaning",
+                "lather",
+                "soap",
+                "soapdish"
+              ]
             },
             {
               "codepoint": "U+1FAE7",
               "name": "bubbles",
-              "keywords": ["burp", "clean", "soap", "underwater"]
+              "keywords": [
+                "bubble",
+                "bubbles",
+                "burp",
+                "clean",
+                "floating",
+                "pearl",
+                "soap",
+                "underwater"
+              ]
             },
             {
               "codepoint": "U+1FAA5",
               "name": "toothbrush",
-              "keywords": ["bathroom", "brush", "clean", "dental", "hygiene", "teeth", "toothbrush"]
+              "keywords": [
+                "bathroom",
+                "brush",
+                "clean",
+                "dental",
+                "hygiene",
+                "teeth",
+                "toiletry",
+                "toothbrush"
+              ]
             },
             {
               "codepoint": "U+1F9FD",
               "name": "sponge",
-              "keywords": ["absorbing", "cleaning", "porous", "sponge"]
+              "keywords": ["absorbing", "cleaning", "porous", "soak", "sponge"]
             },
             {
               "codepoint": "U+1F9EF",
               "name": "fire extinguisher",
-              "keywords": ["extinguish", "fire", "fire extinguisher", "quench"]
+              "keywords": ["extinguish", "extinguisher", "fire", "quench"]
             },
             {
               "codepoint": "U+1F6D2",
@@ -7333,7 +14564,7 @@
           ]
         },
         {
-          "category": "other_object",
+          "category": "other-object",
           "contents": [
             {
               "codepoint": "U+1F6AC",
@@ -7343,12 +14574,22 @@
             {
               "codepoint": "U+26B0",
               "name": "coffin",
-              "keywords": ["coffin", "death"]
+              "keywords": ["coffin", "dead", "death", "vampire"]
             },
             {
               "codepoint": "U+1FAA6",
               "name": "headstone",
-              "keywords": ["cemetery", "grave", "graveyard", "headstone", "tombstone"]
+              "keywords": [
+                "cemetery",
+                "dead",
+                "grave",
+                "graveyard",
+                "headstone",
+                "memorial",
+                "rip",
+                "tomb",
+                "tombstone"
+              ]
             },
             {
               "codepoint": "U+26B1",
@@ -7356,19 +14597,73 @@
               "keywords": ["ashes", "death", "funeral", "urn"]
             },
             {
+              "codepoint": "U+1F9FF",
+              "name": "nazar amulet",
+              "keywords": [
+                "amulet",
+                "bead",
+                "blue",
+                "charm",
+                "evil-eye",
+                "nazar",
+                "talisman"
+              ]
+            },
+            {
+              "codepoint": "U+1FAAC",
+              "name": "hamsa",
+              "keywords": [
+                "amulet",
+                "Fatima",
+                "fortune",
+                "guide",
+                "hamsa",
+                "hand",
+                "Mary",
+                "Miriam",
+                "palm",
+                "protect",
+                "protection"
+              ]
+            },
+            {
               "codepoint": "U+1F5FF",
               "name": "moai",
-              "keywords": ["face", "moai", "moyai", "statue"]
+              "keywords": [
+                "face",
+                "moai",
+                "moyai",
+                "statue",
+                "stoneface",
+                "travel"
+              ]
             },
             {
               "codepoint": "U+1FAA7",
               "name": "placard",
-              "keywords": ["demonstration", "picket", "placard", "protest", "sign"]
+              "keywords": [
+                "card",
+                "demonstration",
+                "notice",
+                "picket",
+                "placard",
+                "plaque",
+                "protest",
+                "sign"
+              ]
             },
             {
               "codepoint": "U+1FAAA",
               "name": "identification card",
-              "keywords": ["credentials", "ID", "license", "security"]
+              "keywords": [
+                "card",
+                "credentials",
+                "document",
+                "ID",
+                "identification",
+                "license",
+                "security"
+              ]
             }
           ]
         }
@@ -7378,17 +14673,25 @@
       "category": "Symbols",
       "contents": [
         {
-          "category": "transport_sign",
+          "category": "transport-sign",
           "contents": [
             {
               "codepoint": "U+1F3E7",
               "name": "ATM sign",
-              "keywords": ["atm", "ATM sign", "automated", "bank", "teller"]
+              "keywords": [
+                "ATM",
+                "automated",
+                "bank",
+                "cash",
+                "money",
+                "sign",
+                "teller"
+              ]
             },
             {
               "codepoint": "U+1F6AE",
               "name": "litter in bin sign",
-              "keywords": ["litter", "litter bin", "litter in bin sign"]
+              "keywords": ["bin", "litter", "litterbin", "sign"]
             },
             {
               "codepoint": "U+1F6B0",
@@ -7398,32 +14701,58 @@
             {
               "codepoint": "U+267F",
               "name": "wheelchair symbol",
-              "keywords": ["access", "wheelchair symbol"]
+              "keywords": ["access", "handicap", "symbol", "wheelchair"]
             },
             {
               "codepoint": "U+1F6B9",
               "name": "men’s room",
-              "keywords": ["lavatory", "man", "men’s room", "restroom", "wc"]
+              "keywords": [
+                "bathroom",
+                "lavatory",
+                "man",
+                "men’s",
+                "restroom",
+                "room",
+                "toilet",
+                "WC"
+              ]
             },
             {
               "codepoint": "U+1F6BA",
               "name": "women’s room",
-              "keywords": ["lavatory", "restroom", "wc", "woman", "women’s room"]
+              "keywords": [
+                "bathroom",
+                "lavatory",
+                "restroom",
+                "room",
+                "toilet",
+                "WC",
+                "woman",
+                "women’s"
+              ]
             },
             {
               "codepoint": "U+1F6BB",
               "name": "restroom",
-              "keywords": ["lavatory", "restroom", "WC"]
+              "keywords": ["bathroom", "lavatory", "restroom", "toilet", "WC"]
             },
             {
               "codepoint": "U+1F6BC",
               "name": "baby symbol",
-              "keywords": ["baby", "baby symbol", "changing"]
+              "keywords": ["baby", "changing", "symbol"]
             },
             {
               "codepoint": "U+1F6BE",
               "name": "water closet",
-              "keywords": ["closet", "lavatory", "restroom", "water", "wc"]
+              "keywords": [
+                "bathroom",
+                "closet",
+                "lavatory",
+                "restroom",
+                "toilet",
+                "water",
+                "WC"
+              ]
             },
             {
               "codepoint": "U+1F6C2",
@@ -7433,17 +14762,30 @@
             {
               "codepoint": "U+1F6C3",
               "name": "customs",
-              "keywords": ["customs"]
+              "keywords": ["customs", "packing"]
             },
             {
               "codepoint": "U+1F6C4",
               "name": "baggage claim",
-              "keywords": ["baggage", "claim"]
+              "keywords": [
+                "arrived",
+                "baggage",
+                "bags",
+                "case",
+                "checked",
+                "claim",
+                "journey",
+                "packing",
+                "plane",
+                "ready",
+                "travel",
+                "trip"
+              ]
             },
             {
               "codepoint": "U+1F6C5",
               "name": "left luggage",
-              "keywords": ["baggage", "left luggage", "locker", "luggage"]
+              "keywords": ["baggage", "case", "left", "locker", "luggage"]
             }
           ]
         },
@@ -7453,57 +14795,136 @@
             {
               "codepoint": "U+26A0",
               "name": "warning",
-              "keywords": ["warning"]
+              "keywords": ["caution", "warning"]
             },
             {
               "codepoint": "U+1F6B8",
               "name": "children crossing",
-              "keywords": ["child", "children crossing", "crossing", "pedestrian", "traffic"]
+              "keywords": [
+                "child",
+                "children",
+                "crossing",
+                "pedestrian",
+                "traffic"
+              ]
             },
             {
               "codepoint": "U+26D4",
               "name": "no entry",
-              "keywords": ["entry", "forbidden", "no", "not", "prohibited", "traffic"]
+              "keywords": [
+                "do",
+                "entry",
+                "fail",
+                "forbidden",
+                "no",
+                "not",
+                "pass",
+                "prohibited",
+                "traffic"
+              ]
             },
             {
               "codepoint": "U+1F6AB",
               "name": "prohibited",
-              "keywords": ["entry", "forbidden", "no", "not", "prohibited"]
+              "keywords": [
+                "entry",
+                "forbidden",
+                "no",
+                "not",
+                "prohibited",
+                "smoke"
+              ]
             },
             {
               "codepoint": "U+1F6B3",
               "name": "no bicycles",
-              "keywords": ["bicycle", "bike", "forbidden", "no", "no bicycles", "prohibited"]
+              "keywords": [
+                "bicycle",
+                "bicycles",
+                "bike",
+                "forbidden",
+                "no",
+                "not",
+                "prohibited"
+              ]
             },
             {
               "codepoint": "U+1F6AD",
               "name": "no smoking",
-              "keywords": ["forbidden", "no", "not", "prohibited", "smoking"]
+              "keywords": [
+                "forbidden",
+                "no",
+                "not",
+                "prohibited",
+                "smoke",
+                "smoking"
+              ]
             },
             {
               "codepoint": "U+1F6AF",
               "name": "no littering",
-              "keywords": ["forbidden", "litter", "no", "no littering", "not", "prohibited"]
+              "keywords": [
+                "forbidden",
+                "litter",
+                "littering",
+                "no",
+                "not",
+                "prohibited"
+              ]
             },
             {
               "codepoint": "U+1F6B1",
               "name": "non-potable water",
-              "keywords": ["non-drinking", "non-potable", "water"]
+              "keywords": [
+                "dry",
+                "non-drinking",
+                "non-potable",
+                "prohibited",
+                "water"
+              ]
             },
             {
               "codepoint": "U+1F6B7",
               "name": "no pedestrians",
-              "keywords": ["forbidden", "no", "no pedestrians", "not", "pedestrian", "prohibited"]
+              "keywords": [
+                "forbidden",
+                "no",
+                "not",
+                "pedestrian",
+                "pedestrians",
+                "prohibited"
+              ]
             },
             {
               "codepoint": "U+1F4F5",
               "name": "no mobile phones",
-              "keywords": ["cell", "forbidden", "mobile", "no", "no mobile phones", "phone"]
+              "keywords": [
+                "cell",
+                "forbidden",
+                "mobile",
+                "no",
+                "not",
+                "phone",
+                "phones",
+                "prohibited",
+                "telephone"
+              ]
             },
             {
               "codepoint": "U+1F51E",
               "name": "no one under eighteen",
-              "keywords": ["18", "age restriction", "eighteen", "no one under eighteen", "prohibited", "underage"]
+              "keywords": [
+                "18",
+                "age",
+                "eighteen",
+                "forbidden",
+                "no",
+                "not",
+                "one",
+                "prohibited",
+                "restriction",
+                "underage"
+              ]
             },
             {
               "codepoint": "U+2622",
@@ -7523,22 +14944,34 @@
             {
               "codepoint": "U+2B06",
               "name": "up arrow",
-              "keywords": ["arrow", "cardinal", "direction", "north", "up arrow"]
+              "keywords": ["arrow", "cardinal", "direction", "north", "up"]
             },
             {
               "codepoint": "U+2197",
               "name": "up-right arrow",
-              "keywords": ["arrow", "direction", "intercardinal", "northeast", "up-right arrow"]
+              "keywords": [
+                "arrow",
+                "direction",
+                "intercardinal",
+                "northeast",
+                "up-right"
+              ]
             },
             {
               "codepoint": "U+27A1",
               "name": "right arrow",
-              "keywords": ["arrow", "cardinal", "direction", "east", "right arrow"]
+              "keywords": ["arrow", "cardinal", "direction", "east", "right"]
             },
             {
               "codepoint": "U+2198",
               "name": "down-right arrow",
-              "keywords": ["arrow", "direction", "down-right arrow", "intercardinal", "southeast"]
+              "keywords": [
+                "arrow",
+                "direction",
+                "down-right",
+                "intercardinal",
+                "southeast"
+              ]
             },
             {
               "codepoint": "U+2B07",
@@ -7548,82 +14981,112 @@
             {
               "codepoint": "U+2199",
               "name": "down-left arrow",
-              "keywords": ["arrow", "direction", "down-left arrow", "intercardinal", "southwest"]
+              "keywords": [
+                "arrow",
+                "direction",
+                "down-left",
+                "intercardinal",
+                "southwest"
+              ]
             },
             {
               "codepoint": "U+2B05",
               "name": "left arrow",
-              "keywords": ["arrow", "cardinal", "direction", "left arrow", "west"]
+              "keywords": ["arrow", "cardinal", "direction", "left", "west"]
             },
             {
               "codepoint": "U+2196",
               "name": "up-left arrow",
-              "keywords": ["arrow", "direction", "intercardinal", "northwest", "up-left arrow"]
+              "keywords": [
+                "arrow",
+                "direction",
+                "intercardinal",
+                "northwest",
+                "up-left"
+              ]
             },
             {
               "codepoint": "U+2195",
               "name": "up-down arrow",
-              "keywords": ["arrow", "up-down arrow"]
+              "keywords": ["arrow", "up-down"]
             },
             {
               "codepoint": "U+2194",
               "name": "left-right arrow",
-              "keywords": ["arrow", "left-right arrow"]
+              "keywords": ["arrow", "left-right"]
             },
             {
               "codepoint": "U+21A9",
               "name": "right arrow curving left",
-              "keywords": ["arrow", "right arrow curving left"]
+              "keywords": ["arrow", "curving", "left", "right"]
             },
             {
               "codepoint": "U+21AA",
               "name": "left arrow curving right",
-              "keywords": ["arrow", "left arrow curving right"]
+              "keywords": ["arrow", "curving", "left", "right"]
             },
             {
               "codepoint": "U+2934",
               "name": "right arrow curving up",
-              "keywords": ["arrow", "right arrow curving up"]
+              "keywords": ["arrow", "curving", "right", "up"]
             },
             {
               "codepoint": "U+2935",
               "name": "right arrow curving down",
-              "keywords": ["arrow", "down", "right arrow curving down"]
+              "keywords": ["arrow", "curving", "down", "right"]
             },
             {
               "codepoint": "U+1F503",
               "name": "clockwise vertical arrows",
-              "keywords": ["arrow", "clockwise", "clockwise vertical arrows", "reload"]
+              "keywords": [
+                "arrow",
+                "arrows",
+                "clockwise",
+                "refresh",
+                "reload",
+                "vertical"
+              ]
             },
             {
               "codepoint": "U+1F504",
               "name": "counterclockwise arrows button",
-              "keywords": ["anticlockwise", "arrow", "counterclockwise", "counterclockwise arrows button", "withershins"]
+              "keywords": [
+                "again",
+                "anticlockwise",
+                "arrow",
+                "arrows",
+                "button",
+                "counterclockwise",
+                "deja",
+                "refresh",
+                "rewindershins",
+                "vu"
+              ]
             },
             {
               "codepoint": "U+1F519",
               "name": "BACK arrow",
-              "keywords": ["arrow", "back", "BACK arrow"]
+              "keywords": ["arrow", "BACK"]
             },
             {
               "codepoint": "U+1F51A",
               "name": "END arrow",
-              "keywords": ["arrow", "end", "END arrow"]
+              "keywords": ["arrow", "END"]
             },
             {
               "codepoint": "U+1F51B",
               "name": "ON! arrow",
-              "keywords": ["arrow", "mark", "on", "ON! arrow"]
+              "keywords": ["arrow", "mark", "ON!"]
             },
             {
               "codepoint": "U+1F51C",
               "name": "SOON arrow",
-              "keywords": ["arrow", "soon", "SOON arrow"]
+              "keywords": ["arrow", "brb", "omw", "SOON"]
             },
             {
               "codepoint": "U+1F51D",
               "name": "TOP arrow",
-              "keywords": ["arrow", "top", "TOP arrow", "up"]
+              "keywords": ["arrow", "homie", "TOP", "up"]
             }
           ]
         },
@@ -7633,12 +15096,12 @@
             {
               "codepoint": "U+1F6D0",
               "name": "place of worship",
-              "keywords": ["place of worship", "religion", "worship"]
+              "keywords": ["place", "pray", "religion", "worship"]
             },
             {
               "codepoint": "U+269B",
               "name": "atom symbol",
-              "keywords": ["atheist", "atom", "atom symbol"]
+              "keywords": ["atheist", "atom", "symbol"]
             },
             {
               "codepoint": "U+1F549",
@@ -7648,52 +15111,100 @@
             {
               "codepoint": "U+2721",
               "name": "star of David",
-              "keywords": ["David", "Jew", "Jewish", "religion", "star", "star of David"]
+              "keywords": [
+                "David",
+                "Jew",
+                "Jewish",
+                "judaism",
+                "religion",
+                "star"
+              ]
             },
             {
               "codepoint": "U+2638",
               "name": "wheel of dharma",
-              "keywords": ["Buddhist", "dharma", "religion", "wheel", "wheel of dharma"]
+              "keywords": ["Buddhist", "dharma", "religion", "wheel"]
             },
             {
               "codepoint": "U+262F",
               "name": "yin yang",
-              "keywords": ["religion", "tao", "taoist", "yang", "yin"]
+              "keywords": [
+                "difficult",
+                "lives",
+                "religion",
+                "tao",
+                "taoist",
+                "total",
+                "yang",
+                "yin",
+                "yinyang"
+              ]
             },
             {
               "codepoint": "U+271D",
               "name": "latin cross",
-              "keywords": ["Christian", "cross", "latin cross", "religion"]
+              "keywords": ["christ", "Christian", "cross", "latin", "religion"]
             },
             {
               "codepoint": "U+2626",
               "name": "orthodox cross",
-              "keywords": ["Christian", "cross", "orthodox cross", "religion"]
+              "keywords": ["Christian", "cross", "orthodox", "religion"]
             },
             {
               "codepoint": "U+262A",
               "name": "star and crescent",
-              "keywords": ["islam", "Muslim", "religion", "star and crescent"]
+              "keywords": [
+                "crescent",
+                "islam",
+                "Muslim",
+                "ramadan",
+                "religion",
+                "star"
+              ]
             },
             {
               "codepoint": "U+262E",
               "name": "peace symbol",
-              "keywords": ["peace", "peace symbol"]
+              "keywords": ["healing", "peace", "peaceful", "symbol"]
             },
             {
               "codepoint": "U+1F54E",
               "name": "menorah",
-              "keywords": ["candelabrum", "candlestick", "menorah", "religion"]
+              "keywords": [
+                "candelabrum",
+                "candlestick",
+                "hanukkah",
+                "jewish",
+                "judaism",
+                "menorah",
+                "religion"
+              ]
             },
             {
               "codepoint": "U+1F52F",
               "name": "dotted six-pointed star",
-              "keywords": ["dotted six-pointed star", "fortune", "star"]
+              "keywords": [
+                "dotted",
+                "fortune",
+                "jewish",
+                "judaism",
+                "six-pointed",
+                "star"
+              ]
             },
             {
               "codepoint": "U+1FAAF",
               "name": "khanda",
-              "keywords": ["khanda","religion","Sikh"]
+              "keywords": [
+                "Deg",
+                "Fateh",
+                "Khalsa",
+                "Khanda",
+                "religion",
+                "Sikh",
+                "Sikhism",
+                "Tegh"
+              ]
             }
           ]
         },
@@ -7703,62 +15214,75 @@
             {
               "codepoint": "U+2648",
               "name": "Aries",
-              "keywords": ["Aries", "ram", "zodiac"]
+              "keywords": ["Aries", "horoscope", "ram", "zodiac"]
             },
             {
               "codepoint": "U+2649",
               "name": "Taurus",
-              "keywords": ["bull", "ox", "Taurus", "zodiac"]
+              "keywords": ["bull", "horoscope", "ox", "Taurus", "zodiac"]
             },
             {
               "codepoint": "U+264A",
               "name": "Gemini",
-              "keywords": ["Gemini", "twins", "zodiac"]
+              "keywords": ["Gemini", "horoscope", "twins", "zodiac"]
             },
             {
               "codepoint": "U+264B",
               "name": "Cancer",
-              "keywords": ["Cancer", "crab", "zodiac"]
+              "keywords": ["Cancer", "crab", "horoscope", "zodiac"]
             },
             {
               "codepoint": "U+264C",
               "name": "Leo",
-              "keywords": ["Leo", "lion", "zodiac"]
+              "keywords": ["horoscope", "Leo", "lion", "zodiac"]
             },
             {
               "codepoint": "U+264D",
               "name": "Virgo",
-              "keywords": ["Virgo", "zodiac"]
+              "keywords": ["horoscope", "Virgo", "zodiac"]
             },
             {
               "codepoint": "U+264E",
               "name": "Libra",
-              "keywords": ["balance", "justice", "Libra", "scales", "zodiac"]
+              "keywords": [
+                "balance",
+                "horoscope",
+                "justice",
+                "Libra",
+                "scales",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+264F",
               "name": "Scorpio",
-              "keywords": ["Scorpio", "scorpion", "scorpius", "zodiac"]
+              "keywords": [
+                "horoscope",
+                "Scorpio",
+                "scorpion",
+                "Scorpius",
+                "zodiac"
+              ]
             },
             {
               "codepoint": "U+2650",
               "name": "Sagittarius",
-              "keywords": ["archer", "Sagittarius", "zodiac"]
+              "keywords": ["archer", "horoscope", "Sagittarius", "zodiac"]
             },
             {
               "codepoint": "U+2651",
               "name": "Capricorn",
-              "keywords": ["Capricorn", "goat", "zodiac"]
+              "keywords": ["Capricorn", "goat", "horoscope", "zodiac"]
             },
             {
               "codepoint": "U+2652",
               "name": "Aquarius",
-              "keywords": ["Aquarius", "bearer", "water", "zodiac"]
+              "keywords": ["Aquarius", "bearer", "horoscope", "water", "zodiac"]
             },
             {
               "codepoint": "U+2653",
               "name": "Pisces",
-              "keywords": ["fish", "Pisces", "zodiac"]
+              "keywords": ["fish", "horoscope", "Pisces", "zodiac"]
             },
             {
               "codepoint": "U+26CE",
@@ -7768,97 +15292,140 @@
           ]
         },
         {
-          "category": "av_symbol",
+          "category": "av-symbol",
           "contents": [
             {
               "codepoint": "U+1F500",
               "name": "shuffle tracks button",
-              "keywords": ["arrow", "crossed", "shuffle tracks button"]
+              "keywords": ["arrow", "button", "crossed", "shuffle", "tracks"]
             },
             {
               "codepoint": "U+1F501",
               "name": "repeat button",
-              "keywords": ["arrow", "clockwise", "repeat", "repeat button"]
+              "keywords": ["arrow", "button", "clockwise", "repeat"]
             },
             {
               "codepoint": "U+1F502",
               "name": "repeat single button",
-              "keywords": ["arrow", "clockwise", "once", "repeat single button"]
+              "keywords": [
+                "arrow",
+                "button",
+                "clockwise",
+                "once",
+                "repeat",
+                "single"
+              ]
             },
             {
               "codepoint": "U+25B6",
               "name": "play button",
-              "keywords": ["arrow", "play", "play button", "right", "triangle"]
+              "keywords": ["arrow", "button", "play", "right", "triangle"]
             },
             {
               "codepoint": "U+23E9",
               "name": "fast-forward button",
-              "keywords": ["arrow", "double", "fast", "fast-forward button", "forward"]
+              "keywords": [
+                "arrow",
+                "button",
+                "double",
+                "fast",
+                "fast-forward",
+                "forward"
+              ]
             },
             {
               "codepoint": "U+23ED",
               "name": "next track button",
-              "keywords": ["arrow", "next scene", "next track", "next track button", "triangle"]
+              "keywords": [
+                "arrow",
+                "button",
+                "next",
+                "scene",
+                "track",
+                "triangle"
+              ]
             },
             {
               "codepoint": "U+23EF",
               "name": "play or pause button",
-              "keywords": ["arrow", "pause", "play", "play or pause button", "right", "triangle"]
+              "keywords": [
+                "arrow",
+                "button",
+                "pause",
+                "play",
+                "right",
+                "triangle"
+              ]
             },
             {
               "codepoint": "U+25C0",
               "name": "reverse button",
-              "keywords": ["arrow", "left", "reverse", "reverse button", "triangle"]
+              "keywords": ["arrow", "button", "left", "reverse", "triangle"]
             },
             {
               "codepoint": "U+23EA",
               "name": "fast reverse button",
-              "keywords": ["arrow", "double", "fast reverse button", "rewind"]
+              "keywords": [
+                "arrow",
+                "button",
+                "double",
+                "fast",
+                "reverse",
+                "rewind"
+              ]
             },
             {
               "codepoint": "U+23EE",
               "name": "last track button",
-              "keywords": ["arrow", "last track button", "previous scene", "previous track", "triangle"]
+              "keywords": [
+                "arrow",
+                "button",
+                "last",
+                "previous",
+                "scene",
+                "track",
+                "triangle"
+              ]
             },
             {
               "codepoint": "U+1F53C",
               "name": "upwards button",
-              "keywords": ["arrow", "button", "red", "upwards button"]
+              "keywords": ["arrow", "button", "red", "up", "upwards"]
             },
             {
               "codepoint": "U+23EB",
               "name": "fast up button",
-              "keywords": ["arrow", "double", "fast up button"]
+              "keywords": ["arrow", "button", "double", "fast", "up"]
             },
             {
               "codepoint": "U+1F53D",
               "name": "downwards button",
-              "keywords": ["arrow", "button", "down", "downwards button", "red"]
+              "keywords": ["arrow", "button", "down", "downwards", "red"]
             },
             {
               "codepoint": "U+23EC",
               "name": "fast down button",
-              "keywords": ["arrow", "double", "down", "fast down button"]
+              "keywords": ["arrow", "button", "double", "down", "fast"]
             },
             {
               "codepoint": "U+23F8",
               "name": "pause button",
-              "keywords": ["bar", "double", "pause", "pause button", "vertical"]
+              "keywords": ["bar", "button", "double", "pause", "vertical"]
             },
             {
               "codepoint": "U+23F9",
               "name": "stop button",
-              "keywords": ["square", "stop", "stop button"]
+              "keywords": ["button", "square", "stop"]
             },
             {
               "codepoint": "U+23FA",
               "name": "record button",
-              "keywords": ["circle", "record", "record button"]
+              "keywords": ["button", "circle", "record"]
             },
             {
               "codepoint": "U+23CF",
               "name": "eject button",
-              "keywords": ["eject", "eject button"]
+              "keywords": ["button", "eject"]
             },
             {
               "codepoint": "U+1F3A6",
@@ -7868,27 +15435,58 @@
             {
               "codepoint": "U+1F505",
               "name": "dim button",
-              "keywords": ["brightness", "dim", "dim button", "low"]
+              "keywords": ["brightness", "button", "dim", "low"]
             },
             {
               "codepoint": "U+1F506",
               "name": "bright button",
-              "keywords": ["bright", "bright button", "brightness"]
+              "keywords": ["bright", "brightness", "button", "light"]
             },
             {
               "codepoint": "U+1F4F6",
               "name": "antenna bars",
-              "keywords": ["antenna", "antenna bars", "bar", "cell", "mobile", "phone"]
+              "keywords": [
+                "antenna",
+                "bar",
+                "bars",
+                "cell",
+                "communication",
+                "mobile",
+                "phone",
+                "signal",
+                "telephone"
+              ]
             },
             {
               "codepoint": "U+1F6DC",
               "name": "wireless",
-              "keywords": ["computer", "internet", "network", "wireless"]
+              "keywords": [
+                "broadband",
+                "computer",
+                "connectivity",
+                "hotspot",
+                "internet",
+                "network",
+                "router",
+                "smartphone",
+                "wi-fi",
+                "wifi",
+                "wireless",
+                "wlan"
+              ]
             },
             {
               "codepoint": "U+1F4F3",
               "name": "vibration mode",
-              "keywords": ["cell", "mobile", "mode", "phone", "telephone", "vibration"]
+              "keywords": [
+                "cell",
+                "communication",
+                "mobile",
+                "mode",
+                "phone",
+                "telephone",
+                "vibration"
+              ]
             },
             {
               "codepoint": "U+1F4F4",
@@ -7903,17 +15501,17 @@
             {
               "codepoint": "U+2640",
               "name": "female sign",
-              "keywords": ["female sign", "woman"]
+              "keywords": ["female", "sign", "woman"]
             },
             {
               "codepoint": "U+2642",
               "name": "male sign",
-              "keywords": ["male sign", "man"]
+              "keywords": ["male", "man", "sign"]
             },
             {
               "codepoint": "U+26A7",
               "name": "transgender symbol",
-              "keywords": ["transgender", "transgender symbol"]
+              "keywords": ["symbol", "transgender"]
             }
           ]
         },
@@ -7923,27 +15521,42 @@
             {
               "codepoint": "U+2716",
               "name": "multiply",
-              "keywords": ["×", "cancel", "multiplication", "multiply", "sign", "x"]
+              "keywords": [
+                "×",
+                "cancel",
+                "multiplication",
+                "multiply",
+                "sign",
+                "x"
+              ]
             },
             {
               "codepoint": "U+2795",
               "name": "plus",
-              "keywords": ["+", "math", "plus", "sign"]
+              "keywords": ["+", "plus"]
             },
             {
               "codepoint": "U+2796",
               "name": "minus",
-              "keywords": ["-", "−", "math", "minus", "sign"]
+              "keywords": ["-", "−", "heavy", "math", "minus", "sign"]
             },
             {
               "codepoint": "U+2797",
               "name": "divide",
-              "keywords": ["÷", "divide", "division", "math", "sign"]
+              "keywords": ["÷", "divide", "division", "heavy", "math", "sign"]
             },
             {
               "codepoint": "U+1F7F0",
               "name": "heavy equals sign",
-              "keywords": ["equality", "math"]
+              "keywords": [
+                "answer",
+                "equal",
+                "equality",
+                "equals",
+                "heavy",
+                "math",
+                "sign"
+              ]
             },
             {
               "codepoint": "U+267E",
@@ -7958,32 +15571,63 @@
             {
               "codepoint": "U+203C",
               "name": "double exclamation mark",
-              "keywords": ["!", "!!", "bangbang", "double exclamation mark", "exclamation", "mark"]
+              "keywords": [
+                "!",
+                "!!",
+                "bangbang",
+                "double",
+                "exclamation",
+                "mark",
+                "punctuation"
+              ]
             },
             {
               "codepoint": "U+2049",
               "name": "exclamation question mark",
-              "keywords": ["!", "!?", "?", "exclamation", "interrobang", "mark", "punctuation", "question"]
+              "keywords": [
+                "!",
+                "!?",
+                "?",
+                "exclamation",
+                "interrobang",
+                "mark",
+                "punctuation",
+                "question"
+              ]
             },
             {
               "codepoint": "U+2753",
               "name": "red question mark",
-              "keywords": ["?", "mark", "punctuation", "question", "red question mark"]
+              "keywords": ["?", "mark", "punctuation", "question", "red"]
             },
             {
               "codepoint": "U+2754",
               "name": "white question mark",
-              "keywords": ["?", "mark", "outlined", "punctuation", "question", "white question mark"]
+              "keywords": [
+                "?",
+                "mark",
+                "outlined",
+                "punctuation",
+                "question",
+                "white"
+              ]
             },
             {
               "codepoint": "U+2755",
               "name": "white exclamation mark",
-              "keywords": ["!", "exclamation", "mark", "outlined", "punctuation", "white exclamation mark"]
+              "keywords": [
+                "!",
+                "exclamation",
+                "mark",
+                "outlined",
+                "punctuation",
+                "white"
+              ]
             },
             {
               "codepoint": "U+2757",
               "name": "red exclamation mark",
-              "keywords": ["!", "exclamation", "mark", "punctuation", "red exclamation mark"]
+              "keywords": ["!", "exclamation", "mark", "punctuation", "red"]
             },
             {
               "codepoint": "U+3030",
@@ -8003,32 +15647,56 @@
             {
               "codepoint": "U+1F4B2",
               "name": "heavy dollar sign",
-              "keywords": ["currency", "dollar", "heavy dollar sign", "money"]
+              "keywords": [
+                "billion",
+                "cash",
+                "charge",
+                "currency",
+                "dollar",
+                "heavy",
+                "million",
+                "money",
+                "pay",
+                "sign"
+              ]
             }
           ]
         },
         {
-          "category": "other_symbol",
+          "category": "other-symbol",
           "contents": [
-  {
+            {
               "codepoint": "U+2695",
               "name": "medical symbol",
-              "keywords": ["aesculapius", "medical symbol", "medicine", "staff"]
+              "keywords": [
+                "aesculapius",
+                "medical",
+                "medicine",
+                "staff",
+                "symbol"
+              ]
             },
             {
               "codepoint": "U+267B",
               "name": "recycling symbol",
-              "keywords": ["recycle", "recycling symbol"]
+              "keywords": ["recycle", "recycling", "symbol"]
             },
             {
               "codepoint": "U+269C",
               "name": "fleur-de-lis",
-              "keywords": ["fleur-de-lis"]
+              "keywords": ["fleur-de-lis", "knights"]
             },
             {
               "codepoint": "U+1F531",
               "name": "trident emblem",
-              "keywords": ["anchor", "emblem", "ship", "tool", "trident"]
+              "keywords": [
+                "anchor",
+                "emblem",
+                "poseidon",
+                "ship",
+                "tool",
+                "trident"
+              ]
             },
             {
               "codepoint": "U+1F4DB",
@@ -8038,62 +15706,118 @@
             {
               "codepoint": "U+1F530",
               "name": "Japanese symbol for beginner",
-              "keywords": ["beginner", "chevron", "Japanese", "Japanese symbol for beginner", "leaf"]
+              "keywords": [
+                "beginner",
+                "chevron",
+                "green",
+                "Japanese",
+                "leaf",
+                "symbol",
+                "tool",
+                "yellow"
+              ]
             },
             {
               "codepoint": "U+2B55",
               "name": "hollow red circle",
-              "keywords": ["circle", "hollow red circle", "large", "o", "red"]
+              "keywords": ["circle", "heavy", "hollow", "large", "o", "red"]
             },
             {
               "codepoint": "U+2705",
               "name": "check mark button",
-              "keywords": ["✓", "button", "check", "mark"]
+              "keywords": [
+                "✓",
+                "button",
+                "check",
+                "checked",
+                "checkmark",
+                "complete",
+                "completed",
+                "done",
+                "fixed",
+                "mark",
+                "tick"
+              ]
             },
             {
               "codepoint": "U+2611",
               "name": "check box with check",
-              "keywords": ["✓", "box", "check", "check box with check"]
+              "keywords": [
+                "✓",
+                "ballot",
+                "box",
+                "check",
+                "checked",
+                "done",
+                "off",
+                "tick"
+              ]
             },
             {
               "codepoint": "U+2714",
               "name": "check mark",
-              "keywords": ["✓", "check", "mark"]
+              "keywords": [
+                "✓",
+                "check",
+                "checked",
+                "checkmark",
+                "done",
+                "heavy",
+                "mark",
+                "tick"
+              ]
             },
             {
               "codepoint": "U+274C",
               "name": "cross mark",
-              "keywords": ["×", "cancel", "cross", "mark", "multiplication", "multiply", "x"]
+              "keywords": [
+                "×",
+                "cancel",
+                "cross",
+                "mark",
+                "multiplication",
+                "multiply",
+                "x"
+              ]
             },
             {
               "codepoint": "U+274E",
               "name": "cross mark button",
-              "keywords": ["×", "cross mark button", "mark", "square", "x"]
+              "keywords": [
+                "×",
+                "button",
+                "cross",
+                "mark",
+                "multiplication",
+                "multiply",
+                "square",
+                "x"
+              ]
             },
             {
               "codepoint": "U+27B0",
               "name": "curly loop",
-              "keywords": ["curl", "curly loop", "loop"]
+              "keywords": ["curl", "curly", "loop"]
             },
             {
               "codepoint": "U+27BF",
               "name": "double curly loop",
-              "keywords": ["curl", "double", "double curly loop", "loop"]
+              "keywords": ["curl", "curly", "double", "loop"]
             },
             {
               "codepoint": "U+303D",
               "name": "part alternation mark",
-              "keywords": ["mark", "part", "part alternation mark"]
+              "keywords": ["alternation", "mark", "part"]
             },
             {
               "codepoint": "U+2733",
               "name": "eight-spoked asterisk",
-              "keywords": ["*", "asterisk", "eight-spoked asterisk"]
+              "keywords": ["*", "asterisk", "eight-spoked"]
             },
             {
               "codepoint": "U+2734",
               "name": "eight-pointed star",
-              "keywords": ["*", "eight-pointed star", "star"]
+              "keywords": ["*", "eight-pointed", "star"]
             },
             {
               "codepoint": "U+2747",
@@ -8103,17 +15827,32 @@
             {
               "codepoint": "U+00A9",
               "name": "copyright",
-              "keywords": ["c", "copyright"]
+              "keywords": ["C", "copyright"]
             },
             {
               "codepoint": "U+00AE",
               "name": "registered",
-              "keywords": ["r", "registered"]
+              "keywords": ["R", "registered"]
             },
             {
               "codepoint": "U+2122",
               "name": "trade mark",
-              "keywords": ["mark", "tm", "trade mark", "trademark"]
+              "keywords": ["mark", "TM", "trade", "trademark"]
+            },
+            {
+              "codepoint": "U+1FADF",
+              "name": "splatter",
+              "keywords": [
+                "drip",
+                "holi",
+                "ink",
+                "liquid",
+                "mess",
+                "paint",
+                "spill",
+                "splatter",
+                "stain"
+              ]
             }
           ]
         },
@@ -8208,7 +15947,7 @@
             {
               "codepoint": "U+1F523",
               "name": "input symbols",
-              "keywords": ["〒♪&%", "input", "input symbols"]
+              "keywords": ["&", "%", "♪", "〒", "input", "symbols"]
             },
             {
               "codepoint": "U+1F524",
@@ -8218,172 +15957,203 @@
             {
               "codepoint": "U+1F170",
               "name": "A button (blood type)",
-              "keywords": ["a", "A button (blood type)", "blood type"]
+              "keywords": ["blood", "button", "type"]
             },
             {
               "codepoint": "U+1F18E",
               "name": "AB button (blood type)",
-              "keywords": ["ab", "AB button (blood type)", "blood type"]
+              "keywords": ["AB", "blood", "button", "type"]
             },
             {
               "codepoint": "U+1F171",
               "name": "B button (blood type)",
-              "keywords": ["b", "B button (blood type)", "blood type"]
+              "keywords": ["B", "blood", "button", "type"]
             },
             {
               "codepoint": "U+1F191",
               "name": "CL button",
-              "keywords": ["cl", "CL button"]
+              "keywords": ["button", "CL"]
             },
             {
               "codepoint": "U+1F192",
               "name": "COOL button",
-              "keywords": ["cool", "COOL button"]
+              "keywords": ["button", "COOL"]
             },
             {
               "codepoint": "U+1F193",
               "name": "FREE button",
-              "keywords": ["free", "FREE button"]
+              "keywords": ["button", "FREE"]
             },
             {
               "codepoint": "U+2139",
               "name": "information",
-              "keywords": ["i", "information"]
+              "keywords": ["I", "information"]
             },
             {
               "codepoint": "U+1F194",
               "name": "ID button",
-              "keywords": ["id", "ID button", "identity"]
+              "keywords": ["button", "ID", "identity"]
             },
             {
               "codepoint": "U+24C2",
               "name": "circled M",
-              "keywords": ["circle", "circled M", "m"]
+              "keywords": ["circle", "circled", "M"]
             },
             {
               "codepoint": "U+1F195",
               "name": "NEW button",
-              "keywords": ["new", "NEW button"]
+              "keywords": ["button", "NEW"]
             },
             {
               "codepoint": "U+1F196",
               "name": "NG button",
-              "keywords": ["ng", "NG button"]
+              "keywords": ["button", "NG"]
             },
             {
               "codepoint": "U+1F17E",
               "name": "O button (blood type)",
-              "keywords": ["blood type", "o", "O button (blood type)"]
+              "keywords": ["blood", "button", "O", "type"]
             },
             {
               "codepoint": "U+1F197",
               "name": "OK button",
-              "keywords": ["OK", "OK button"]
+              "keywords": ["button", "OK", "okay"]
             },
             {
               "codepoint": "U+1F17F",
               "name": "P button",
-              "keywords": ["P button", "parking"]
+              "keywords": ["button", "P", "parking"]
             },
             {
               "codepoint": "U+1F198",
               "name": "SOS button",
-              "keywords": ["help", "sos", "SOS button"]
+              "keywords": ["button", "help", "SOS"]
             },
             {
               "codepoint": "U+1F199",
               "name": "UP! button",
-              "keywords": ["mark", "up", "UP! button"]
+              "keywords": ["button", "mark", "UP", "UP!"]
             },
             {
               "codepoint": "U+1F19A",
               "name": "VS button",
-              "keywords": ["versus", "vs", "VS button"]
+              "keywords": ["button", "versus", "VS"]
             },
             {
               "codepoint": "U+1F201",
               "name": "Japanese “here” button",
-              "keywords": ["“here”", "Japanese", "Japanese “here” button", "katakana", "ココ"]
+              "keywords": ["button", "here", "Japanese", "katakana"]
             },
             {
               "codepoint": "U+1F202",
               "name": "Japanese “service charge” button",
-              "keywords": ["“service charge”", "Japanese", "Japanese “service charge” button", "katakana", "サ"]
+              "keywords": [
+                "button",
+                "charge",
+                "Japanese",
+                "katakana",
+                "service"
+              ]
             },
             {
               "codepoint": "U+1F237",
               "name": "Japanese “monthly amount” button",
-              "keywords": ["“monthly amount”", "ideograph", "Japanese", "Japanese “monthly amount” button", "月"]
+              "keywords": [
+                "amount",
+                "button",
+                "ideograph",
+                "Japanese",
+                "monthly"
+              ]
             },
             {
               "codepoint": "U+1F236",
               "name": "Japanese “not free of charge” button",
-              "keywords": ["“not free of charge”", "ideograph", "Japanese", "Japanese “not free of charge” button", "有"]
+              "keywords": [
+                "button",
+                "charge",
+                "free",
+                "ideograph",
+                "Japanese",
+                "not"
+              ]
             },
             {
               "codepoint": "U+1F22F",
               "name": "Japanese “reserved” button",
-              "keywords": ["“reserved”", "ideograph", "Japanese", "Japanese “reserved” button", "指"]
+              "keywords": ["button", "ideograph", "Japanese", "reserved"]
             },
             {
               "codepoint": "U+1F250",
               "name": "Japanese “bargain” button",
-              "keywords": ["“bargain”", "ideograph", "Japanese", "Japanese “bargain” button", "得"]
+              "keywords": ["bargain", "button", "ideograph", "Japanese"]
             },
             {
               "codepoint": "U+1F239",
               "name": "Japanese “discount” button",
-              "keywords": ["“discount”", "ideograph", "Japanese", "Japanese “discount” button", "割"]
+              "keywords": ["button", "discount", "ideograph", "Japanese"]
             },
             {
               "codepoint": "U+1F21A",
               "name": "Japanese “free of charge” button",
-              "keywords": ["“free of charge”", "ideograph", "Japanese", "Japanese “free of charge” button", "無"]
+              "keywords": ["button", "charge", "free", "ideograph", "Japanese"]
             },
             {
               "codepoint": "U+1F232",
               "name": "Japanese “prohibited” button",
-              "keywords": ["“prohibited”", "ideograph", "Japanese", "Japanese “prohibited” button", "禁"]
+              "keywords": ["button", "ideograph", "Japanese", "prohibited"]
             },
             {
               "codepoint": "U+1F251",
               "name": "Japanese “acceptable” button",
-              "keywords": ["“acceptable”", "ideograph", "Japanese", "Japanese “acceptable” button", "可"]
+              "keywords": ["acceptable", "button", "ideograph", "Japanese"]
             },
             {
               "codepoint": "U+1F238",
               "name": "Japanese “application” button",
-              "keywords": ["“application”", "ideograph", "Japanese", "Japanese “application” button", "申"]
+              "keywords": ["application", "button", "ideograph", "Japanese"]
             },
             {
               "codepoint": "U+1F234",
               "name": "Japanese “passing grade” button",
-              "keywords": ["“passing grade”", "ideograph", "Japanese", "Japanese “passing grade” button", "合"]
+              "keywords": [
+                "button",
+                "grade",
+                "ideograph",
+                "Japanese",
+                "passing"
+              ]
             },
             {
               "codepoint": "U+1F233",
               "name": "Japanese “vacancy” button",
-              "keywords": ["“vacancy”", "ideograph", "Japanese", "Japanese “vacancy” button", "空"]
+              "keywords": ["button", "ideograph", "Japanese", "vacancy"]
             },
             {
               "codepoint": "U+3297",
               "name": "Japanese “congratulations” button",
-              "keywords": ["“congratulations”", "ideograph", "Japanese", "Japanese “congratulations” button", "祝"]
+              "keywords": ["button", "congratulations", "ideograph", "Japanese"]
             },
             {
               "codepoint": "U+3299",
               "name": "Japanese “secret” button",
-              "keywords": ["“secret”", "ideograph", "Japanese", "Japanese “secret” button", "秘"]
+              "keywords": ["button", "ideograph", "Japanese", "secret"]
             },
             {
               "codepoint": "U+1F23A",
               "name": "Japanese “open for business” button",
-              "keywords": ["“open for business”", "ideograph", "Japanese", "Japanese “open for business” button", "営"]
+              "keywords": [
+                "business",
+                "button",
+                "ideograph",
+                "Japanese",
+                "open"
+              ]
             },
             {
               "codepoint": "U+1F235",
               "name": "Japanese “no vacancy” button",
-              "keywords": ["“no vacancy”", "ideograph", "Japanese", "Japanese “no vacancy” button", "満"]
+              "keywords": ["button", "ideograph", "Japanese", "no", "vacancy"]
             }
           ]
         },
@@ -8428,17 +16198,17 @@
             {
               "codepoint": "U+26AB",
               "name": "black circle",
-              "keywords": ["black circle", "circle", "geometric"]
+              "keywords": ["black", "circle", "geometric"]
             },
             {
               "codepoint": "U+26AA",
               "name": "white circle",
-              "keywords": ["circle", "geometric", "white circle"]
+              "keywords": ["circle", "geometric", "white"]
             },
             {
               "codepoint": "U+1F7E5",
               "name": "red square",
-              "keywords": ["red", "square"]
+              "keywords": ["card", "penalty", "red", "square"]
             },
             {
               "codepoint": "U+1F7E7",
@@ -8448,7 +16218,7 @@
             {
               "codepoint": "U+1F7E8",
               "name": "yellow square",
-              "keywords": ["square", "yellow"]
+              "keywords": ["card", "penalty", "square", "yellow"]
             },
             {
               "codepoint": "U+1F7E9",
@@ -8473,77 +16243,77 @@
             {
               "codepoint": "U+2B1B",
               "name": "black large square",
-              "keywords": ["black large square", "geometric", "square"]
+              "keywords": ["black", "geometric", "large", "square"]
             },
             {
               "codepoint": "U+2B1C",
               "name": "white large square",
-              "keywords": ["geometric", "square", "white large square"]
+              "keywords": ["geometric", "large", "square", "white"]
             },
             {
               "codepoint": "U+25FC",
               "name": "black medium square",
-              "keywords": ["black medium square", "geometric", "square"]
+              "keywords": ["black", "geometric", "medium", "square"]
             },
             {
               "codepoint": "U+25FB",
               "name": "white medium square",
-              "keywords": ["geometric", "square", "white medium square"]
+              "keywords": ["geometric", "medium", "square", "white"]
             },
             {
               "codepoint": "U+25FE",
               "name": "black medium-small square",
-              "keywords": ["black medium-small square", "geometric", "square"]
+              "keywords": ["black", "geometric", "medium-small", "square"]
             },
             {
               "codepoint": "U+25FD",
               "name": "white medium-small square",
-              "keywords": ["geometric", "square", "white medium-small square"]
+              "keywords": ["geometric", "medium-small", "square", "white"]
             },
             {
               "codepoint": "U+25AA",
               "name": "black small square",
-              "keywords": ["black small square", "geometric", "square"]
+              "keywords": ["black", "geometric", "small", "square"]
             },
             {
               "codepoint": "U+25AB",
               "name": "white small square",
-              "keywords": ["geometric", "square", "white small square"]
+              "keywords": ["geometric", "small", "square", "white"]
             },
             {
               "codepoint": "U+1F536",
               "name": "large orange diamond",
-              "keywords": ["diamond", "geometric", "large orange diamond", "orange"]
+              "keywords": ["diamond", "geometric", "large", "orange"]
             },
             {
               "codepoint": "U+1F537",
               "name": "large blue diamond",
-              "keywords": ["blue", "diamond", "geometric", "large blue diamond"]
+              "keywords": ["blue", "diamond", "geometric", "large"]
             },
             {
               "codepoint": "U+1F538",
               "name": "small orange diamond",
-              "keywords": ["diamond", "geometric", "orange", "small orange diamond"]
+              "keywords": ["diamond", "geometric", "orange", "small"]
             },
             {
               "codepoint": "U+1F539",
               "name": "small blue diamond",
-              "keywords": ["blue", "diamond", "geometric", "small blue diamond"]
+              "keywords": ["blue", "diamond", "geometric", "small"]
             },
             {
               "codepoint": "U+1F53A",
               "name": "red triangle pointed up",
-              "keywords": ["geometric", "red", "red triangle pointed up"]
+              "keywords": ["geometric", "pointed", "red", "triangle", "up"]
             },
             {
               "codepoint": "U+1F53B",
               "name": "red triangle pointed down",
-              "keywords": ["down", "geometric", "red", "red triangle pointed down"]
+              "keywords": ["down", "geometric", "pointed", "red", "triangle"]
             },
             {
               "codepoint": "U+1F4A0",
               "name": "diamond with a dot",
-              "keywords": ["comic", "diamond", "diamond with a dot", "geometric", "inside"]
+              "keywords": ["comic", "diamond", "dot", "geometric"]
             },
             {
               "codepoint": "U+1F518",
@@ -8553,12 +16323,12 @@
             {
               "codepoint": "U+1F533",
               "name": "white square button",
-              "keywords": ["button", "geometric", "outlined", "square", "white square button"]
+              "keywords": ["button", "geometric", "outlined", "square", "white"]
             },
             {
               "codepoint": "U+1F532",
               "name": "black square button",
-              "keywords": ["black square button", "button", "geometric", "square"]
+              "keywords": ["black", "button", "geometric", "square"]
             }
           ]
         }
@@ -8573,47 +16343,94 @@
             {
               "codepoint": "U+1F3C1",
               "name": "chequered flag",
-              "keywords": ["checkered", "chequered", "chequered flag", "racing"]
+              "keywords": [
+                "checkered",
+                "chequered",
+                "finish",
+                "flag",
+                "flags",
+                "game",
+                "race",
+                "racing",
+                "sport",
+                "win"
+              ]
             },
             {
               "codepoint": "U+1F6A9",
               "name": "triangular flag",
-              "keywords": ["post", "triangular flag"]
+              "keywords": ["construction", "flag", "golf", "post", "triangular"]
             },
             {
               "codepoint": "U+1F38C",
               "name": "crossed flags",
-              "keywords": ["celebration", "cross", "crossed", "crossed flags", "Japanese"]
+              "keywords": [
+                "celebration",
+                "cross",
+                "crossed",
+                "flags",
+                "Japanese"
+              ]
             },
             {
               "codepoint": "U+1F3F4",
               "name": "black flag",
-              "keywords": ["black flag", "waving"]
+              "keywords": ["black", "flag", "waving"]
             },
             {
               "codepoint": "U+1F3F3",
               "name": "white flag",
-              "keywords": ["waving", "white flag"]
+              "keywords": ["flag", "waving", "white"]
             },
             {
               "codepoint": "U+1F3F3 U+FE0F U+200D U+1F308",
               "name": "rainbow flag",
-              "keywords": ["pride", "rainbow", "rainbow flag"]
+              "keywords": [
+                "bisexual",
+                "flag",
+                "gay",
+                "genderqueer",
+                "glbt",
+                "glbtq",
+                "lesbian",
+                "lgbt",
+                "lgbtq",
+                "lgbtqia",
+                "pride",
+                "queer",
+                "rainbow",
+                "trans",
+                "transgender"
+              ]
             },
             {
               "codepoint": "U+1F3F3 U+FE0F U+200D U+26A7 U+FE0F",
               "name": "transgender flag",
-              "keywords": ["flag", "light blue", "pink", "transgender", "white"]
+              "keywords": [
+                "blue",
+                "flag",
+                "light",
+                "pink",
+                "transgender",
+                "white"
+              ]
             },
             {
               "codepoint": "U+1F3F4 U+200D U+2620 U+FE0F",
               "name": "pirate flag",
-              "keywords": ["Jolly Roger", "pirate", "pirate flag", "plunder", "treasure"]
+              "keywords": [
+                "flag",
+                "Jolly",
+                "pirate",
+                "plunder",
+                "Roger",
+                "treasure"
+              ]
             }
           ]
         },
         {
-          "category": "country_flag",
+          "category": "country-flag",
           "contents": [
             {
               "codepoint": "U+1F1E6 U+1F1E8",
@@ -8868,6 +16685,11 @@
             {
               "codepoint": "U+1F1E8 U+1F1F5",
               "name": "flag: Clipperton Island",
+              "keywords": ["flag"]
+            },
+            {
+              "codepoint": "U+1F1E8 U+1F1F6",
+              "name": "flag: Sark",
               "keywords": ["flag"]
             },
             {
@@ -9772,7 +17594,7 @@
             },
             {
               "codepoint": "U+1F1F9 U+1F1F7",
-              "name": "flag: Turkey",
+              "name": "flag: Türkiye",
               "keywords": ["flag"]
             },
             {
@@ -9908,7 +17730,7 @@
           ]
         },
         {
-          "category": "subdivision_flag",
+          "category": "subdivision-flag",
           "contents": [
             {
               "codepoint": "U+1F3F4 U+E0067 U+E0062 U+E0065 U+E006E U+E0067 U+E007F",

--- a/assets/unicode-emoji.json
+++ b/assets/unicode-emoji.json
@@ -6,7 +6,7 @@
     "which can be found at https://unicode.org/emoji/charts/emoji-list.html",
     "It should never be changed unless the official list does,",
     "and even then, only if you know what you're doing.",
-    
+
     "The list of images for Forumoji is kept in forumoji.json"
   ],
   "category": "root",
@@ -20,156 +20,42 @@
             {
               "codepoint": "U+1F600",
               "name": "grinning face",
-              "keywords": [
-                "cheerful",
-                "cheery",
-                "face",
-                "grin",
-                "grinning",
-                "happy",
-                "laugh",
-                "nice",
-                "smile",
-                "smiling",
-                "teeth"
-              ]
+              "keywords": ["cheerful", "cheery", "face", "grin", "grinning", "happy", "laugh", "nice", "smile", "smiling", "teeth"]
             },
             {
               "codepoint": "U+1F603",
               "name": "grinning face with big eyes",
-              "keywords": [
-                "awesome",
-                "big",
-                "eyes",
-                "face",
-                "grin",
-                "grinning",
-                "happy",
-                "mouth",
-                "open",
-                "smile",
-                "smiling",
-                "teeth",
-                "yay"
-              ]
+              "keywords": ["awesome", "big", "eyes", "face", "grin", "grinning", "happy", "mouth", "open", "smile", "smiling", "teeth", "yay"]
             },
             {
               "codepoint": "U+1F604",
               "name": "grinning face with smiling eyes",
-              "keywords": [
-                "eye",
-                "eyes",
-                "face",
-                "grin",
-                "grinning",
-                "happy",
-                "laugh",
-                "lol",
-                "mouth",
-                "open",
-                "smile",
-                "smiling"
-              ]
+              "keywords": ["eye", "eyes", "face", "grin", "grinning", "happy", "laugh", "lol", "mouth", "open", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F601",
               "name": "beaming face with smiling eyes",
-              "keywords": [
-                "beaming",
-                "eye",
-                "eyes",
-                "face",
-                "grin",
-                "grinning",
-                "happy",
-                "nice",
-                "smile",
-                "smiling",
-                "teeth"
-              ]
+              "keywords": ["beaming", "eye", "eyes", "face", "grin", "grinning", "happy", "nice", "smile", "smiling", "teeth"]
             },
             {
               "codepoint": "U+1F606",
               "name": "grinning squinting face",
-              "keywords": [
-                "closed",
-                "eyes",
-                "face",
-                "grinning",
-                "haha",
-                "hahaha",
-                "happy",
-                "laugh",
-                "lol",
-                "mouth",
-                "open",
-                "rofl",
-                "smile",
-                "smiling",
-                "squinting"
-              ]
+              "keywords": ["closed", "eyes", "face", "grinning", "haha", "hahaha", "happy", "laugh", "lol", "mouth", "open", "rofl", "smile", "smiling", "squinting"]
             },
             {
               "codepoint": "U+1F605",
               "name": "grinning face with sweat",
-              "keywords": [
-                "cold",
-                "dejected",
-                "excited",
-                "face",
-                "grinning",
-                "mouth",
-                "nervous",
-                "open",
-                "smile",
-                "smiling",
-                "stress",
-                "stressed",
-                "sweat"
-              ]
+              "keywords": ["cold", "dejected", "excited", "face", "grinning", "mouth", "nervous", "open", "smile", "smiling", "stress", "stressed", "sweat"]
             },
             {
               "codepoint": "U+1F923",
               "name": "rolling on the floor laughing",
-              "keywords": [
-                "crying",
-                "face",
-                "floor",
-                "funny",
-                "haha",
-                "happy",
-                "hehe",
-                "hilarious",
-                "joy",
-                "laugh",
-                "lmao",
-                "lol",
-                "rofl",
-                "roflmao",
-                "rolling",
-                "tear"
-              ]
+              "keywords": ["crying", "face", "floor", "funny", "haha", "happy", "hehe", "hilarious", "joy", "laugh", "lmao", "lol", "rofl", "roflmao", "rolling", "tear"]
             },
             {
               "codepoint": "U+1F602",
               "name": "face with tears of joy",
-              "keywords": [
-                "crying",
-                "face",
-                "feels",
-                "funny",
-                "haha",
-                "happy",
-                "hehe",
-                "hilarious",
-                "joy",
-                "laugh",
-                "lmao",
-                "lol",
-                "rofl",
-                "roflmao",
-                "tear"
-              ]
+              "keywords": ["crying", "face", "feels", "funny", "haha", "happy", "hehe", "hilarious", "joy", "laugh", "lmao", "lol", "rofl", "roflmao", "tear"]
             },
             {
               "codepoint": "U+1F642",
@@ -184,72 +70,22 @@
             {
               "codepoint": "U+1FAE0",
               "name": "melting face",
-              "keywords": [
-                "disappear",
-                "dissolve",
-                "embarrassed",
-                "face",
-                "haha",
-                "heat",
-                "hot",
-                "liquid",
-                "lol",
-                "melt",
-                "melting",
-                "sarcasm",
-                "sarcastic"
-              ]
+              "keywords": ["disappear", "dissolve", "embarrassed", "face", "haha", "heat", "hot", "liquid", "lol", "melt", "melting", "sarcasm", "sarcastic"]
             },
             {
               "codepoint": "U+1F609",
               "name": "winking face",
-              "keywords": [
-                "face",
-                "flirt",
-                "heartbreaker",
-                "sexy",
-                "slide",
-                "tease",
-                "wink",
-                "winking",
-                "winks"
-              ]
+              "keywords": ["face", "flirt", "heartbreaker", "sexy", "slide", "tease", "wink", "winking", "winks"]
             },
             {
               "codepoint": "U+1F60A",
               "name": "smiling face with smiling eyes",
-              "keywords": [
-                "blush",
-                "eye",
-                "eyes",
-                "face",
-                "glad",
-                "satisfied",
-                "smile",
-                "smiling"
-              ]
+              "keywords": ["blush", "eye", "eyes", "face", "glad", "satisfied", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F607",
               "name": "smiling face with halo",
-              "keywords": [
-                "angel",
-                "angelic",
-                "angels",
-                "blessed",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "halo",
-                "happy",
-                "innocent",
-                "peaceful",
-                "smile",
-                "smiling",
-                "spirit",
-                "tale"
-              ]
+              "keywords": ["angel", "angelic", "angels", "blessed", "face", "fairy", "fairytale", "fantasy", "halo", "happy", "innocent", "peaceful", "smile", "smiling", "spirit", "tale"]
             }
           ]
         },
@@ -259,169 +95,47 @@
             {
               "codepoint": "U+1F970",
               "name": "smiling face with hearts",
-              "keywords": [
-                "3",
-                "adore",
-                "crush",
-                "face",
-                "heart",
-                "hearts",
-                "ily",
-                "love",
-                "romance",
-                "smile",
-                "smiling",
-                "you"
-              ]
+              "keywords": ["3", "adore", "crush", "face", "heart", "hearts", "ily", "love", "romance", "smile", "smiling", "you"]
             },
             {
               "codepoint": "U+1F60D",
               "name": "smiling face with heart-eyes",
-              "keywords": [
-                "143",
-                "bae",
-                "eye",
-                "face",
-                "feels",
-                "heart-eyes",
-                "hearts",
-                "ily",
-                "kisses",
-                "love",
-                "romance",
-                "romantic",
-                "smile",
-                "xoxo"
-              ]
+              "keywords": ["143", "bae", "eye", "face", "feels", "heart-eyes", "hearts", "ily", "kisses", "love", "romance", "romantic", "smile", "xoxo"]
             },
             {
               "codepoint": "U+1F929",
               "name": "star-struck",
-              "keywords": [
-                "excited",
-                "eyes",
-                "face",
-                "grinning",
-                "smile",
-                "star",
-                "star-struck",
-                "starry-eyed",
-                "wow"
-              ]
+              "keywords": ["excited", "eyes", "face", "grinning", "smile", "star", "star-struck", "starry-eyed", "wow"]
             },
             {
               "codepoint": "U+1F618",
               "name": "face blowing a kiss",
-              "keywords": [
-                "adorbs",
-                "bae",
-                "blowing",
-                "face",
-                "flirt",
-                "heart",
-                "ily",
-                "kiss",
-                "love",
-                "lover",
-                "miss",
-                "muah",
-                "romantic",
-                "smooch",
-                "xoxo",
-                "you"
-              ]
+              "keywords": ["adorbs", "bae", "blowing", "face", "flirt", "heart", "ily", "kiss", "love", "lover", "miss", "muah", "romantic", "smooch", "xoxo", "you"]
             },
             {
               "codepoint": "U+1F617",
               "name": "kissing face",
-              "keywords": [
-                "143",
-                "date",
-                "dating",
-                "face",
-                "flirt",
-                "ily",
-                "kiss",
-                "love",
-                "smooch",
-                "smooches",
-                "xoxo",
-                "you"
-              ]
+              "keywords": ["143", "date", "dating", "face", "flirt", "ily", "kiss", "love", "smooch", "smooches", "xoxo", "you"]
             },
             {
               "codepoint": "U+263A",
               "name": "smiling face",
-              "keywords": [
-                "face",
-                "happy",
-                "outlined",
-                "relaxed",
-                "smile",
-                "smiling"
-              ]
+              "keywords": ["face", "happy", "outlined", "relaxed", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F61A",
               "name": "kissing face with closed eyes",
-              "keywords": [
-                "143",
-                "bae",
-                "blush",
-                "closed",
-                "date",
-                "dating",
-                "eye",
-                "eyes",
-                "face",
-                "flirt",
-                "ily",
-                "kisses",
-                "kissing",
-                "smooches",
-                "xoxo"
-              ]
+              "keywords": ["143", "bae", "blush", "closed", "date", "dating", "eye", "eyes", "face", "flirt", "ily", "kisses", "kissing", "smooches", "xoxo"]
             },
             {
               "codepoint": "U+1F619",
               "name": "kissing face with smiling eyes",
-              "keywords": [
-                "143",
-                "closed",
-                "date",
-                "dating",
-                "eye",
-                "eyes",
-                "face",
-                "flirt",
-                "ily",
-                "kiss",
-                "kisses",
-                "kissing",
-                "love",
-                "night",
-                "smile",
-                "smiling"
-              ]
+              "keywords": ["143", "closed", "date", "dating", "eye", "eyes", "face", "flirt", "ily", "kiss", "kisses", "kissing", "love", "night", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F972",
               "name": "smiling face with tear",
-              "keywords": [
-                "face",
-                "glad",
-                "grateful",
-                "happy",
-                "joy",
-                "pain",
-                "proud",
-                "relieved",
-                "smile",
-                "smiley",
-                "smiling",
-                "tear",
-                "touched"
-              ]
+              "keywords": ["face", "glad", "grateful", "happy", "joy", "pain", "proud", "relieved", "smile", "smiley", "smiling", "tear", "touched"]
             }
           ]
         },
@@ -431,90 +145,27 @@
             {
               "codepoint": "U+1F60B",
               "name": "face savoring food",
-              "keywords": [
-                "delicious",
-                "eat",
-                "face",
-                "food",
-                "full",
-                "hungry",
-                "savor",
-                "smile",
-                "smiling",
-                "tasty",
-                "um",
-                "yum",
-                "yummy"
-              ]
+              "keywords": ["delicious", "eat", "face", "food", "full", "hungry", "savor", "smile", "smiling", "tasty", "um", "yum", "yummy"]
             },
             {
               "codepoint": "U+1F61B",
               "name": "face with tongue",
-              "keywords": [
-                "awesome",
-                "cool",
-                "face",
-                "nice",
-                "party",
-                "stuck-out",
-                "sweet",
-                "tongue"
-              ]
+              "keywords": ["awesome", "cool", "face", "nice", "party", "stuck-out", "sweet", "tongue"]
             },
             {
               "codepoint": "U+1F61C",
               "name": "winking face with tongue",
-              "keywords": [
-                "crazy",
-                "epic",
-                "eye",
-                "face",
-                "funny",
-                "joke",
-                "loopy",
-                "nutty",
-                "party",
-                "stuck-out",
-                "tongue",
-                "wacky",
-                "weirdo",
-                "wink",
-                "winking",
-                "yolo"
-              ]
+              "keywords": ["crazy", "epic", "eye", "face", "funny", "joke", "loopy", "nutty", "party", "stuck-out", "tongue", "wacky", "weirdo", "wink", "winking", "yolo"]
             },
             {
               "codepoint": "U+1F92A",
               "name": "zany face",
-              "keywords": [
-                "crazy",
-                "eye",
-                "eyes",
-                "face",
-                "goofy",
-                "large",
-                "small",
-                "zany"
-              ]
+              "keywords": ["crazy", "eye", "eyes", "face", "goofy", "large", "small", "zany"]
             },
             {
               "codepoint": "U+1F61D",
               "name": "squinting face with tongue",
-              "keywords": [
-                "closed",
-                "eye",
-                "eyes",
-                "face",
-                "gross",
-                "horrible",
-                "omg",
-                "squinting",
-                "stuck-out",
-                "taste",
-                "tongue",
-                "whatever",
-                "yolo"
-              ]
+              "keywords": ["closed", "eye", "eyes", "face", "gross", "horrible", "omg", "squinting", "stuck-out", "taste", "tongue", "whatever", "yolo"]
             },
             {
               "codepoint": "U+1F911",
@@ -534,60 +185,17 @@
             {
               "codepoint": "U+1F92D",
               "name": "face with hand over mouth",
-              "keywords": [
-                "face",
-                "giggle",
-                "giggling",
-                "hand",
-                "mouth",
-                "oops",
-                "realization",
-                "secret",
-                "shock",
-                "sudden",
-                "surprise",
-                "whoops"
-              ]
+              "keywords": ["face", "giggle", "giggling", "hand", "mouth", "oops", "realization", "secret", "shock", "sudden", "surprise", "whoops"]
             },
             {
               "codepoint": "U+1FAE2",
               "name": "face with open eyes and hand over mouth",
-              "keywords": [
-                "amazement",
-                "awe",
-                "disbelief",
-                "embarrass",
-                "eyes",
-                "face",
-                "gasp",
-                "hand",
-                "mouth",
-                "omg",
-                "open",
-                "over",
-                "quiet",
-                "scared",
-                "shock",
-                "surprise"
-              ]
+              "keywords": ["amazement", "awe", "disbelief", "embarrass", "eyes", "face", "gasp", "hand", "mouth", "omg", "open", "over", "quiet", "scared", "shock", "surprise"]
             },
             {
               "codepoint": "U+1FAE3",
               "name": "face with peeking eye",
-              "keywords": [
-                "captivated",
-                "embarrass",
-                "eye",
-                "face",
-                "hide",
-                "hiding",
-                "peek",
-                "peeking",
-                "peep",
-                "scared",
-                "shy",
-                "stare"
-              ]
+              "keywords": ["captivated", "embarrass", "eye", "face", "hide", "hiding", "peek", "peeking", "peep", "scared", "shy", "stare"]
             },
             {
               "codepoint": "U+1F92B",
@@ -597,33 +205,12 @@
             {
               "codepoint": "U+1F914",
               "name": "thinking face",
-              "keywords": [
-                "chin",
-                "consider",
-                "face",
-                "hmm",
-                "ponder",
-                "pondering",
-                "thinking",
-                "wondering"
-              ]
+              "keywords": ["chin", "consider", "face", "hmm", "ponder", "pondering", "thinking", "wondering"]
             },
             {
               "codepoint": "U+1FAE1",
               "name": "saluting face",
-              "keywords": [
-                "face",
-                "good",
-                "luck",
-                "ma’am",
-                "OK",
-                "respect",
-                "salute",
-                "saluting",
-                "sir",
-                "troops",
-                "yes"
-              ]
+              "keywords": ["face", "good", "luck", "ma’am", "OK", "respect", "salute", "saluting", "sir", "troops", "yes"]
             }
           ]
         },
@@ -633,117 +220,32 @@
             {
               "codepoint": "U+1F910",
               "name": "zipper-mouth face",
-              "keywords": [
-                "face",
-                "keep",
-                "mouth",
-                "quiet",
-                "secret",
-                "shut",
-                "zip",
-                "zipper",
-                "zipper-mouth"
-              ]
+              "keywords": ["face", "keep", "mouth", "quiet", "secret", "shut", "zip", "zipper", "zipper-mouth"]
             },
             {
               "codepoint": "U+1F928",
               "name": "face with raised eyebrow",
-              "keywords": [
-                "disapproval",
-                "disbelief",
-                "distrust",
-                "emoji",
-                "eyebrow",
-                "face",
-                "hmm",
-                "mild",
-                "raised",
-                "skeptic",
-                "skeptical",
-                "skepticism",
-                "surprise",
-                "what"
-              ]
+              "keywords": ["disapproval", "disbelief", "distrust", "emoji", "eyebrow", "face", "hmm", "mild", "raised", "skeptic", "skeptical", "skepticism", "surprise", "what"]
             },
             {
               "codepoint": "U+1F610",
               "name": "neutral face",
-              "keywords": [
-                "awkward",
-                "blank",
-                "deadpan",
-                "expressionless",
-                "face",
-                "fine",
-                "jealous",
-                "meh",
-                "neutral",
-                "oh",
-                "shade",
-                "straight",
-                "unamused",
-                "unhappy",
-                "unimpressed",
-                "whatever"
-              ]
+              "keywords": ["awkward", "blank", "deadpan", "expressionless", "face", "fine", "jealous", "meh", "neutral", "oh", "shade", "straight", "unamused", "unhappy", "unimpressed", "whatever"]
             },
             {
               "codepoint": "U+1F611",
               "name": "expressionless face",
-              "keywords": [
-                "awkward",
-                "dead",
-                "expressionless",
-                "face",
-                "fine",
-                "inexpressive",
-                "jealous",
-                "meh",
-                "not",
-                "oh",
-                "omg",
-                "straight",
-                "uh",
-                "unhappy",
-                "unimpressed",
-                "whatever"
-              ]
+              "keywords": ["awkward", "dead", "expressionless", "face", "fine", "inexpressive", "jealous", "meh", "not", "oh", "omg", "straight", "uh", "unhappy", "unimpressed", "whatever"]
             },
             {
               "codepoint": "U+1F636",
               "name": "face without mouth",
-              "keywords": [
-                "awkward",
-                "blank",
-                "expressionless",
-                "face",
-                "mouth",
-                "mouthless",
-                "mute",
-                "quiet",
-                "secret",
-                "silence",
-                "silent",
-                "speechless"
-              ]
+              "keywords": ["awkward", "blank", "expressionless", "face", "mouth", "mouthless", "mute", "quiet", "secret", "silence", "silent", "speechless"]
             },
             {
               "codepoint": "U+1FAE5",
               "name": "dotted line face",
-              "keywords": [
-                "depressed",
-                "disappear",
-                "dotted",
-                "face",
-                "hidden",
-                "hide",
-                "introvert",
-                "invisible",
-                "line",
-                "meh",
-                "whatever",
-                "wtv"
-              ]
+              "keywords": ["depressed", "disappear", "dotted", "face", "hidden", "hide", "introvert", "invisible", "line", "meh", "whatever", "wtv"]
             },
             {
               "codepoint": "U+1F636 U+200D U+1F32B U+FE0F",
@@ -753,93 +255,27 @@
             {
               "codepoint": "U+1F60F",
               "name": "smirking face",
-              "keywords": [
-                "boss",
-                "dapper",
-                "face",
-                "flirt",
-                "homie",
-                "kidding",
-                "leer",
-                "shade",
-                "slick",
-                "sly",
-                "smirk",
-                "smug",
-                "snicker",
-                "suave",
-                "suspicious",
-                "swag"
-              ]
+              "keywords": ["boss", "dapper", "face", "flirt", "homie", "kidding", "leer", "shade", "slick", "sly", "smirk", "smug", "snicker", "suave", "suspicious", "swag"]
             },
             {
               "codepoint": "U+1F612",
               "name": "unamused face",
-              "keywords": [
-                "...",
-                "bored",
-                "face",
-                "fine",
-                "jealous",
-                "jel",
-                "jelly",
-                "pissed",
-                "smh",
-                "ugh",
-                "uhh",
-                "unamused",
-                "unhappy",
-                "weird",
-                "whatever"
-              ]
+              "keywords": ["...", "bored", "face", "fine", "jealous", "jel", "jelly", "pissed", "smh", "ugh", "uhh", "unamused", "unhappy", "weird", "whatever"]
             },
             {
               "codepoint": "U+1F644",
               "name": "face with rolling eyes",
-              "keywords": [
-                "eyeroll",
-                "eyes",
-                "face",
-                "rolling",
-                "shade",
-                "ugh",
-                "whatever"
-              ]
+              "keywords": ["eyeroll", "eyes", "face", "rolling", "shade", "ugh", "whatever"]
             },
             {
               "codepoint": "U+1F62C",
               "name": "grimacing face",
-              "keywords": [
-                "awk",
-                "awkward",
-                "dentist",
-                "face",
-                "grimace",
-                "grimacing",
-                "grinning",
-                "smile",
-                "smiling"
-              ]
+              "keywords": ["awk", "awkward", "dentist", "face", "grimace", "grimacing", "grinning", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F62E U+200D U+1F4A8",
               "name": "face exhaling",
-              "keywords": [
-                "blow",
-                "blowing",
-                "exhale",
-                "exhaling",
-                "exhausted",
-                "face",
-                "gasp",
-                "groan",
-                "relief",
-                "sigh",
-                "smiley",
-                "smoke",
-                "whisper",
-                "whistle"
-              ]
+              "keywords": ["blow", "blowing", "exhale", "exhaling", "exhausted", "face", "gasp", "groan", "relief", "sigh", "smiley", "smoke", "whisper", "whistle"]
             },
             {
               "codepoint": "U+1F925",
@@ -849,20 +285,7 @@
             {
               "codepoint": "U+1FAE8",
               "name": "shaking face",
-              "keywords": [
-                "crazy",
-                "daze",
-                "earthquake",
-                "face",
-                "omg",
-                "panic",
-                "shaking",
-                "shock",
-                "surprise",
-                "vibrate",
-                "whoa",
-                "wow"
-              ]
+              "keywords": ["crazy", "daze", "earthquake", "face", "omg", "panic", "shaking", "shock", "surprise", "vibrate", "whoa", "wow"]
             },
             {
               "codepoint": "U+1F642 U+200D U+2194 U+FE0F",
@@ -887,34 +310,12 @@
             {
               "codepoint": "U+1F614",
               "name": "pensive face",
-              "keywords": [
-                "awful",
-                "bored",
-                "dejected",
-                "died",
-                "disappointed",
-                "face",
-                "losing",
-                "lost",
-                "pensive",
-                "sad",
-                "sucks"
-              ]
+              "keywords": ["awful", "bored", "dejected", "died", "disappointed", "face", "losing", "lost", "pensive", "sad", "sucks"]
             },
             {
               "codepoint": "U+1F62A",
               "name": "sleepy face",
-              "keywords": [
-                "crying",
-                "face",
-                "good",
-                "night",
-                "sad",
-                "sleep",
-                "sleeping",
-                "sleepy",
-                "tired"
-              ]
+              "keywords": ["crying", "face", "good", "night", "sad", "sleep", "sleeping", "sleepy", "tired"]
             },
             {
               "codepoint": "U+1F924",
@@ -924,37 +325,12 @@
             {
               "codepoint": "U+1F634",
               "name": "sleeping face",
-              "keywords": [
-                "bed",
-                "bedtime",
-                "face",
-                "good",
-                "goodnight",
-                "nap",
-                "night",
-                "sleep",
-                "sleeping",
-                "tired",
-                "whatever",
-                "yawn",
-                "zzz"
-              ]
+              "keywords": ["bed", "bedtime", "face", "good", "goodnight", "nap", "night", "sleep", "sleeping", "tired", "whatever", "yawn", "zzz"]
             },
             {
               "codepoint": "U+1FAE9",
               "name": "face with bags under eyes",
-              "keywords": [
-                "bags",
-                "bored",
-                "exhausted",
-                "eyes",
-                "face",
-                "fatigued",
-                "late",
-                "sleepy",
-                "tired",
-                "weary"
-              ]
+              "keywords": ["bags", "bored", "exhausted", "eyes", "face", "fatigued", "late", "sleepy", "tired", "weary"]
             }
           ]
         },
@@ -964,19 +340,7 @@
             {
               "codepoint": "U+1F637",
               "name": "face with medical mask",
-              "keywords": [
-                "cold",
-                "dentist",
-                "dermatologist",
-                "doctor",
-                "dr",
-                "face",
-                "germs",
-                "mask",
-                "medical",
-                "medicine",
-                "sick"
-              ]
+              "keywords": ["cold", "dentist", "dermatologist", "doctor", "dr", "face", "germs", "mask", "medical", "medicine", "sick"]
             },
             {
               "codepoint": "U+1F912",
@@ -986,152 +350,52 @@
             {
               "codepoint": "U+1F915",
               "name": "face with head-bandage",
-              "keywords": [
-                "bandage",
-                "face",
-                "head-bandage",
-                "hurt",
-                "injury",
-                "ouch"
-              ]
+              "keywords": ["bandage", "face", "head-bandage", "hurt", "injury", "ouch"]
             },
             {
               "codepoint": "U+1F922",
               "name": "nauseated face",
-              "keywords": [
-                "face",
-                "gross",
-                "nasty",
-                "nauseated",
-                "sick",
-                "vomit"
-              ]
+              "keywords": ["face", "gross", "nasty", "nauseated", "sick", "vomit"]
             },
             {
               "codepoint": "U+1F92E",
               "name": "face vomiting",
-              "keywords": [
-                "barf",
-                "ew",
-                "face",
-                "gross",
-                "puke",
-                "sick",
-                "spew",
-                "throw",
-                "up",
-                "vomit",
-                "vomiting"
-              ]
+              "keywords": ["barf", "ew", "face", "gross", "puke", "sick", "spew", "throw", "up", "vomit", "vomiting"]
             },
             {
               "codepoint": "U+1F927",
               "name": "sneezing face",
-              "keywords": [
-                "face",
-                "fever",
-                "flu",
-                "gesundheit",
-                "sick",
-                "sneeze",
-                "sneezing"
-              ]
+              "keywords": ["face", "fever", "flu", "gesundheit", "sick", "sneeze", "sneezing"]
             },
             {
               "codepoint": "U+1F975",
               "name": "hot face",
-              "keywords": [
-                "dying",
-                "face",
-                "feverish",
-                "heat",
-                "hot",
-                "panting",
-                "red-faced",
-                "stroke",
-                "sweating",
-                "tongue"
-              ]
+              "keywords": ["dying", "face", "feverish", "heat", "hot", "panting", "red-faced", "stroke", "sweating", "tongue"]
             },
             {
               "codepoint": "U+1F976",
               "name": "cold face",
-              "keywords": [
-                "blue",
-                "blue-faced",
-                "cold",
-                "face",
-                "freezing",
-                "frostbite",
-                "icicles",
-                "subzero",
-                "teeth"
-              ]
+              "keywords": ["blue", "blue-faced", "cold", "face", "freezing", "frostbite", "icicles", "subzero", "teeth"]
             },
             {
               "codepoint": "U+1F974",
               "name": "woozy face",
-              "keywords": [
-                "dizzy",
-                "drunk",
-                "eyes",
-                "face",
-                "intoxicated",
-                "mouth",
-                "tipsy",
-                "uneven",
-                "wavy",
-                "woozy"
-              ]
+              "keywords": ["dizzy", "drunk", "eyes", "face", "intoxicated", "mouth", "tipsy", "uneven", "wavy", "woozy"]
             },
             {
               "codepoint": "U+1F635",
               "name": "face with crossed-out eyes",
-              "keywords": [
-                "crossed-out",
-                "dead",
-                "dizzy",
-                "eyes",
-                "face",
-                "feels",
-                "knocked",
-                "out",
-                "sick",
-                "tired"
-              ]
+              "keywords": ["crossed-out", "dead", "dizzy", "eyes", "face", "feels", "knocked", "out", "sick", "tired"]
             },
             {
               "codepoint": "U+1F635 U+200D U+1F4AB",
               "name": "face with spiral eyes",
-              "keywords": [
-                "confused",
-                "dizzy",
-                "eyes",
-                "face",
-                "hypnotized",
-                "omg",
-                "smiley",
-                "spiral",
-                "trouble",
-                "whoa",
-                "woah",
-                "woozy"
-              ]
+              "keywords": ["confused", "dizzy", "eyes", "face", "hypnotized", "omg", "smiley", "spiral", "trouble", "whoa", "woah", "woozy"]
             },
             {
               "codepoint": "U+1F92F",
               "name": "exploding head",
-              "keywords": [
-                "blown",
-                "explode",
-                "exploding",
-                "head",
-                "mind",
-                "mindblown",
-                "no",
-                "shocked",
-                "way"
-              ]
+              "keywords": ["blown", "explode", "exploding", "head", "mind", "mindblown", "no", "shocked", "way"]
             }
           ]
         },
@@ -1146,38 +410,12 @@
             {
               "codepoint": "U+1F973",
               "name": "partying face",
-              "keywords": [
-                "bday",
-                "birthday",
-                "celebrate",
-                "celebration",
-                "excited",
-                "face",
-                "happy",
-                "hat",
-                "hooray",
-                "horn",
-                "party",
-                "partying"
-              ]
+              "keywords": ["bday", "birthday", "celebrate", "celebration", "excited", "face", "happy", "hat", "hooray", "horn", "party", "partying"]
             },
             {
               "codepoint": "U+1F978",
               "name": "disguised face",
-              "keywords": [
-                "disguise",
-                "eyebrow",
-                "face",
-                "glasses",
-                "incognito",
-                "moustache",
-                "mustache",
-                "nose",
-                "person",
-                "spy",
-                "tache",
-                "tash"
-              ]
+              "keywords": ["disguise", "eyebrow", "face", "glasses", "incognito", "moustache", "mustache", "nose", "person", "spy", "tache", "tash"]
             }
           ]
         },
@@ -1187,53 +425,17 @@
             {
               "codepoint": "U+1F60E",
               "name": "smiling face with sunglasses",
-              "keywords": [
-                "awesome",
-                "beach",
-                "bright",
-                "bro",
-                "chilling",
-                "cool",
-                "face",
-                "rad",
-                "relaxed",
-                "shades",
-                "slay",
-                "smile",
-                "style",
-                "sunglasses",
-                "swag",
-                "win"
-              ]
+              "keywords": ["awesome", "beach", "bright", "bro", "chilling", "cool", "face", "rad", "relaxed", "shades", "slay", "smile", "style", "sunglasses", "swag", "win"]
             },
             {
               "codepoint": "U+1F913",
               "name": "nerd face",
-              "keywords": [
-                "brainy",
-                "clever",
-                "expert",
-                "face",
-                "geek",
-                "gifted",
-                "glasses",
-                "intelligent",
-                "nerd",
-                "smart"
-              ]
+              "keywords": ["brainy", "clever", "expert", "face", "geek", "gifted", "glasses", "intelligent", "nerd", "smart"]
             },
             {
               "codepoint": "U+1F9D0",
               "name": "face with monocle",
-              "keywords": [
-                "classy",
-                "face",
-                "fancy",
-                "monocle",
-                "rich",
-                "stuffy",
-                "wealthy"
-              ]
+              "keywords": ["classy", "face", "fancy", "monocle", "rich", "stuffy", "wealthy"]
             }
           ]
         },
@@ -1243,58 +445,17 @@
             {
               "codepoint": "U+1F615",
               "name": "confused face",
-              "keywords": [
-                "befuddled",
-                "confused",
-                "confusing",
-                "dunno",
-                "face",
-                "frown",
-                "hm",
-                "meh",
-                "not",
-                "sad",
-                "sorry",
-                "sure"
-              ]
+              "keywords": ["befuddled", "confused", "confusing", "dunno", "face", "frown", "hm", "meh", "not", "sad", "sorry", "sure"]
             },
             {
               "codepoint": "U+1FAE4",
               "name": "face with diagonal mouth",
-              "keywords": [
-                "confused",
-                "confusion",
-                "diagonal",
-                "disappointed",
-                "doubt",
-                "doubtful",
-                "face",
-                "frustrated",
-                "frustration",
-                "meh",
-                "mouth",
-                "skeptical",
-                "unsure",
-                "whatever",
-                "wtv"
-              ]
+              "keywords": ["confused", "confusion", "diagonal", "disappointed", "doubt", "doubtful", "face", "frustrated", "frustration", "meh", "mouth", "skeptical", "unsure", "whatever", "wtv"]
             },
             {
               "codepoint": "U+1F61F",
               "name": "worried face",
-              "keywords": [
-                "anxious",
-                "butterflies",
-                "face",
-                "nerves",
-                "nervous",
-                "sad",
-                "stress",
-                "stressed",
-                "surprised",
-                "worried",
-                "worry"
-              ]
+              "keywords": ["anxious", "butterflies", "face", "nerves", "nervous", "sad", "stress", "stressed", "surprised", "worried", "worry"]
             },
             {
               "codepoint": "U+1F641",
@@ -1309,357 +470,107 @@
             {
               "codepoint": "U+1F62E",
               "name": "face with open mouth",
-              "keywords": [
-                "believe",
-                "face",
-                "forgot",
-                "mouth",
-                "omg",
-                "open",
-                "shocked",
-                "surprised",
-                "sympathy",
-                "unbelievable",
-                "unreal",
-                "whoa",
-                "wow",
-                "you"
-              ]
+              "keywords": ["believe", "face", "forgot", "mouth", "omg", "open", "shocked", "surprised", "sympathy", "unbelievable", "unreal", "whoa", "wow", "you"]
             },
             {
               "codepoint": "U+1F62F",
               "name": "hushed face",
-              "keywords": [
-                "epic",
-                "face",
-                "hushed",
-                "omg",
-                "stunned",
-                "surprised",
-                "whoa",
-                "woah"
-              ]
+              "keywords": ["epic", "face", "hushed", "omg", "stunned", "surprised", "whoa", "woah"]
             },
             {
               "codepoint": "U+1F632",
               "name": "astonished face",
-              "keywords": [
-                "astonished",
-                "cost",
-                "face",
-                "no",
-                "omg",
-                "shocked",
-                "totally",
-                "way"
-              ]
+              "keywords": ["astonished", "cost", "face", "no", "omg", "shocked", "totally", "way"]
             },
             {
               "codepoint": "U+1F633",
               "name": "flushed face",
-              "keywords": [
-                "amazed",
-                "awkward",
-                "crazy",
-                "dazed",
-                "dead",
-                "disbelief",
-                "embarrassed",
-                "face",
-                "flushed",
-                "geez",
-                "heat",
-                "hot",
-                "impressed",
-                "jeez",
-                "what",
-                "wow"
-              ]
+              "keywords": ["amazed", "awkward", "crazy", "dazed", "dead", "disbelief", "embarrassed", "face", "flushed", "geez", "heat", "hot", "impressed", "jeez", "what", "wow"]
             },
             {
               "codepoint": "U+1F97A",
               "name": "pleading face",
-              "keywords": [
-                "begging",
-                "big",
-                "eyes",
-                "face",
-                "mercy",
-                "not",
-                "pleading",
-                "please",
-                "pretty",
-                "puppy",
-                "sad",
-                "why"
-              ]
+              "keywords": ["begging", "big", "eyes", "face", "mercy", "not", "pleading", "please", "pretty", "puppy", "sad", "why"]
             },
             {
               "codepoint": "U+1F979",
               "name": "face holding back tears",
-              "keywords": [
-                "admiration",
-                "aww",
-                "back",
-                "cry",
-                "embarrassed",
-                "face",
-                "feelings",
-                "grateful",
-                "gratitude",
-                "holding",
-                "joy",
-                "please",
-                "proud",
-                "resist",
-                "sad",
-                "tears"
-              ]
+              "keywords": ["admiration", "aww", "back", "cry", "embarrassed", "face", "feelings", "grateful", "gratitude", "holding", "joy", "please", "proud", "resist", "sad", "tears"]
             },
             {
               "codepoint": "U+1F626",
               "name": "frowning face with open mouth",
-              "keywords": [
-                "caught",
-                "face",
-                "frown",
-                "frowning",
-                "guard",
-                "mouth",
-                "open",
-                "scared",
-                "scary",
-                "surprise",
-                "what",
-                "wow"
-              ]
+              "keywords": ["caught", "face", "frown", "frowning", "guard", "mouth", "open", "scared", "scary", "surprise", "what", "wow"]
             },
             {
               "codepoint": "U+1F627",
               "name": "anguished face",
-              "keywords": [
-                "anguished",
-                "face",
-                "forgot",
-                "scared",
-                "scary",
-                "stressed",
-                "surprise",
-                "unhappy",
-                "what",
-                "wow"
-              ]
+              "keywords": ["anguished", "face", "forgot", "scared", "scary", "stressed", "surprise", "unhappy", "what", "wow"]
             },
             {
               "codepoint": "U+1F628",
               "name": "fearful face",
-              "keywords": [
-                "afraid",
-                "anxious",
-                "blame",
-                "face",
-                "fear",
-                "fearful",
-                "scared",
-                "worried"
-              ]
+              "keywords": ["afraid", "anxious", "blame", "face", "fear", "fearful", "scared", "worried"]
             },
             {
               "codepoint": "U+1F630",
               "name": "anxious face with sweat",
-              "keywords": [
-                "anxious",
-                "blue",
-                "cold",
-                "eek",
-                "face",
-                "mouth",
-                "nervous",
-                "open",
-                "rushed",
-                "scared",
-                "sweat",
-                "yikes"
-              ]
+              "keywords": ["anxious", "blue", "cold", "eek", "face", "mouth", "nervous", "open", "rushed", "scared", "sweat", "yikes"]
             },
             {
               "codepoint": "U+1F625",
               "name": "sad but relieved face",
-              "keywords": [
-                "anxious",
-                "call",
-                "close",
-                "complicated",
-                "disappointed",
-                "face",
-                "not",
-                "relieved",
-                "sad",
-                "sweat",
-                "time",
-                "whew"
-              ]
+              "keywords": ["anxious", "call", "close", "complicated", "disappointed", "face", "not", "relieved", "sad", "sweat", "time", "whew"]
             },
             {
               "codepoint": "U+1F622",
               "name": "crying face",
-              "keywords": [
-                "awful",
-                "cry",
-                "crying",
-                "face",
-                "feels",
-                "miss",
-                "sad",
-                "tear",
-                "triste",
-                "unhappy"
-              ]
+              "keywords": ["awful", "cry", "crying", "face", "feels", "miss", "sad", "tear", "triste", "unhappy"]
             },
             {
               "codepoint": "U+1F62D",
               "name": "loudly crying face",
-              "keywords": [
-                "bawling",
-                "cry",
-                "crying",
-                "face",
-                "loudly",
-                "sad",
-                "sob",
-                "tear",
-                "tears",
-                "unhappy"
-              ]
+              "keywords": ["bawling", "cry", "crying", "face", "loudly", "sad", "sob", "tear", "tears", "unhappy"]
             },
             {
               "codepoint": "U+1F631",
               "name": "face screaming in fear",
-              "keywords": [
-                "epic",
-                "face",
-                "fear",
-                "fearful",
-                "munch",
-                "scared",
-                "scream",
-                "screamer",
-                "screaming",
-                "shocked",
-                "surprised",
-                "woah"
-              ]
+              "keywords": ["epic", "face", "fear", "fearful", "munch", "scared", "scream", "screamer", "screaming", "shocked", "surprised", "woah"]
             },
             {
               "codepoint": "U+1F616",
               "name": "confounded face",
-              "keywords": [
-                "annoyed",
-                "confounded",
-                "confused",
-                "cringe",
-                "distraught",
-                "face",
-                "feels",
-                "frustrated",
-                "mad",
-                "sad"
-              ]
+              "keywords": ["annoyed", "confounded", "confused", "cringe", "distraught", "face", "feels", "frustrated", "mad", "sad"]
             },
             {
               "codepoint": "U+1F623",
               "name": "persevering face",
-              "keywords": [
-                "concentrate",
-                "concentration",
-                "face",
-                "focus",
-                "headache",
-                "persevere",
-                "persevering"
-              ]
+              "keywords": ["concentrate", "concentration", "face", "focus", "headache", "persevere", "persevering"]
             },
             {
               "codepoint": "U+1F61E",
               "name": "disappointed face",
-              "keywords": [
-                "awful",
-                "blame",
-                "dejected",
-                "disappointed",
-                "face",
-                "fail",
-                "losing",
-                "sad",
-                "unhappy"
-              ]
+              "keywords": ["awful", "blame", "dejected", "disappointed", "face", "fail", "losing", "sad", "unhappy"]
             },
             {
               "codepoint": "U+1F613",
               "name": "downcast face with sweat",
-              "keywords": [
-                "close",
-                "cold",
-                "downcast",
-                "face",
-                "feels",
-                "headache",
-                "nervous",
-                "sad",
-                "scared",
-                "sweat",
-                "yikes"
-              ]
+              "keywords": ["close", "cold", "downcast", "face", "feels", "headache", "nervous", "sad", "scared", "sweat", "yikes"]
             },
             {
               "codepoint": "U+1F629",
               "name": "weary face",
-              "keywords": [
-                "crying",
-                "face",
-                "fail",
-                "feels",
-                "hungry",
-                "mad",
-                "nooo",
-                "sad",
-                "sleepy",
-                "tired",
-                "unhappy",
-                "weary"
-              ]
+              "keywords": ["crying", "face", "fail", "feels", "hungry", "mad", "nooo", "sad", "sleepy", "tired", "unhappy", "weary"]
             },
             {
               "codepoint": "U+1F62B",
               "name": "tired face",
-              "keywords": [
-                "cost",
-                "face",
-                "feels",
-                "nap",
-                "sad",
-                "sneeze",
-                "tired"
-              ]
+              "keywords": ["cost", "face", "feels", "nap", "sad", "sneeze", "tired"]
             },
             {
               "codepoint": "U+1F971",
               "name": "yawning face",
-              "keywords": [
-                "bedtime",
-                "bored",
-                "face",
-                "goodnight",
-                "nap",
-                "night",
-                "sleep",
-                "sleepy",
-                "tired",
-                "whatever",
-                "yawn",
-                "yawning",
-                "zzz"
-              ]
+              "keywords": ["bedtime", "bored", "face", "goodnight", "nap", "night", "sleep", "sleepy", "tired", "whatever", "yawn", "yawning", "zzz"]
             }
           ]
         },
@@ -1669,144 +580,42 @@
             {
               "codepoint": "U+1F624",
               "name": "face with steam from nose",
-              "keywords": [
-                "anger",
-                "angry",
-                "face",
-                "feels",
-                "fume",
-                "fuming",
-                "furious",
-                "fury",
-                "mad",
-                "nose",
-                "steam",
-                "triumph",
-                "unhappy",
-                "won"
-              ]
+              "keywords": ["anger", "angry", "face", "feels", "fume", "fuming", "furious", "fury", "mad", "nose", "steam", "triumph", "unhappy", "won"]
             },
             {
               "codepoint": "U+1F621",
               "name": "enraged face",
-              "keywords": [
-                "anger",
-                "angry",
-                "enraged",
-                "face",
-                "feels",
-                "mad",
-                "maddening",
-                "pouting",
-                "rage",
-                "red",
-                "shade",
-                "unhappy",
-                "upset"
-              ]
+              "keywords": ["anger", "angry", "enraged", "face", "feels", "mad", "maddening", "pouting", "rage", "red", "shade", "unhappy", "upset"]
             },
             {
               "codepoint": "U+1F620",
               "name": "angry face",
-              "keywords": [
-                "anger",
-                "angry",
-                "blame",
-                "face",
-                "feels",
-                "frustrated",
-                "mad",
-                "maddening",
-                "rage",
-                "shade",
-                "unhappy",
-                "upset"
-              ]
+              "keywords": ["anger", "angry", "blame", "face", "feels", "frustrated", "mad", "maddening", "rage", "shade", "unhappy", "upset"]
             },
             {
               "codepoint": "U+1F92C",
               "name": "face with symbols on mouth",
-              "keywords": [
-                "censor",
-                "cursing",
-                "cussing",
-                "face",
-                "mad",
-                "mouth",
-                "pissed",
-                "swearing",
-                "symbols"
-              ]
+              "keywords": ["censor", "cursing", "cussing", "face", "mad", "mouth", "pissed", "swearing", "symbols"]
             },
             {
               "codepoint": "U+1F608",
               "name": "smiling face with horns",
-              "keywords": [
-                "demon",
-                "devil",
-                "evil",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "horns",
-                "purple",
-                "shade",
-                "smile",
-                "smiling",
-                "tale"
-              ]
+              "keywords": ["demon", "devil", "evil", "face", "fairy", "fairytale", "fantasy", "horns", "purple", "shade", "smile", "smiling", "tale"]
             },
             {
               "codepoint": "U+1F47F",
               "name": "angry face with horns",
-              "keywords": [
-                "angry",
-                "demon",
-                "devil",
-                "evil",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "horns",
-                "imp",
-                "mischievous",
-                "purple",
-                "shade",
-                "tale"
-              ]
+              "keywords": ["angry", "demon", "devil", "evil", "face", "fairy", "fairytale", "fantasy", "horns", "imp", "mischievous", "purple", "shade", "tale"]
             },
             {
               "codepoint": "U+1F480",
               "name": "skull",
-              "keywords": [
-                "body",
-                "dead",
-                "death",
-                "face",
-                "fairy",
-                "fairytale",
-                "i’m",
-                "lmao",
-                "monster",
-                "skull",
-                "tale",
-                "yolo"
-              ]
+              "keywords": ["body", "dead", "death", "face", "fairy", "fairytale", "i’m", "lmao", "monster", "skull", "tale", "yolo"]
             },
             {
               "codepoint": "U+2620",
               "name": "skull and crossbones",
-              "keywords": [
-                "bone",
-                "crossbones",
-                "dead",
-                "death",
-                "face",
-                "monster",
-                "skull"
-              ]
+              "keywords": ["bone", "crossbones", "dead", "death", "face", "monster", "skull"]
             }
           ]
         },
@@ -1816,24 +625,7 @@
             {
               "codepoint": "U+1F4A9",
               "name": "pile of poo",
-              "keywords": [
-                "bs",
-                "comic",
-                "doo",
-                "dung",
-                "face",
-                "fml",
-                "monster",
-                "pile",
-                "poo",
-                "poop",
-                "smelly",
-                "smh",
-                "stink",
-                "stinks",
-                "stinky",
-                "turd"
-              ]
+              "keywords": ["bs", "comic", "doo", "dung", "face", "fml", "monster", "pile", "poo", "poop", "smelly", "smh", "stink", "stinks", "stinky", "turd"]
             },
             {
               "codepoint": "U+1F921",
@@ -1843,94 +635,27 @@
             {
               "codepoint": "U+1F479",
               "name": "ogre",
-              "keywords": [
-                "creature",
-                "devil",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "mask",
-                "monster",
-                "ogre",
-                "scary",
-                "tale"
-              ]
+              "keywords": ["creature", "devil", "face", "fairy", "fairytale", "fantasy", "mask", "monster", "ogre", "scary", "tale"]
             },
             {
               "codepoint": "U+1F47A",
               "name": "goblin",
-              "keywords": [
-                "angry",
-                "creature",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "goblin",
-                "mask",
-                "mean",
-                "monster",
-                "tale"
-              ]
+              "keywords": ["angry", "creature", "face", "fairy", "fairytale", "fantasy", "goblin", "mask", "mean", "monster", "tale"]
             },
             {
               "codepoint": "U+1F47B",
               "name": "ghost",
-              "keywords": [
-                "boo",
-                "creature",
-                "excited",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "ghost",
-                "halloween",
-                "haunting",
-                "monster",
-                "scary",
-                "silly",
-                "tale"
-              ]
+              "keywords": ["boo", "creature", "excited", "face", "fairy", "fairytale", "fantasy", "ghost", "halloween", "haunting", "monster", "scary", "silly", "tale"]
             },
             {
               "codepoint": "U+1F47D",
               "name": "alien",
-              "keywords": [
-                "alien",
-                "creature",
-                "extraterrestrial",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "monster",
-                "space",
-                "tale",
-                "ufo"
-              ]
+              "keywords": ["alien", "creature", "extraterrestrial", "face", "fairy", "fairytale", "fantasy", "monster", "space", "tale", "ufo"]
             },
             {
               "codepoint": "U+1F47E",
               "name": "alien monster",
-              "keywords": [
-                "alien",
-                "creature",
-                "extraterrestrial",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "game",
-                "gamer",
-                "games",
-                "monster",
-                "pixelated",
-                "space",
-                "tale",
-                "ufo"
-              ]
+              "keywords": ["alien", "creature", "extraterrestrial", "face", "fairy", "fairytale", "fantasy", "game", "gamer", "games", "monster", "pixelated", "space", "tale", "ufo"]
             },
             {
               "codepoint": "U+1F916",
@@ -1945,61 +670,22 @@
             {
               "codepoint": "U+1F63A",
               "name": "grinning cat",
-              "keywords": [
-                "animal",
-                "cat",
-                "face",
-                "grinning",
-                "mouth",
-                "open",
-                "smile",
-                "smiling"
-              ]
+              "keywords": ["animal", "cat", "face", "grinning", "mouth", "open", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F638",
               "name": "grinning cat with smiling eyes",
-              "keywords": [
-                "animal",
-                "cat",
-                "eye",
-                "eyes",
-                "face",
-                "grin",
-                "grinning",
-                "smile",
-                "smiling"
-              ]
+              "keywords": ["animal", "cat", "eye", "eyes", "face", "grin", "grinning", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F639",
               "name": "cat with tears of joy",
-              "keywords": [
-                "animal",
-                "cat",
-                "face",
-                "joy",
-                "laugh",
-                "laughing",
-                "lol",
-                "tear",
-                "tears"
-              ]
+              "keywords": ["animal", "cat", "face", "joy", "laugh", "laughing", "lol", "tear", "tears"]
             },
             {
               "codepoint": "U+1F63B",
               "name": "smiling cat with heart-eyes",
-              "keywords": [
-                "animal",
-                "cat",
-                "eye",
-                "face",
-                "heart",
-                "heart-eyes",
-                "love",
-                "smile",
-                "smiling"
-              ]
+              "keywords": ["animal", "cat", "eye", "face", "heart", "heart-eyes", "love", "smile", "smiling"]
             },
             {
               "codepoint": "U+1F63C",
@@ -2009,16 +695,7 @@
             {
               "codepoint": "U+1F63D",
               "name": "kissing cat",
-              "keywords": [
-                "animal",
-                "cat",
-                "closed",
-                "eye",
-                "eyes",
-                "face",
-                "kiss",
-                "kissing"
-              ]
+              "keywords": ["animal", "cat", "closed", "eye", "eyes", "face", "kiss", "kissing"]
             },
             {
               "codepoint": "U+1F640",
@@ -2028,15 +705,7 @@
             {
               "codepoint": "U+1F63F",
               "name": "crying cat",
-              "keywords": [
-                "animal",
-                "cat",
-                "cry",
-                "crying",
-                "face",
-                "sad",
-                "tear"
-              ]
+              "keywords": ["animal", "cat", "cry", "crying", "face", "sad", "tear"]
             },
             {
               "codepoint": "U+1F63E",
@@ -2051,64 +720,17 @@
             {
               "codepoint": "U+1F648",
               "name": "see-no-evil monkey",
-              "keywords": [
-                "embarrassed",
-                "evil",
-                "face",
-                "forbidden",
-                "forgot",
-                "gesture",
-                "hide",
-                "monkey",
-                "no",
-                "omg",
-                "prohibited",
-                "scared",
-                "secret",
-                "smh",
-                "watch"
-              ]
+              "keywords": ["embarrassed", "evil", "face", "forbidden", "forgot", "gesture", "hide", "monkey", "no", "omg", "prohibited", "scared", "secret", "smh", "watch"]
             },
             {
               "codepoint": "U+1F649",
               "name": "hear-no-evil monkey",
-              "keywords": [
-                "animal",
-                "ears",
-                "evil",
-                "face",
-                "forbidden",
-                "gesture",
-                "hear",
-                "listen",
-                "monkey",
-                "no",
-                "not",
-                "prohibited",
-                "secret",
-                "shh",
-                "tmi"
-              ]
+              "keywords": ["animal", "ears", "evil", "face", "forbidden", "gesture", "hear", "listen", "monkey", "no", "not", "prohibited", "secret", "shh", "tmi"]
             },
             {
               "codepoint": "U+1F64A",
               "name": "speak-no-evil monkey",
-              "keywords": [
-                "animal",
-                "evil",
-                "face",
-                "forbidden",
-                "gesture",
-                "monkey",
-                "no",
-                "not",
-                "oops",
-                "prohibited",
-                "quiet",
-                "secret",
-                "speak",
-                "stealth"
-              ]
+              "keywords": ["animal", "evil", "face", "forbidden", "gesture", "monkey", "no", "not", "oops", "prohibited", "quiet", "secret", "speak", "stealth"]
             }
           ]
         },
@@ -2118,168 +740,57 @@
             {
               "codepoint": "U+1F48C",
               "name": "love letter",
-              "keywords": [
-                "heart",
-                "letter",
-                "love",
-                "mail",
-                "romance",
-                "valentine"
-              ]
+              "keywords": ["heart", "letter", "love", "mail", "romance", "valentine"]
             },
             {
               "codepoint": "U+1F498",
               "name": "heart with arrow",
-              "keywords": [
-                "143",
-                "adorbs",
-                "arrow",
-                "cupid",
-                "date",
-                "emotion",
-                "heart",
-                "ily",
-                "love",
-                "romance",
-                "valentine"
-              ]
+              "keywords": ["143", "adorbs", "arrow", "cupid", "date", "emotion", "heart", "ily", "love", "romance", "valentine"]
             },
             {
               "codepoint": "U+1F49D",
               "name": "heart with ribbon",
-              "keywords": [
-                "143",
-                "anniversary",
-                "emotion",
-                "heart",
-                "ily",
-                "kisses",
-                "ribbon",
-                "valentine",
-                "xoxo"
-              ]
+              "keywords": ["143", "anniversary", "emotion", "heart", "ily", "kisses", "ribbon", "valentine", "xoxo"]
             },
             {
               "codepoint": "U+1F496",
               "name": "sparkling heart",
-              "keywords": [
-                "143",
-                "emotion",
-                "excited",
-                "good",
-                "heart",
-                "ily",
-                "kisses",
-                "morning",
-                "night",
-                "sparkle",
-                "sparkling",
-                "xoxo"
-              ]
+              "keywords": ["143", "emotion", "excited", "good", "heart", "ily", "kisses", "morning", "night", "sparkle", "sparkling", "xoxo"]
             },
             {
               "codepoint": "U+1F497",
               "name": "growing heart",
-              "keywords": [
-                "143",
-                "emotion",
-                "excited",
-                "growing",
-                "heart",
-                "heartpulse",
-                "ily",
-                "kisses",
-                "muah",
-                "nervous",
-                "pulse",
-                "xoxo"
-              ]
+              "keywords": ["143", "emotion", "excited", "growing", "heart", "heartpulse", "ily", "kisses", "muah", "nervous", "pulse", "xoxo"]
             },
             {
               "codepoint": "U+1F493",
               "name": "beating heart",
-              "keywords": [
-                "143",
-                "beating",
-                "cardio",
-                "emotion",
-                "heart",
-                "heartbeat",
-                "ily",
-                "love",
-                "pulsating",
-                "pulse"
-              ]
+              "keywords": ["143", "beating", "cardio", "emotion", "heart", "heartbeat", "ily", "love", "pulsating", "pulse"]
             },
             {
               "codepoint": "U+1F49E",
               "name": "revolving hearts",
-              "keywords": [
-                "143",
-                "adorbs",
-                "anniversary",
-                "emotion",
-                "heart",
-                "hearts",
-                "revolving"
-              ]
+              "keywords": ["143", "adorbs", "anniversary", "emotion", "heart", "hearts", "revolving"]
             },
             {
               "codepoint": "U+1F495",
               "name": "two hearts",
-              "keywords": [
-                "143",
-                "anniversary",
-                "date",
-                "dating",
-                "emotion",
-                "heart",
-                "hearts",
-                "ily",
-                "kisses",
-                "love",
-                "loving",
-                "two",
-                "xoxo"
-              ]
+              "keywords": ["143", "anniversary", "date", "dating", "emotion", "heart", "hearts", "ily", "kisses", "love", "loving", "two", "xoxo"]
             },
             {
               "codepoint": "U+1F49F",
               "name": "heart decoration",
-              "keywords": [
-                "143",
-                "decoration",
-                "emotion",
-                "heart",
-                "hearth",
-                "purple",
-                "white"
-              ]
+              "keywords": ["143", "decoration", "emotion", "heart", "hearth", "purple", "white"]
             },
             {
               "codepoint": "U+2763",
               "name": "heart exclamation",
-              "keywords": [
-                "exclamation",
-                "heart",
-                "heavy",
-                "mark",
-                "punctuation"
-              ]
+              "keywords": ["exclamation", "heart", "heavy", "mark", "punctuation"]
             },
             {
               "codepoint": "U+1F494",
               "name": "broken heart",
-              "keywords": [
-                "break",
-                "broken",
-                "crushed",
-                "emotion",
-                "heart",
-                "heartbroken",
-                "lonely",
-                "sad"
-              ]
+              "keywords": ["break", "broken", "crushed", "emotion", "heart", "heartbroken", "lonely", "sad"]
             },
             {
               "codepoint": "U+2764 U+FE0F U+200D U+1F525",
@@ -2289,15 +800,7 @@
             {
               "codepoint": "U+2764 U+FE0F U+200D U+1FA79",
               "name": "mending heart",
-              "keywords": [
-                "healthier",
-                "heart",
-                "improving",
-                "mending",
-                "recovering",
-                "recuperating",
-                "well"
-              ]
+              "keywords": ["healthier", "heart", "improving", "mending", "recovering", "recuperating", "well"]
             },
             {
               "codepoint": "U+2764",
@@ -2307,19 +810,7 @@
             {
               "codepoint": "U+1FA77",
               "name": "pink heart",
-              "keywords": [
-                "143",
-                "adorable",
-                "cute",
-                "emotion",
-                "heart",
-                "ily",
-                "like",
-                "love",
-                "pink",
-                "special",
-                "sweet"
-              ]
+              "keywords": ["143", "adorable", "cute", "emotion", "heart", "ily", "like", "love", "pink", "special", "sweet"]
             },
             {
               "codepoint": "U+1F9E1",
@@ -2329,73 +820,27 @@
             {
               "codepoint": "U+1F49B",
               "name": "yellow heart",
-              "keywords": [
-                "143",
-                "cardiac",
-                "emotion",
-                "heart",
-                "ily",
-                "love",
-                "yellow"
-              ]
+              "keywords": ["143", "cardiac", "emotion", "heart", "ily", "love", "yellow"]
             },
             {
               "codepoint": "U+1F49A",
               "name": "green heart",
-              "keywords": [
-                "143",
-                "emotion",
-                "green",
-                "heart",
-                "ily",
-                "love",
-                "romantic"
-              ]
+              "keywords": ["143", "emotion", "green", "heart", "ily", "love", "romantic"]
             },
             {
               "codepoint": "U+1F499",
               "name": "blue heart",
-              "keywords": [
-                "143",
-                "blue",
-                "emotion",
-                "heart",
-                "ily",
-                "love",
-                "romance"
-              ]
+              "keywords": ["143", "blue", "emotion", "heart", "ily", "love", "romance"]
             },
             {
               "codepoint": "U+1FA75",
               "name": "light blue heart",
-              "keywords": [
-                "143",
-                "blue",
-                "cute",
-                "cyan",
-                "emotion",
-                "heart",
-                "ily",
-                "light",
-                "like",
-                "love",
-                "sky",
-                "special",
-                "teal"
-              ]
+              "keywords": ["143", "blue", "cute", "cyan", "emotion", "heart", "ily", "light", "like", "love", "sky", "special", "teal"]
             },
             {
               "codepoint": "U+1F49C",
               "name": "purple heart",
-              "keywords": [
-                "143",
-                "bestest",
-                "emotion",
-                "heart",
-                "ily",
-                "love",
-                "purple"
-              ]
+              "keywords": ["143", "bestest", "emotion", "heart", "ily", "love", "purple"]
             },
             {
               "codepoint": "U+1F90E",
@@ -2410,18 +855,7 @@
             {
               "codepoint": "U+1FA76",
               "name": "grey heart",
-              "keywords": [
-                "143",
-                "emotion",
-                "gray",
-                "grey",
-                "heart",
-                "ily",
-                "love",
-                "silver",
-                "slate",
-                "special"
-              ]
+              "keywords": ["143", "emotion", "gray", "grey", "heart", "ily", "love", "silver", "slate", "special"]
             },
             {
               "codepoint": "U+1F90D",
@@ -2436,39 +870,12 @@
             {
               "codepoint": "U+1F48B",
               "name": "kiss mark",
-              "keywords": [
-                "dating",
-                "emotion",
-                "heart",
-                "kiss",
-                "kissing",
-                "lips",
-                "mark",
-                "romance",
-                "sexy"
-              ]
+              "keywords": ["dating", "emotion", "heart", "kiss", "kissing", "lips", "mark", "romance", "sexy"]
             },
             {
               "codepoint": "U+1F4AF",
               "name": "hundred points",
-              "keywords": [
-                "100",
-                "a+",
-                "agree",
-                "clearly",
-                "definitely",
-                "faithful",
-                "fleek",
-                "full",
-                "hundred",
-                "keep",
-                "perfect",
-                "point",
-                "score",
-                "TRUE",
-                "truth",
-                "yup"
-              ]
+              "keywords": ["100", "a+", "agree", "clearly", "definitely", "faithful", "fleek", "full", "hundred", "keep", "perfect", "point", "score", "TRUE", "truth", "yup"]
             },
             {
               "codepoint": "U+1F4A2",
@@ -2478,79 +885,28 @@
             {
               "codepoint": "U+1F4A5",
               "name": "collision",
-              "keywords": [
-                "bomb",
-                "boom",
-                "collide",
-                "collision",
-                "comic",
-                "explode"
-              ]
+              "keywords": ["bomb", "boom", "collide", "collision", "comic", "explode"]
             },
             {
               "codepoint": "U+1F4AB",
               "name": "dizzy",
-              "keywords": [
-                "comic",
-                "dizzy",
-                "shining",
-                "shooting",
-                "star",
-                "stars"
-              ]
+              "keywords": ["comic", "dizzy", "shining", "shooting", "star", "stars"]
             },
             {
               "codepoint": "U+1F4A6",
               "name": "sweat droplets",
-              "keywords": [
-                "comic",
-                "drip",
-                "droplet",
-                "droplets",
-                "drops",
-                "splashing",
-                "squirt",
-                "sweat",
-                "water",
-                "wet",
-                "work",
-                "workout"
-              ]
+              "keywords": ["comic", "drip", "droplet", "droplets", "drops", "splashing", "squirt", "sweat", "water", "wet", "work", "workout"]
             },
             {
               "codepoint": "U+1F4A8",
               "name": "dashing away",
-              "keywords": [
-                "away",
-                "cloud",
-                "comic",
-                "dash",
-                "dashing",
-                "fart",
-                "fast",
-                "go",
-                "gone",
-                "gotta",
-                "running",
-                "smoke"
-              ]
+              "keywords": ["away", "cloud", "comic", "dash", "dashing", "fart", "fast", "go", "gone", "gotta", "running", "smoke"]
             },
             { "codepoint": "U+1F573", "name": "hole", "keywords": ["hole"] },
             {
               "codepoint": "U+1F4AC",
               "name": "speech balloon",
-              "keywords": [
-                "balloon",
-                "bubble",
-                "comic",
-                "dialog",
-                "message",
-                "sms",
-                "speech",
-                "talk",
-                "text",
-                "typing"
-              ]
+              "keywords": ["balloon", "bubble", "comic", "dialog", "message", "sms", "speech", "talk", "text", "typing"]
             },
             {
               "codepoint": "U+1F441 U+FE0F U+200D U+1F5E8 U+FE0F",
@@ -2565,50 +921,17 @@
             {
               "codepoint": "U+1F5EF",
               "name": "right anger bubble",
-              "keywords": [
-                "anger",
-                "angry",
-                "balloon",
-                "bubble",
-                "mad",
-                "right"
-              ]
+              "keywords": ["anger", "angry", "balloon", "bubble", "mad", "right"]
             },
             {
               "codepoint": "U+1F4AD",
               "name": "thought balloon",
-              "keywords": [
-                "balloon",
-                "bubble",
-                "cartoon",
-                "cloud",
-                "comic",
-                "daydream",
-                "decisions",
-                "dream",
-                "idea",
-                "invent",
-                "invention",
-                "realize",
-                "think",
-                "thoughts",
-                "wonder"
-              ]
+              "keywords": ["balloon", "bubble", "cartoon", "cloud", "comic", "daydream", "decisions", "dream", "idea", "invent", "invention", "realize", "think", "thoughts", "wonder"]
             },
             {
               "codepoint": "U+1F4A4",
               "name": "ZZZ",
-              "keywords": [
-                "comic",
-                "good",
-                "goodnight",
-                "night",
-                "sleep",
-                "sleeping",
-                "sleepy",
-                "tired",
-                "zzz"
-              ]
+              "keywords": ["comic", "good", "goodnight", "night", "sleep", "sleeping", "sleepy", "tired", "zzz"]
             }
           ]
         }
@@ -2623,24 +946,7 @@
             {
               "codepoint": "U+1F44B",
               "name": "waving hand",
-              "keywords": [
-                "bye",
-                "cya",
-                "g2g",
-                "greetings",
-                "gtg",
-                "hand",
-                "hello",
-                "hey",
-                "hi",
-                "later",
-                "outtie",
-                "ttfn",
-                "ttyl",
-                "wave",
-                "yo",
-                "you"
-              ]
+              "keywords": ["bye", "cya", "g2g", "greetings", "gtg", "hand", "hello", "hey", "hi", "later", "outtie", "ttfn", "ttyl", "wave", "yo", "you"]
             },
             {
               "codepoint": "U+1F91A",
@@ -2650,14 +956,7 @@
             {
               "codepoint": "U+1F590",
               "name": "hand with fingers splayed",
-              "keywords": [
-                "finger",
-                "fingers",
-                "hand",
-                "raised",
-                "splayed",
-                "stop"
-              ]
+              "keywords": ["finger", "fingers", "hand", "raised", "splayed", "stop"]
             },
             {
               "codepoint": "U+270B",
@@ -2672,104 +971,32 @@
             {
               "codepoint": "U+1FAF1",
               "name": "rightwards hand",
-              "keywords": [
-                "hand",
-                "handshake",
-                "hold",
-                "reach",
-                "right",
-                "rightward",
-                "rightwards",
-                "shake"
-              ]
+              "keywords": ["hand", "handshake", "hold", "reach", "right", "rightward", "rightwards", "shake"]
             },
             {
               "codepoint": "U+1FAF2",
               "name": "leftwards hand",
-              "keywords": [
-                "hand",
-                "handshake",
-                "hold",
-                "left",
-                "leftward",
-                "leftwards",
-                "reach",
-                "shake"
-              ]
+              "keywords": ["hand", "handshake", "hold", "left", "leftward", "leftwards", "reach", "shake"]
             },
             {
               "codepoint": "U+1FAF3",
               "name": "palm down hand",
-              "keywords": [
-                "dismiss",
-                "down",
-                "drop",
-                "dropped",
-                "hand",
-                "palm",
-                "pick",
-                "shoo",
-                "up"
-              ]
+              "keywords": ["dismiss", "down", "drop", "dropped", "hand", "palm", "pick", "shoo", "up"]
             },
             {
               "codepoint": "U+1FAF4",
               "name": "palm up hand",
-              "keywords": [
-                "beckon",
-                "catch",
-                "come",
-                "hand",
-                "hold",
-                "know",
-                "lift",
-                "me",
-                "offer",
-                "palm",
-                "tell"
-              ]
+              "keywords": ["beckon", "catch", "come", "hand", "hold", "know", "lift", "me", "offer", "palm", "tell"]
             },
             {
               "codepoint": "U+1FAF7",
               "name": "leftwards pushing hand",
-              "keywords": [
-                "block",
-                "five",
-                "halt",
-                "hand",
-                "high",
-                "hold",
-                "leftward",
-                "leftwards",
-                "pause",
-                "push",
-                "pushing",
-                "refuse",
-                "slap",
-                "stop",
-                "wait"
-              ]
+              "keywords": ["block", "five", "halt", "hand", "high", "hold", "leftward", "leftwards", "pause", "push", "pushing", "refuse", "slap", "stop", "wait"]
             },
             {
               "codepoint": "U+1FAF8",
               "name": "rightwards pushing hand",
-              "keywords": [
-                "block",
-                "five",
-                "halt",
-                "hand",
-                "high",
-                "hold",
-                "pause",
-                "push",
-                "pushing",
-                "refuse",
-                "rightward",
-                "rightwards",
-                "slap",
-                "stop",
-                "wait"
-              ]
+              "keywords": ["block", "five", "halt", "hand", "high", "hold", "pause", "push", "pushing", "refuse", "rightward", "rightwards", "slap", "stop", "wait"]
             }
           ]
         },
@@ -2779,57 +1006,17 @@
             {
               "codepoint": "U+1F44C",
               "name": "OK hand",
-              "keywords": [
-                "awesome",
-                "bet",
-                "dope",
-                "fleek",
-                "fosho",
-                "got",
-                "gotcha",
-                "hand",
-                "legit",
-                "OK",
-                "okay",
-                "pinch",
-                "rad",
-                "sure",
-                "sweet",
-                "three"
-              ]
+              "keywords": ["awesome", "bet", "dope", "fleek", "fosho", "got", "gotcha", "hand", "legit", "OK", "okay", "pinch", "rad", "sure", "sweet", "three"]
             },
             {
               "codepoint": "U+1F90C",
               "name": "pinched fingers",
-              "keywords": [
-                "fingers",
-                "gesture",
-                "hand",
-                "hold",
-                "huh",
-                "interrogation",
-                "patience",
-                "pinched",
-                "relax",
-                "sarcastic",
-                "ugh",
-                "what",
-                "zip"
-              ]
+              "keywords": ["fingers", "gesture", "hand", "hold", "huh", "interrogation", "patience", "pinched", "relax", "sarcastic", "ugh", "what", "zip"]
             },
             {
               "codepoint": "U+1F90F",
               "name": "pinching hand",
-              "keywords": [
-                "amount",
-                "bit",
-                "fingers",
-                "hand",
-                "little",
-                "pinching",
-                "small",
-                "sort"
-              ]
+              "keywords": ["amount", "bit", "fingers", "hand", "little", "pinching", "small", "sort"]
             },
             {
               "codepoint": "U+270C",
@@ -2839,45 +1026,17 @@
             {
               "codepoint": "U+1F91E",
               "name": "crossed fingers",
-              "keywords": [
-                "cross",
-                "crossed",
-                "finger",
-                "fingers",
-                "hand",
-                "luck"
-              ]
+              "keywords": ["cross", "crossed", "finger", "fingers", "hand", "luck"]
             },
             {
               "codepoint": "U+1FAF0",
               "name": "hand with index finger and thumb crossed",
-              "keywords": [
-                "<3",
-                "crossed",
-                "expensive",
-                "finger",
-                "hand",
-                "heart",
-                "index",
-                "love",
-                "money",
-                "snap",
-                "thumb"
-              ]
+              "keywords": ["<3", "crossed", "expensive", "finger", "hand", "heart", "index", "love", "money", "snap", "thumb"]
             },
             {
               "codepoint": "U+1F91F",
               "name": "love-you gesture",
-              "keywords": [
-                "fingers",
-                "gesture",
-                "hand",
-                "ILY",
-                "love",
-                "love-you",
-                "three",
-                "you"
-              ]
+              "keywords": ["fingers", "gesture", "hand", "ILY", "love", "love-you", "three", "you"]
             },
             {
               "codepoint": "U+1F918",
@@ -2897,41 +1056,17 @@
             {
               "codepoint": "U+1F448",
               "name": "backhand index pointing left",
-              "keywords": [
-                "backhand",
-                "finger",
-                "hand",
-                "index",
-                "left",
-                "point",
-                "pointing"
-              ]
+              "keywords": ["backhand", "finger", "hand", "index", "left", "point", "pointing"]
             },
             {
               "codepoint": "U+1F449",
               "name": "backhand index pointing right",
-              "keywords": [
-                "backhand",
-                "finger",
-                "hand",
-                "index",
-                "point",
-                "pointing",
-                "right"
-              ]
+              "keywords": ["backhand", "finger", "hand", "index", "point", "pointing", "right"]
             },
             {
               "codepoint": "U+1F446",
               "name": "backhand index pointing up",
-              "keywords": [
-                "backhand",
-                "finger",
-                "hand",
-                "index",
-                "point",
-                "pointing",
-                "up"
-              ]
+              "keywords": ["backhand", "finger", "hand", "index", "point", "pointing", "up"]
             },
             {
               "codepoint": "U+1F595",
@@ -2941,42 +1076,17 @@
             {
               "codepoint": "U+1F447",
               "name": "backhand index pointing down",
-              "keywords": [
-                "backhand",
-                "down",
-                "finger",
-                "hand",
-                "index",
-                "point",
-                "pointing"
-              ]
+              "keywords": ["backhand", "down", "finger", "hand", "index", "point", "pointing"]
             },
             {
               "codepoint": "U+261D",
               "name": "index pointing up",
-              "keywords": [
-                "finger",
-                "hand",
-                "index",
-                "point",
-                "pointing",
-                "this",
-                "up"
-              ]
+              "keywords": ["finger", "hand", "index", "point", "pointing", "this", "up"]
             },
             {
               "codepoint": "U+1FAF5",
               "name": "index pointing at the viewer",
-              "keywords": [
-                "at",
-                "finger",
-                "hand",
-                "index",
-                "pointing",
-                "poke",
-                "viewer",
-                "you"
-              ]
+              "keywords": ["at", "finger", "hand", "index", "pointing", "poke", "viewer", "you"]
             }
           ]
         },
@@ -2991,52 +1101,17 @@
             {
               "codepoint": "U+1F44E",
               "name": "thumbs down",
-              "keywords": [
-                "-1",
-                "bad",
-                "dislike",
-                "down",
-                "good",
-                "hand",
-                "no",
-                "nope",
-                "thumb",
-                "thumbs"
-              ]
+              "keywords": ["-1", "bad", "dislike", "down", "good", "hand", "no", "nope", "thumb", "thumbs"]
             },
             {
               "codepoint": "U+270A",
               "name": "raised fist",
-              "keywords": [
-                "clenched",
-                "fist",
-                "hand",
-                "punch",
-                "raised",
-                "solidarity"
-              ]
+              "keywords": ["clenched", "fist", "hand", "punch", "raised", "solidarity"]
             },
             {
               "codepoint": "U+1F44A",
               "name": "oncoming fist",
-              "keywords": [
-                "absolutely",
-                "agree",
-                "boom",
-                "bro",
-                "bruh",
-                "bump",
-                "clenched",
-                "correct",
-                "fist",
-                "hand",
-                "knuckle",
-                "oncoming",
-                "pound",
-                "punch",
-                "rock",
-                "ttyl"
-              ]
+              "keywords": ["absolutely", "agree", "boom", "bro", "bruh", "bump", "clenched", "correct", "fist", "hand", "knuckle", "oncoming", "pound", "punch", "rock", "ttyl"]
             },
             {
               "codepoint": "U+1F91B",
@@ -3056,38 +1131,12 @@
             {
               "codepoint": "U+1F44F",
               "name": "clapping hands",
-              "keywords": [
-                "applause",
-                "approval",
-                "awesome",
-                "clap",
-                "congrats",
-                "congratulations",
-                "excited",
-                "good",
-                "great",
-                "hand",
-                "homie",
-                "job",
-                "nice",
-                "prayed",
-                "well",
-                "yay"
-              ]
+              "keywords": ["applause", "approval", "awesome", "clap", "congrats", "congratulations", "excited", "good", "great", "hand", "homie", "job", "nice", "prayed", "well", "yay"]
             },
             {
               "codepoint": "U+1F64C",
               "name": "raising hands",
-              "keywords": [
-                "celebration",
-                "gesture",
-                "hand",
-                "hands",
-                "hooray",
-                "praise",
-                "raised",
-                "raising"
-              ]
+              "keywords": ["celebration", "gesture", "hand", "hands", "hooray", "praise", "raised", "raising"]
             },
             {
               "codepoint": "U+1FAF6",
@@ -3102,50 +1151,17 @@
             {
               "codepoint": "U+1F932",
               "name": "palms up together",
-              "keywords": [
-                "cupped",
-                "dua",
-                "hands",
-                "palms",
-                "pray",
-                "prayer",
-                "together",
-                "up",
-                "wish"
-              ]
+              "keywords": ["cupped", "dua", "hands", "palms", "pray", "prayer", "together", "up", "wish"]
             },
             {
               "codepoint": "U+1F91D",
               "name": "handshake",
-              "keywords": [
-                "agreement",
-                "deal",
-                "hand",
-                "handshake",
-                "meeting",
-                "shake"
-              ]
+              "keywords": ["agreement", "deal", "hand", "handshake", "meeting", "shake"]
             },
             {
               "codepoint": "U+1F64F",
               "name": "folded hands",
-              "keywords": [
-                "appreciate",
-                "ask",
-                "beg",
-                "blessed",
-                "bow",
-                "cmon",
-                "five",
-                "folded",
-                "gesture",
-                "hand",
-                "high",
-                "please",
-                "pray",
-                "thanks",
-                "thx"
-              ]
+              "keywords": ["appreciate", "ask", "beg", "blessed", "bow", "cmon", "five", "folded", "gesture", "hand", "high", "please", "pray", "thanks", "thx"]
             }
           ]
         },
@@ -3160,17 +1176,7 @@
             {
               "codepoint": "U+1F485",
               "name": "nail polish",
-              "keywords": [
-                "bored",
-                "care",
-                "cosmetics",
-                "done",
-                "makeup",
-                "manicure",
-                "nail",
-                "polish",
-                "whatever"
-              ]
+              "keywords": ["bored", "care", "cosmetics", "done", "makeup", "manicure", "nail", "polish", "whatever"]
             },
             {
               "codepoint": "U+1F933",
@@ -3185,24 +1191,7 @@
             {
               "codepoint": "U+1F4AA",
               "name": "flexed biceps",
-              "keywords": [
-                "arm",
-                "beast",
-                "bench",
-                "biceps",
-                "bodybuilder",
-                "bro",
-                "curls",
-                "flex",
-                "gains",
-                "gym",
-                "jacked",
-                "muscle",
-                "press",
-                "ripped",
-                "strong",
-                "weightlift"
-              ]
+              "keywords": ["arm", "beast", "bench", "biceps", "bodybuilder", "bro", "curls", "flex", "gains", "gym", "jacked", "muscle", "press", "ripped", "strong", "weightlift"]
             },
             {
               "codepoint": "U+1F9BE",
@@ -3227,16 +1216,7 @@
             {
               "codepoint": "U+1F442",
               "name": "ear",
-              "keywords": [
-                "body",
-                "ear",
-                "ears",
-                "hear",
-                "hearing",
-                "listen",
-                "listening",
-                "sound"
-              ]
+              "keywords": ["body", "ear", "ears", "hear", "hearing", "listen", "listening", "sound"]
             },
             {
               "codepoint": "U+1F9BB",
@@ -3246,15 +1226,7 @@
             {
               "codepoint": "U+1F443",
               "name": "nose",
-              "keywords": [
-                "body",
-                "nose",
-                "noses",
-                "nosey",
-                "odor",
-                "smell",
-                "smells"
-              ]
+              "keywords": ["body", "nose", "noses", "nosey", "odor", "smell", "smells"]
             },
             {
               "codepoint": "U+1F9E0",
@@ -3264,31 +1236,12 @@
             {
               "codepoint": "U+1FAC0",
               "name": "anatomical heart",
-              "keywords": [
-                "anatomical",
-                "beat",
-                "cardiology",
-                "heart",
-                "heartbeat",
-                "organ",
-                "pulse",
-                "real",
-                "red"
-              ]
+              "keywords": ["anatomical", "beat", "cardiology", "heart", "heartbeat", "organ", "pulse", "real", "red"]
             },
             {
               "codepoint": "U+1FAC1",
               "name": "lungs",
-              "keywords": [
-                "breath",
-                "breathe",
-                "exhalation",
-                "inhalation",
-                "lung",
-                "lungs",
-                "organ",
-                "respiration"
-              ]
+              "keywords": ["breath", "breathe", "exhalation", "inhalation", "lung", "lungs", "organ", "respiration"]
             },
             {
               "codepoint": "U+1F9B7",
@@ -3303,19 +1256,7 @@
             {
               "codepoint": "U+1F440",
               "name": "eyes",
-              "keywords": [
-                "body",
-                "eye",
-                "eyes",
-                "face",
-                "googly",
-                "look",
-                "looking",
-                "omg",
-                "peep",
-                "see",
-                "seeing"
-              ]
+              "keywords": ["body", "eye", "eyes", "face", "googly", "look", "looking", "omg", "peep", "see", "seeing"]
             },
             {
               "codepoint": "U+1F441",
@@ -3330,35 +1271,12 @@
             {
               "codepoint": "U+1F444",
               "name": "mouth",
-              "keywords": [
-                "beauty",
-                "body",
-                "kiss",
-                "kissing",
-                "lips",
-                "lipstick",
-                "mouth"
-              ]
+              "keywords": ["beauty", "body", "kiss", "kissing", "lips", "lipstick", "mouth"]
             },
             {
               "codepoint": "U+1FAE6",
               "name": "biting lip",
-              "keywords": [
-                "anxious",
-                "bite",
-                "biting",
-                "fear",
-                "flirt",
-                "flirting",
-                "kiss",
-                "lip",
-                "lipstick",
-                "nervous",
-                "sexy",
-                "uncomfortable",
-                "worried",
-                "worry"
-              ]
+              "keywords": ["anxious", "bite", "biting", "fear", "flirt", "flirting", "kiss", "lip", "lipstick", "nervous", "sexy", "uncomfortable", "worried", "worry"]
             }
           ]
         },
@@ -3368,58 +1286,22 @@
             {
               "codepoint": "U+1F476",
               "name": "baby",
-              "keywords": [
-                "babies",
-                "baby",
-                "children",
-                "goo",
-                "infant",
-                "newborn",
-                "pregnant",
-                "young"
-              ]
+              "keywords": ["babies", "baby", "children", "goo", "infant", "newborn", "pregnant", "young"]
             },
             {
               "codepoint": "U+1F9D2",
               "name": "child",
-              "keywords": [
-                "bright-eyed",
-                "child",
-                "grandchild",
-                "kid",
-                "young",
-                "younger"
-              ]
+              "keywords": ["bright-eyed", "child", "grandchild", "kid", "young", "younger"]
             },
             {
               "codepoint": "U+1F466",
               "name": "boy",
-              "keywords": [
-                "boy",
-                "bright-eyed",
-                "child",
-                "grandson",
-                "kid",
-                "son",
-                "young",
-                "younger"
-              ]
+              "keywords": ["boy", "bright-eyed", "child", "grandson", "kid", "son", "young", "younger"]
             },
             {
               "codepoint": "U+1F467",
               "name": "girl",
-              "keywords": [
-                "bright-eyed",
-                "child",
-                "daughter",
-                "girl",
-                "granddaughter",
-                "kid",
-                "Virgo",
-                "young",
-                "younger",
-                "zodiac"
-              ]
+              "keywords": ["bright-eyed", "child", "daughter", "girl", "granddaughter", "kid", "Virgo", "young", "younger", "zodiac"]
             },
             {
               "codepoint": "U+1F9D1",
@@ -3529,44 +1411,17 @@
             {
               "codepoint": "U+1F9D3",
               "name": "older person",
-              "keywords": [
-                "adult",
-                "elderly",
-                "grandparent",
-                "old",
-                "person",
-                "wise"
-              ]
+              "keywords": ["adult", "elderly", "grandparent", "old", "person", "wise"]
             },
             {
               "codepoint": "U+1F474",
               "name": "old man",
-              "keywords": [
-                "adult",
-                "bald",
-                "elderly",
-                "gramps",
-                "grandfather",
-                "grandpa",
-                "man",
-                "old",
-                "wise"
-              ]
+              "keywords": ["adult", "bald", "elderly", "gramps", "grandfather", "grandpa", "man", "old", "wise"]
             },
             {
               "codepoint": "U+1F475",
               "name": "old woman",
-              "keywords": [
-                "adult",
-                "elderly",
-                "grandma",
-                "grandmother",
-                "granny",
-                "lady",
-                "old",
-                "wise",
-                "woman"
-              ]
+              "keywords": ["adult", "elderly", "grandma", "grandmother", "granny", "lady", "old", "wise", "woman"]
             }
           ]
         },
@@ -3576,488 +1431,152 @@
             {
               "codepoint": "U+1F64D",
               "name": "person frowning",
-              "keywords": [
-                "annoyed",
-                "disappointed",
-                "disgruntled",
-                "disturbed",
-                "frown",
-                "frowning",
-                "frustrated",
-                "gesture",
-                "irritated",
-                "person",
-                "upset"
-              ]
+              "keywords": ["annoyed", "disappointed", "disgruntled", "disturbed", "frown", "frowning", "frustrated", "gesture", "irritated", "person", "upset"]
             },
             {
               "codepoint": "U+1F64D U+200D U+2642 U+FE0F",
               "name": "man frowning",
-              "keywords": [
-                "annoyed",
-                "disappointed",
-                "disgruntled",
-                "disturbed",
-                "frown",
-                "frowning",
-                "frustrated",
-                "gesture",
-                "irritated",
-                "man",
-                "upset"
-              ]
+              "keywords": ["annoyed", "disappointed", "disgruntled", "disturbed", "frown", "frowning", "frustrated", "gesture", "irritated", "man", "upset"]
             },
             {
               "codepoint": "U+1F64D U+200D U+2640 U+FE0F",
               "name": "woman frowning",
-              "keywords": [
-                "annoyed",
-                "disappointed",
-                "disgruntled",
-                "disturbed",
-                "frown",
-                "frowning",
-                "frustrated",
-                "gesture",
-                "irritated",
-                "upset",
-                "woman"
-              ]
+              "keywords": ["annoyed", "disappointed", "disgruntled", "disturbed", "frown", "frowning", "frustrated", "gesture", "irritated", "upset", "woman"]
             },
             {
               "codepoint": "U+1F64E",
               "name": "person pouting",
-              "keywords": [
-                "disappointed",
-                "downtrodden",
-                "frown",
-                "grimace",
-                "person",
-                "pouting",
-                "scowl",
-                "sulk",
-                "upset",
-                "whine"
-              ]
+              "keywords": ["disappointed", "downtrodden", "frown", "grimace", "person", "pouting", "scowl", "sulk", "upset", "whine"]
             },
             {
               "codepoint": "U+1F64E U+200D U+2642 U+FE0F",
               "name": "man pouting",
-              "keywords": [
-                "disappointed",
-                "downtrodden",
-                "frown",
-                "grimace",
-                "man",
-                "pouting",
-                "scowl",
-                "sulk",
-                "upset",
-                "whine"
-              ]
+              "keywords": ["disappointed", "downtrodden", "frown", "grimace", "man", "pouting", "scowl", "sulk", "upset", "whine"]
             },
             {
               "codepoint": "U+1F64E U+200D U+2640 U+FE0F",
               "name": "woman pouting",
-              "keywords": [
-                "disappointed",
-                "downtrodden",
-                "frown",
-                "grimace",
-                "pouting",
-                "scowl",
-                "sulk",
-                "upset",
-                "whine",
-                "woman"
-              ]
+              "keywords": ["disappointed", "downtrodden", "frown", "grimace", "pouting", "scowl", "sulk", "upset", "whine", "woman"]
             },
             {
               "codepoint": "U+1F645",
               "name": "person gesturing NO",
-              "keywords": [
-                "forbidden",
-                "gesture",
-                "hand",
-                "NO",
-                "not",
-                "person",
-                "prohibit"
-              ]
+              "keywords": ["forbidden", "gesture", "hand", "NO", "not", "person", "prohibit"]
             },
             {
               "codepoint": "U+1F645 U+200D U+2642 U+FE0F",
               "name": "man gesturing NO",
-              "keywords": [
-                "forbidden",
-                "gesture",
-                "hand",
-                "man",
-                "NO",
-                "not",
-                "prohibit"
-              ]
+              "keywords": ["forbidden", "gesture", "hand", "man", "NO", "not", "prohibit"]
             },
             {
               "codepoint": "U+1F645 U+200D U+2640 U+FE0F",
               "name": "woman gesturing NO",
-              "keywords": [
-                "forbidden",
-                "gesture",
-                "hand",
-                "NO",
-                "not",
-                "prohibit",
-                "woman"
-              ]
+              "keywords": ["forbidden", "gesture", "hand", "NO", "not", "prohibit", "woman"]
             },
             {
               "codepoint": "U+1F646",
               "name": "person gesturing OK",
-              "keywords": [
-                "exercise",
-                "gesture",
-                "gesturing",
-                "hand",
-                "OK",
-                "omg",
-                "person"
-              ]
+              "keywords": ["exercise", "gesture", "gesturing", "hand", "OK", "omg", "person"]
             },
             {
               "codepoint": "U+1F646 U+200D U+2642 U+FE0F",
               "name": "man gesturing OK",
-              "keywords": [
-                "exercise",
-                "gesture",
-                "gesturing",
-                "hand",
-                "man",
-                "OK",
-                "omg"
-              ]
+              "keywords": ["exercise", "gesture", "gesturing", "hand", "man", "OK", "omg"]
             },
             {
               "codepoint": "U+1F646 U+200D U+2640 U+FE0F",
               "name": "woman gesturing OK",
-              "keywords": [
-                "exercise",
-                "gesture",
-                "gesturing",
-                "hand",
-                "OK",
-                "omg",
-                "woman"
-              ]
+              "keywords": ["exercise", "gesture", "gesturing", "hand", "OK", "omg", "woman"]
             },
             {
               "codepoint": "U+1F481",
               "name": "person tipping hand",
-              "keywords": [
-                "fetch",
-                "flick",
-                "flip",
-                "gossip",
-                "hand",
-                "person",
-                "sarcasm",
-                "sarcastic",
-                "sassy",
-                "seriously",
-                "tipping",
-                "whatever"
-              ]
+              "keywords": ["fetch", "flick", "flip", "gossip", "hand", "person", "sarcasm", "sarcastic", "sassy", "seriously", "tipping", "whatever"]
             },
             {
               "codepoint": "U+1F481 U+200D U+2642 U+FE0F",
               "name": "man tipping hand",
-              "keywords": [
-                "fetch",
-                "flick",
-                "flip",
-                "gossip",
-                "hand",
-                "man",
-                "sarcasm",
-                "sarcastic",
-                "sassy",
-                "seriously",
-                "tipping",
-                "whatever"
-              ]
+              "keywords": ["fetch", "flick", "flip", "gossip", "hand", "man", "sarcasm", "sarcastic", "sassy", "seriously", "tipping", "whatever"]
             },
             {
               "codepoint": "U+1F481 U+200D U+2640 U+FE0F",
               "name": "woman tipping hand",
-              "keywords": [
-                "fetch",
-                "flick",
-                "flip",
-                "gossip",
-                "hand",
-                "sarcasm",
-                "sarcastic",
-                "sassy",
-                "seriously",
-                "tipping",
-                "whatever",
-                "woman"
-              ]
+              "keywords": ["fetch", "flick", "flip", "gossip", "hand", "sarcasm", "sarcastic", "sassy", "seriously", "tipping", "whatever", "woman"]
             },
             {
               "codepoint": "U+1F64B",
               "name": "person raising hand",
-              "keywords": [
-                "gesture",
-                "hand",
-                "here",
-                "know",
-                "me",
-                "person",
-                "pick",
-                "question",
-                "raise",
-                "raising"
-              ]
+              "keywords": ["gesture", "hand", "here", "know", "me", "person", "pick", "question", "raise", "raising"]
             },
             {
               "codepoint": "U+1F64B U+200D U+2642 U+FE0F",
               "name": "man raising hand",
-              "keywords": [
-                "gesture",
-                "hand",
-                "here",
-                "know",
-                "man",
-                "me",
-                "pick",
-                "question",
-                "raise",
-                "raising"
-              ]
+              "keywords": ["gesture", "hand", "here", "know", "man", "me", "pick", "question", "raise", "raising"]
             },
             {
               "codepoint": "U+1F64B U+200D U+2640 U+FE0F",
               "name": "woman raising hand",
-              "keywords": [
-                "gesture",
-                "hand",
-                "here",
-                "know",
-                "me",
-                "pick",
-                "question",
-                "raise",
-                "raising",
-                "woman"
-              ]
+              "keywords": ["gesture", "hand", "here", "know", "me", "pick", "question", "raise", "raising", "woman"]
             },
             {
               "codepoint": "U+1F9CF",
               "name": "deaf person",
-              "keywords": [
-                "accessibility",
-                "deaf",
-                "ear",
-                "gesture",
-                "hear",
-                "person"
-              ]
+              "keywords": ["accessibility", "deaf", "ear", "gesture", "hear", "person"]
             },
             {
               "codepoint": "U+1F9CF U+200D U+2642 U+FE0F",
               "name": "deaf man",
-              "keywords": [
-                "accessibility",
-                "deaf",
-                "ear",
-                "gesture",
-                "hear",
-                "man"
-              ]
+              "keywords": ["accessibility", "deaf", "ear", "gesture", "hear", "man"]
             },
             {
               "codepoint": "U+1F9CF U+200D U+2640 U+FE0F",
               "name": "deaf woman",
-              "keywords": [
-                "accessibility",
-                "deaf",
-                "ear",
-                "gesture",
-                "hear",
-                "woman"
-              ]
+              "keywords": ["accessibility", "deaf", "ear", "gesture", "hear", "woman"]
             },
             {
               "codepoint": "U+1F647",
               "name": "person bowing",
-              "keywords": [
-                "apology",
-                "ask",
-                "beg",
-                "bow",
-                "bowing",
-                "favor",
-                "forgive",
-                "gesture",
-                "meditate",
-                "meditation",
-                "person",
-                "pity",
-                "regret",
-                "sorry"
-              ]
+              "keywords": ["apology", "ask", "beg", "bow", "bowing", "favor", "forgive", "gesture", "meditate", "meditation", "person", "pity", "regret", "sorry"]
             },
             {
               "codepoint": "U+1F647 U+200D U+2642 U+FE0F",
               "name": "man bowing",
-              "keywords": [
-                "apology",
-                "ask",
-                "beg",
-                "bow",
-                "bowing",
-                "favor",
-                "forgive",
-                "gesture",
-                "man",
-                "meditate",
-                "meditation",
-                "pity",
-                "regret",
-                "sorry"
-              ]
+              "keywords": ["apology", "ask", "beg", "bow", "bowing", "favor", "forgive", "gesture", "man", "meditate", "meditation", "pity", "regret", "sorry"]
             },
             {
               "codepoint": "U+1F647 U+200D U+2640 U+FE0F",
               "name": "woman bowing",
-              "keywords": [
-                "apology",
-                "ask",
-                "beg",
-                "bow",
-                "bowing",
-                "favor",
-                "forgive",
-                "gesture",
-                "meditate",
-                "meditation",
-                "pity",
-                "regret",
-                "sorry",
-                "woman"
-              ]
+              "keywords": ["apology", "ask", "beg", "bow", "bowing", "favor", "forgive", "gesture", "meditate", "meditation", "pity", "regret", "sorry", "woman"]
             },
             {
               "codepoint": "U+1F926",
               "name": "person facepalming",
-              "keywords": [
-                "again",
-                "bewilder",
-                "disbelief",
-                "exasperation",
-                "facepalm",
-                "no",
-                "not",
-                "oh",
-                "omg",
-                "person",
-                "shock",
-                "smh"
-              ]
+              "keywords": ["again", "bewilder", "disbelief", "exasperation", "facepalm", "no", "not", "oh", "omg", "person", "shock", "smh"]
             },
             {
               "codepoint": "U+1F926 U+200D U+2642 U+FE0F",
               "name": "man facepalming",
-              "keywords": [
-                "again",
-                "bewilder",
-                "disbelief",
-                "exasperation",
-                "facepalm",
-                "man",
-                "no",
-                "not",
-                "oh",
-                "omg",
-                "shock",
-                "smh"
-              ]
+              "keywords": ["again", "bewilder", "disbelief", "exasperation", "facepalm", "man", "no", "not", "oh", "omg", "shock", "smh"]
             },
             {
               "codepoint": "U+1F926 U+200D U+2640 U+FE0F",
               "name": "woman facepalming",
-              "keywords": [
-                "again",
-                "bewilder",
-                "disbelief",
-                "exasperation",
-                "facepalm",
-                "no",
-                "not",
-                "oh",
-                "omg",
-                "shock",
-                "smh",
-                "woman"
-              ]
+              "keywords": ["again", "bewilder", "disbelief", "exasperation", "facepalm", "no", "not", "oh", "omg", "shock", "smh", "woman"]
             },
             {
               "codepoint": "U+1F937",
               "name": "person shrugging",
-              "keywords": [
-                "doubt",
-                "dunno",
-                "guess",
-                "idk",
-                "ignorance",
-                "indifference",
-                "knows",
-                "maybe",
-                "person",
-                "shrug",
-                "shrugging",
-                "whatever",
-                "who"
-              ]
+              "keywords": ["doubt", "dunno", "guess", "idk", "ignorance", "indifference", "knows", "maybe", "person", "shrug", "shrugging", "whatever", "who"]
             },
             {
               "codepoint": "U+1F937 U+200D U+2642 U+FE0F",
               "name": "man shrugging",
-              "keywords": [
-                "doubt",
-                "dunno",
-                "guess",
-                "idk",
-                "ignorance",
-                "indifference",
-                "knows",
-                "man",
-                "maybe",
-                "shrug",
-                "shrugging",
-                "whatever",
-                "who"
-              ]
+              "keywords": ["doubt", "dunno", "guess", "idk", "ignorance", "indifference", "knows", "man", "maybe", "shrug", "shrugging", "whatever", "who"]
             },
             {
               "codepoint": "U+1F937 U+200D U+2640 U+FE0F",
               "name": "woman shrugging",
-              "keywords": [
-                "doubt",
-                "dunno",
-                "guess",
-                "idk",
-                "ignorance",
-                "indifference",
-                "knows",
-                "maybe",
-                "shrug",
-                "shrugging",
-                "whatever",
-                "who",
-                "woman"
-              ]
+              "keywords": ["doubt", "dunno", "guess", "idk", "ignorance", "indifference", "knows", "maybe", "shrug", "shrugging", "whatever", "who", "woman"]
             }
           ]
         },
@@ -4067,40 +1586,17 @@
             {
               "codepoint": "U+1F9D1 U+200D U+2695 U+FE0F",
               "name": "health worker",
-              "keywords": [
-                "doctor",
-                "health",
-                "healthcare",
-                "nurse",
-                "therapist",
-                "worker"
-              ]
+              "keywords": ["doctor", "health", "healthcare", "nurse", "therapist", "worker"]
             },
             {
               "codepoint": "U+1F468 U+200D U+2695 U+FE0F",
               "name": "man health worker",
-              "keywords": [
-                "doctor",
-                "health",
-                "healthcare",
-                "man",
-                "nurse",
-                "therapist",
-                "worker"
-              ]
+              "keywords": ["doctor", "health", "healthcare", "man", "nurse", "therapist", "worker"]
             },
             {
               "codepoint": "U+1F469 U+200D U+2695 U+FE0F",
               "name": "woman health worker",
-              "keywords": [
-                "doctor",
-                "health",
-                "healthcare",
-                "nurse",
-                "therapist",
-                "woman",
-                "worker"
-              ]
+              "keywords": ["doctor", "health", "healthcare", "nurse", "therapist", "woman", "worker"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F393",
@@ -4125,24 +1621,12 @@
             {
               "codepoint": "U+1F468 U+200D U+1F3EB",
               "name": "man teacher",
-              "keywords": [
-                "instructor",
-                "lecturer",
-                "man",
-                "professor",
-                "teacher"
-              ]
+              "keywords": ["instructor", "lecturer", "man", "professor", "teacher"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F3EB",
               "name": "woman teacher",
-              "keywords": [
-                "instructor",
-                "lecturer",
-                "professor",
-                "teacher",
-                "woman"
-              ]
+              "keywords": ["instructor", "lecturer", "professor", "teacher", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+2696 U+FE0F",
@@ -4197,24 +1681,12 @@
             {
               "codepoint": "U+1F468 U+200D U+1F527",
               "name": "man mechanic",
-              "keywords": [
-                "electrician",
-                "man",
-                "mechanic",
-                "plumber",
-                "tradesperson"
-              ]
+              "keywords": ["electrician", "man", "mechanic", "plumber", "tradesperson"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F527",
               "name": "woman mechanic",
-              "keywords": [
-                "electrician",
-                "mechanic",
-                "plumber",
-                "tradesperson",
-                "woman"
-              ]
+              "keywords": ["electrician", "mechanic", "plumber", "tradesperson", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F3ED",
@@ -4229,165 +1701,67 @@
             {
               "codepoint": "U+1F469 U+200D U+1F3ED",
               "name": "woman factory worker",
-              "keywords": [
-                "assembly",
-                "factory",
-                "industrial",
-                "woman",
-                "worker"
-              ]
+              "keywords": ["assembly", "factory", "industrial", "woman", "worker"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F4BC",
               "name": "office worker",
-              "keywords": [
-                "architect",
-                "business",
-                "manager",
-                "office",
-                "white-collar",
-                "worker"
-              ]
+              "keywords": ["architect", "business", "manager", "office", "white-collar", "worker"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F4BC",
               "name": "man office worker",
-              "keywords": [
-                "architect",
-                "business",
-                "man",
-                "manager",
-                "office",
-                "white-collar",
-                "worker"
-              ]
+              "keywords": ["architect", "business", "man", "manager", "office", "white-collar", "worker"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F4BC",
               "name": "woman office worker",
-              "keywords": [
-                "architect",
-                "business",
-                "manager",
-                "office",
-                "white-collar",
-                "woman",
-                "worker"
-              ]
+              "keywords": ["architect", "business", "manager", "office", "white-collar", "woman", "worker"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F52C",
               "name": "scientist",
-              "keywords": [
-                "biologist",
-                "chemist",
-                "engineer",
-                "mathematician",
-                "physicist",
-                "scientist"
-              ]
+              "keywords": ["biologist", "chemist", "engineer", "mathematician", "physicist", "scientist"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F52C",
               "name": "man scientist",
-              "keywords": [
-                "biologist",
-                "chemist",
-                "engineer",
-                "man",
-                "mathematician",
-                "physicist",
-                "scientist"
-              ]
+              "keywords": ["biologist", "chemist", "engineer", "man", "mathematician", "physicist", "scientist"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F52C",
               "name": "woman scientist",
-              "keywords": [
-                "biologist",
-                "chemist",
-                "engineer",
-                "mathematician",
-                "physicist",
-                "scientist",
-                "woman"
-              ]
+              "keywords": ["biologist", "chemist", "engineer", "mathematician", "physicist", "scientist", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F4BB",
               "name": "technologist",
-              "keywords": [
-                "coder",
-                "computer",
-                "developer",
-                "inventor",
-                "software",
-                "technologist"
-              ]
+              "keywords": ["coder", "computer", "developer", "inventor", "software", "technologist"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F4BB",
               "name": "man technologist",
-              "keywords": [
-                "coder",
-                "computer",
-                "developer",
-                "inventor",
-                "man",
-                "software",
-                "technologist"
-              ]
+              "keywords": ["coder", "computer", "developer", "inventor", "man", "software", "technologist"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F4BB",
               "name": "woman technologist",
-              "keywords": [
-                "coder",
-                "computer",
-                "developer",
-                "inventor",
-                "software",
-                "technologist",
-                "woman"
-              ]
+              "keywords": ["coder", "computer", "developer", "inventor", "software", "technologist", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F3A4",
               "name": "singer",
-              "keywords": [
-                "actor",
-                "entertainer",
-                "rock",
-                "rockstar",
-                "singer",
-                "star"
-              ]
+              "keywords": ["actor", "entertainer", "rock", "rockstar", "singer", "star"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F3A4",
               "name": "man singer",
-              "keywords": [
-                "actor",
-                "entertainer",
-                "man",
-                "rock",
-                "rockstar",
-                "singer",
-                "star"
-              ]
+              "keywords": ["actor", "entertainer", "man", "rock", "rockstar", "singer", "star"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F3A4",
               "name": "woman singer",
-              "keywords": [
-                "actor",
-                "entertainer",
-                "rock",
-                "rockstar",
-                "singer",
-                "star",
-                "woman"
-              ]
+              "keywords": ["actor", "entertainer", "rock", "rockstar", "singer", "star", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F3A8",
@@ -4452,52 +1826,17 @@
             {
               "codepoint": "U+1F46E",
               "name": "police officer",
-              "keywords": [
-                "apprehend",
-                "arrest",
-                "citation",
-                "cop",
-                "law",
-                "officer",
-                "over",
-                "police",
-                "pulled",
-                "undercover"
-              ]
+              "keywords": ["apprehend", "arrest", "citation", "cop", "law", "officer", "over", "police", "pulled", "undercover"]
             },
             {
               "codepoint": "U+1F46E U+200D U+2642 U+FE0F",
               "name": "man police officer",
-              "keywords": [
-                "apprehend",
-                "arrest",
-                "citation",
-                "cop",
-                "law",
-                "man",
-                "officer",
-                "over",
-                "police",
-                "pulled",
-                "undercover"
-              ]
+              "keywords": ["apprehend", "arrest", "citation", "cop", "law", "man", "officer", "over", "police", "pulled", "undercover"]
             },
             {
               "codepoint": "U+1F46E U+200D U+2640 U+FE0F",
               "name": "woman police officer",
-              "keywords": [
-                "apprehend",
-                "arrest",
-                "citation",
-                "cop",
-                "law",
-                "officer",
-                "over",
-                "police",
-                "pulled",
-                "undercover",
-                "woman"
-              ]
+              "keywords": ["apprehend", "arrest", "citation", "cop", "law", "officer", "over", "police", "pulled", "undercover", "woman"]
             },
             {
               "codepoint": "U+1F575",
@@ -4522,140 +1861,47 @@
             {
               "codepoint": "U+1F482 U+200D U+2642 U+FE0F",
               "name": "man guard",
-              "keywords": [
-                "buckingham",
-                "guard",
-                "helmet",
-                "london",
-                "man",
-                "palace"
-              ]
+              "keywords": ["buckingham", "guard", "helmet", "london", "man", "palace"]
             },
             {
               "codepoint": "U+1F482 U+200D U+2640 U+FE0F",
               "name": "woman guard",
-              "keywords": [
-                "buckingham",
-                "guard",
-                "helmet",
-                "london",
-                "palace",
-                "woman"
-              ]
+              "keywords": ["buckingham", "guard", "helmet", "london", "palace", "woman"]
             },
             {
               "codepoint": "U+1F977",
               "name": "ninja",
-              "keywords": [
-                "assassin",
-                "fight",
-                "fighter",
-                "hidden",
-                "ninja",
-                "person",
-                "secret",
-                "skills",
-                "sly",
-                "soldier",
-                "stealth",
-                "war"
-              ]
+              "keywords": ["assassin", "fight", "fighter", "hidden", "ninja", "person", "secret", "skills", "sly", "soldier", "stealth", "war"]
             },
             {
               "codepoint": "U+1F477",
               "name": "construction worker",
-              "keywords": [
-                "build",
-                "construction",
-                "fix",
-                "hardhat",
-                "hat",
-                "man",
-                "person",
-                "rebuild",
-                "remodel",
-                "repair",
-                "work",
-                "worker"
-              ]
+              "keywords": ["build", "construction", "fix", "hardhat", "hat", "man", "person", "rebuild", "remodel", "repair", "work", "worker"]
             },
             {
               "codepoint": "U+1F477 U+200D U+2642 U+FE0F",
               "name": "man construction worker",
-              "keywords": [
-                "build",
-                "construction",
-                "fix",
-                "hardhat",
-                "hat",
-                "man",
-                "rebuild",
-                "remodel",
-                "repair",
-                "work",
-                "worker"
-              ]
+              "keywords": ["build", "construction", "fix", "hardhat", "hat", "man", "rebuild", "remodel", "repair", "work", "worker"]
             },
             {
               "codepoint": "U+1F477 U+200D U+2640 U+FE0F",
               "name": "woman construction worker",
-              "keywords": [
-                "build",
-                "construction",
-                "fix",
-                "hardhat",
-                "hat",
-                "man",
-                "rebuild",
-                "remodel",
-                "repair",
-                "woman",
-                "work",
-                "worker"
-              ]
+              "keywords": ["build", "construction", "fix", "hardhat", "hat", "man", "rebuild", "remodel", "repair", "woman", "work", "worker"]
             },
             {
               "codepoint": "U+1FAC5",
               "name": "person with crown",
-              "keywords": [
-                "crown",
-                "monarch",
-                "noble",
-                "person",
-                "regal",
-                "royal",
-                "royalty"
-              ]
+              "keywords": ["crown", "monarch", "noble", "person", "regal", "royal", "royalty"]
             },
             {
               "codepoint": "U+1F934",
               "name": "prince",
-              "keywords": [
-                "crown",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "king",
-                "prince",
-                "royal",
-                "royalty",
-                "tale"
-              ]
+              "keywords": ["crown", "fairy", "fairytale", "fantasy", "king", "prince", "royal", "royalty", "tale"]
             },
             {
               "codepoint": "U+1F478",
               "name": "princess",
-              "keywords": [
-                "crown",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "princess",
-                "queen",
-                "royal",
-                "royalty",
-                "tale"
-              ]
+              "keywords": ["crown", "fairy", "fairytale", "fantasy", "princess", "queen", "royal", "royalty", "tale"]
             },
             {
               "codepoint": "U+1F473",
@@ -4675,31 +1921,12 @@
             {
               "codepoint": "U+1F472",
               "name": "person with skullcap",
-              "keywords": [
-                "cap",
-                "Chinese",
-                "gua",
-                "guapi",
-                "hat",
-                "mao",
-                "person",
-                "pi",
-                "skullcap"
-              ]
+              "keywords": ["cap", "Chinese", "gua", "guapi", "hat", "mao", "person", "pi", "skullcap"]
             },
             {
               "codepoint": "U+1F9D5",
               "name": "woman with headscarf",
-              "keywords": [
-                "bandana",
-                "head",
-                "headscarf",
-                "hijab",
-                "kerchief",
-                "mantilla",
-                "tichel",
-                "woman"
-              ]
+              "keywords": ["bandana", "head", "headscarf", "hijab", "kerchief", "mantilla", "tichel", "woman"]
             },
             {
               "codepoint": "U+1F935",
@@ -4739,84 +1966,32 @@
             {
               "codepoint": "U+1FAC3",
               "name": "pregnant man",
-              "keywords": [
-                "belly",
-                "bloated",
-                "full",
-                "man",
-                "overeat",
-                "pregnant"
-              ]
+              "keywords": ["belly", "bloated", "full", "man", "overeat", "pregnant"]
             },
             {
               "codepoint": "U+1FAC4",
               "name": "pregnant person",
-              "keywords": [
-                "belly",
-                "bloated",
-                "full",
-                "overeat",
-                "person",
-                "pregnant",
-                "stuffed"
-              ]
+              "keywords": ["belly", "bloated", "full", "overeat", "person", "pregnant", "stuffed"]
             },
             {
               "codepoint": "U+1F931",
               "name": "breast-feeding",
-              "keywords": [
-                "baby",
-                "breast",
-                "breast-feeding",
-                "feeding",
-                "mom",
-                "mother",
-                "nursing",
-                "woman"
-              ]
+              "keywords": ["baby", "breast", "breast-feeding", "feeding", "mom", "mother", "nursing", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F37C",
               "name": "woman feeding baby",
-              "keywords": [
-                "baby",
-                "feed",
-                "feeding",
-                "mom",
-                "mother",
-                "nanny",
-                "newborn",
-                "nursing",
-                "woman"
-              ]
+              "keywords": ["baby", "feed", "feeding", "mom", "mother", "nanny", "newborn", "nursing", "woman"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F37C",
               "name": "man feeding baby",
-              "keywords": [
-                "baby",
-                "dad",
-                "father",
-                "feed",
-                "feeding",
-                "man",
-                "nanny",
-                "newborn",
-                "nursing"
-              ]
+              "keywords": ["baby", "dad", "father", "feed", "feeding", "man", "nanny", "newborn", "nursing"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F37C",
               "name": "person feeding baby",
-              "keywords": [
-                "baby",
-                "feed",
-                "feeding",
-                "nanny",
-                "newborn",
-                "nursing",
-                "parent"
-              ]
+              "keywords": ["baby", "feed", "feeding", "nanny", "newborn", "nursing", "parent"]
             }
           ]
         },
@@ -4826,68 +2001,22 @@
             {
               "codepoint": "U+1F47C",
               "name": "baby angel",
-              "keywords": [
-                "angel",
-                "baby",
-                "church",
-                "face",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "tale"
-              ]
+              "keywords": ["angel", "baby", "church", "face", "fairy", "fairytale", "fantasy", "tale"]
             },
             {
               "codepoint": "U+1F385",
               "name": "Santa Claus",
-              "keywords": [
-                "celebration",
-                "Christmas",
-                "claus",
-                "fairy",
-                "fantasy",
-                "father",
-                "holiday",
-                "merry",
-                "santa",
-                "tale",
-                "xmas"
-              ]
+              "keywords": ["celebration", "Christmas", "claus", "fairy", "fantasy", "father", "holiday", "merry", "santa", "tale", "xmas"]
             },
             {
               "codepoint": "U+1F936",
               "name": "Mrs. Claus",
-              "keywords": [
-                "celebration",
-                "Christmas",
-                "claus",
-                "fairy",
-                "fantasy",
-                "holiday",
-                "merry",
-                "mother",
-                "Mrs",
-                "santa",
-                "tale",
-                "xmas"
-              ]
+              "keywords": ["celebration", "Christmas", "claus", "fairy", "fantasy", "holiday", "merry", "mother", "Mrs", "santa", "tale", "xmas"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F384",
               "name": "Mx Claus",
-              "keywords": [
-                "celebration",
-                "Christmas",
-                "claus",
-                "fairy",
-                "fantasy",
-                "holiday",
-                "merry",
-                "Mx",
-                "santa",
-                "tale",
-                "xmas"
-              ]
+              "keywords": ["celebration", "Christmas", "claus", "fairy", "fantasy", "holiday", "merry", "Mx", "santa", "tale", "xmas"]
             },
             {
               "codepoint": "U+1F9B8",
@@ -4902,387 +2031,132 @@
             {
               "codepoint": "U+1F9B8 U+200D U+2640 U+FE0F",
               "name": "woman superhero",
-              "keywords": [
-                "good",
-                "hero",
-                "heroine",
-                "superhero",
-                "superpower",
-                "woman"
-              ]
+              "keywords": ["good", "hero", "heroine", "superhero", "superpower", "woman"]
             },
             {
               "codepoint": "U+1F9B9",
               "name": "supervillain",
-              "keywords": [
-                "bad",
-                "criminal",
-                "evil",
-                "superpower",
-                "supervillain",
-                "villain"
-              ]
+              "keywords": ["bad", "criminal", "evil", "superpower", "supervillain", "villain"]
             },
             {
               "codepoint": "U+1F9B9 U+200D U+2642 U+FE0F",
               "name": "man supervillain",
-              "keywords": [
-                "bad",
-                "criminal",
-                "evil",
-                "man",
-                "superpower",
-                "supervillain",
-                "villain"
-              ]
+              "keywords": ["bad", "criminal", "evil", "man", "superpower", "supervillain", "villain"]
             },
             {
               "codepoint": "U+1F9B9 U+200D U+2640 U+FE0F",
               "name": "woman supervillain",
-              "keywords": [
-                "bad",
-                "criminal",
-                "evil",
-                "superpower",
-                "supervillain",
-                "villain",
-                "woman"
-              ]
+              "keywords": ["bad", "criminal", "evil", "superpower", "supervillain", "villain", "woman"]
             },
             {
               "codepoint": "U+1F9D9",
               "name": "mage",
-              "keywords": [
-                "fantasy",
-                "mage",
-                "magic",
-                "play",
-                "sorcerer",
-                "sorceress",
-                "sorcery",
-                "spell",
-                "summon",
-                "witch",
-                "wizard"
-              ]
+              "keywords": ["fantasy", "mage", "magic", "play", "sorcerer", "sorceress", "sorcery", "spell", "summon", "witch", "wizard"]
             },
             {
               "codepoint": "U+1F9D9 U+200D U+2642 U+FE0F",
               "name": "man mage",
-              "keywords": [
-                "fantasy",
-                "mage",
-                "magic",
-                "man",
-                "play",
-                "sorcerer",
-                "sorceress",
-                "sorcery",
-                "spell",
-                "summon",
-                "witch",
-                "wizard"
-              ]
+              "keywords": ["fantasy", "mage", "magic", "man", "play", "sorcerer", "sorceress", "sorcery", "spell", "summon", "witch", "wizard"]
             },
             {
               "codepoint": "U+1F9D9 U+200D U+2640 U+FE0F",
               "name": "woman mage",
-              "keywords": [
-                "fantasy",
-                "mage",
-                "magic",
-                "play",
-                "sorcerer",
-                "sorceress",
-                "sorcery",
-                "spell",
-                "summon",
-                "witch",
-                "wizard",
-                "woman"
-              ]
+              "keywords": ["fantasy", "mage", "magic", "play", "sorcerer", "sorceress", "sorcery", "spell", "summon", "witch", "wizard", "woman"]
             },
             {
               "codepoint": "U+1F9DA",
               "name": "fairy",
-              "keywords": [
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "myth",
-                "person",
-                "pixie",
-                "tale",
-                "wings"
-              ]
+              "keywords": ["fairy", "fairytale", "fantasy", "myth", "person", "pixie", "tale", "wings"]
             },
             {
               "codepoint": "U+1F9DA U+200D U+2642 U+FE0F",
               "name": "man fairy",
-              "keywords": [
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "man",
-                "myth",
-                "Oberon",
-                "person",
-                "pixie",
-                "Puck",
-                "tale",
-                "wings"
-              ]
+              "keywords": ["fairy", "fairytale", "fantasy", "man", "myth", "Oberon", "person", "pixie", "Puck", "tale", "wings"]
             },
             {
               "codepoint": "U+1F9DA U+200D U+2640 U+FE0F",
               "name": "woman fairy",
-              "keywords": [
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "myth",
-                "person",
-                "pixie",
-                "tale",
-                "Titania",
-                "wings",
-                "woman"
-              ]
+              "keywords": ["fairy", "fairytale", "fantasy", "myth", "person", "pixie", "tale", "Titania", "wings", "woman"]
             },
             {
               "codepoint": "U+1F9DB",
               "name": "vampire",
-              "keywords": [
-                "blood",
-                "Dracula",
-                "fangs",
-                "halloween",
-                "scary",
-                "supernatural",
-                "teeth",
-                "undead",
-                "vampire"
-              ]
+              "keywords": ["blood", "Dracula", "fangs", "halloween", "scary", "supernatural", "teeth", "undead", "vampire"]
             },
             {
               "codepoint": "U+1F9DB U+200D U+2642 U+FE0F",
               "name": "man vampire",
-              "keywords": [
-                "blood",
-                "fangs",
-                "halloween",
-                "man",
-                "scary",
-                "supernatural",
-                "teeth",
-                "undead",
-                "vampire"
-              ]
+              "keywords": ["blood", "fangs", "halloween", "man", "scary", "supernatural", "teeth", "undead", "vampire"]
             },
             {
               "codepoint": "U+1F9DB U+200D U+2640 U+FE0F",
               "name": "woman vampire",
-              "keywords": [
-                "blood",
-                "fangs",
-                "halloween",
-                "scary",
-                "supernatural",
-                "teeth",
-                "undead",
-                "vampire",
-                "woman"
-              ]
+              "keywords": ["blood", "fangs", "halloween", "scary", "supernatural", "teeth", "undead", "vampire", "woman"]
             },
             {
               "codepoint": "U+1F9DC",
               "name": "merperson",
-              "keywords": [
-                "creature",
-                "fairytale",
-                "folklore",
-                "merperson",
-                "ocean",
-                "sea",
-                "siren",
-                "trident"
-              ]
+              "keywords": ["creature", "fairytale", "folklore", "merperson", "ocean", "sea", "siren", "trident"]
             },
             {
               "codepoint": "U+1F9DC U+200D U+2642 U+FE0F",
               "name": "merman",
-              "keywords": [
-                "creature",
-                "fairytale",
-                "folklore",
-                "merman",
-                "Neptune",
-                "ocean",
-                "Poseidon",
-                "sea",
-                "siren",
-                "trident",
-                "Triton"
-              ]
+              "keywords": ["creature", "fairytale", "folklore", "merman", "Neptune", "ocean", "Poseidon", "sea", "siren", "trident", "Triton"]
             },
             {
               "codepoint": "U+1F9DC U+200D U+2640 U+FE0F",
               "name": "mermaid",
-              "keywords": [
-                "creature",
-                "fairytale",
-                "folklore",
-                "mermaid",
-                "merwoman",
-                "ocean",
-                "sea",
-                "siren",
-                "trident"
-              ]
+              "keywords": ["creature", "fairytale", "folklore", "mermaid", "merwoman", "ocean", "sea", "siren", "trident"]
             },
             {
               "codepoint": "U+1F9DD",
               "name": "elf",
-              "keywords": [
-                "elf",
-                "elves",
-                "enchantment",
-                "fantasy",
-                "folklore",
-                "magic",
-                "magical",
-                "myth"
-              ]
+              "keywords": ["elf", "elves", "enchantment", "fantasy", "folklore", "magic", "magical", "myth"]
             },
             {
               "codepoint": "U+1F9DD U+200D U+2642 U+FE0F",
               "name": "man elf",
-              "keywords": [
-                "elf",
-                "elves",
-                "enchantment",
-                "fantasy",
-                "folklore",
-                "magic",
-                "magical",
-                "man",
-                "myth"
-              ]
+              "keywords": ["elf", "elves", "enchantment", "fantasy", "folklore", "magic", "magical", "man", "myth"]
             },
             {
               "codepoint": "U+1F9DD U+200D U+2640 U+FE0F",
               "name": "woman elf",
-              "keywords": [
-                "elf",
-                "elves",
-                "enchantment",
-                "fantasy",
-                "folklore",
-                "magic",
-                "magical",
-                "myth",
-                "woman"
-              ]
+              "keywords": ["elf", "elves", "enchantment", "fantasy", "folklore", "magic", "magical", "myth", "woman"]
             },
             {
               "codepoint": "U+1F9DE",
               "name": "genie",
-              "keywords": [
-                "djinn",
-                "fantasy",
-                "genie",
-                "jinn",
-                "lamp",
-                "myth",
-                "rub",
-                "wishes"
-              ]
+              "keywords": ["djinn", "fantasy", "genie", "jinn", "lamp", "myth", "rub", "wishes"]
             },
             {
               "codepoint": "U+1F9DE U+200D U+2642 U+FE0F",
               "name": "man genie",
-              "keywords": [
-                "djinn",
-                "fantasy",
-                "genie",
-                "jinn",
-                "lamp",
-                "man",
-                "myth",
-                "rub",
-                "wishes"
-              ]
+              "keywords": ["djinn", "fantasy", "genie", "jinn", "lamp", "man", "myth", "rub", "wishes"]
             },
             {
               "codepoint": "U+1F9DE U+200D U+2640 U+FE0F",
               "name": "woman genie",
-              "keywords": [
-                "djinn",
-                "fantasy",
-                "genie",
-                "jinn",
-                "lamp",
-                "myth",
-                "rub",
-                "wishes",
-                "woman"
-              ]
+              "keywords": ["djinn", "fantasy", "genie", "jinn", "lamp", "myth", "rub", "wishes", "woman"]
             },
             {
               "codepoint": "U+1F9DF",
               "name": "zombie",
-              "keywords": [
-                "apocalypse",
-                "dead",
-                "halloween",
-                "horror",
-                "scary",
-                "undead",
-                "walking",
-                "zombie"
-              ]
+              "keywords": ["apocalypse", "dead", "halloween", "horror", "scary", "undead", "walking", "zombie"]
             },
             {
               "codepoint": "U+1F9DF U+200D U+2642 U+FE0F",
               "name": "man zombie",
-              "keywords": [
-                "apocalypse",
-                "dead",
-                "halloween",
-                "horror",
-                "man",
-                "scary",
-                "undead",
-                "walking",
-                "zombie"
-              ]
+              "keywords": ["apocalypse", "dead", "halloween", "horror", "man", "scary", "undead", "walking", "zombie"]
             },
             {
               "codepoint": "U+1F9DF U+200D U+2640 U+FE0F",
               "name": "woman zombie",
-              "keywords": [
-                "apocalypse",
-                "dead",
-                "halloween",
-                "horror",
-                "scary",
-                "undead",
-                "walking",
-                "woman",
-                "zombie"
-              ]
+              "keywords": ["apocalypse", "dead", "halloween", "horror", "scary", "undead", "walking", "woman", "zombie"]
             },
             {
               "codepoint": "U+1F9CC",
               "name": "troll",
-              "keywords": [
-                "fairy",
-                "fantasy",
-                "monster",
-                "tale",
-                "troll",
-                "trolling"
-              ]
+              "keywords": ["fairy", "fantasy", "monster", "tale", "troll", "trolling"]
             }
           ]
         },
@@ -5292,221 +2166,62 @@
             {
               "codepoint": "U+1F486",
               "name": "person getting massage",
-              "keywords": [
-                "face",
-                "getting",
-                "headache",
-                "massage",
-                "person",
-                "relax",
-                "relaxing",
-                "salon",
-                "soothe",
-                "spa",
-                "tension",
-                "therapy",
-                "treatment"
-              ]
+              "keywords": ["face", "getting", "headache", "massage", "person", "relax", "relaxing", "salon", "soothe", "spa", "tension", "therapy", "treatment"]
             },
             {
               "codepoint": "U+1F486 U+200D U+2642 U+FE0F",
               "name": "man getting massage",
-              "keywords": [
-                "face",
-                "getting",
-                "headache",
-                "man",
-                "massage",
-                "relax",
-                "relaxing",
-                "salon",
-                "soothe",
-                "spa",
-                "tension",
-                "therapy",
-                "treatment"
-              ]
+              "keywords": ["face", "getting", "headache", "man", "massage", "relax", "relaxing", "salon", "soothe", "spa", "tension", "therapy", "treatment"]
             },
             {
               "codepoint": "U+1F486 U+200D U+2640 U+FE0F",
               "name": "woman getting massage",
-              "keywords": [
-                "face",
-                "getting",
-                "headache",
-                "massage",
-                "relax",
-                "relaxing",
-                "salon",
-                "soothe",
-                "spa",
-                "tension",
-                "therapy",
-                "treatment",
-                "woman"
-              ]
+              "keywords": ["face", "getting", "headache", "massage", "relax", "relaxing", "salon", "soothe", "spa", "tension", "therapy", "treatment", "woman"]
             },
             {
               "codepoint": "U+1F487",
               "name": "person getting haircut",
-              "keywords": [
-                "barber",
-                "beauty",
-                "chop",
-                "cosmetology",
-                "cut",
-                "groom",
-                "hair",
-                "haircut",
-                "parlor",
-                "person",
-                "shears",
-                "style"
-              ]
+              "keywords": ["barber", "beauty", "chop", "cosmetology", "cut", "groom", "hair", "haircut", "parlor", "person", "shears", "style"]
             },
             {
               "codepoint": "U+1F487 U+200D U+2642 U+FE0F",
               "name": "man getting haircut",
-              "keywords": [
-                "barber",
-                "beauty",
-                "chop",
-                "cosmetology",
-                "cut",
-                "groom",
-                "hair",
-                "haircut",
-                "man",
-                "parlor",
-                "person",
-                "shears",
-                "style"
-              ]
+              "keywords": ["barber", "beauty", "chop", "cosmetology", "cut", "groom", "hair", "haircut", "man", "parlor", "person", "shears", "style"]
             },
             {
               "codepoint": "U+1F487 U+200D U+2640 U+FE0F",
               "name": "woman getting haircut",
-              "keywords": [
-                "barber",
-                "beauty",
-                "chop",
-                "cosmetology",
-                "cut",
-                "groom",
-                "hair",
-                "haircut",
-                "parlor",
-                "person",
-                "shears",
-                "style",
-                "woman"
-              ]
+              "keywords": ["barber", "beauty", "chop", "cosmetology", "cut", "groom", "hair", "haircut", "parlor", "person", "shears", "style", "woman"]
             },
             {
               "codepoint": "U+1F6B6",
               "name": "person walking",
-              "keywords": [
-                "amble",
-                "gait",
-                "hike",
-                "man",
-                "pace",
-                "pedestrian",
-                "person",
-                "stride",
-                "stroll",
-                "walk",
-                "walking"
-              ]
+              "keywords": ["amble", "gait", "hike", "man", "pace", "pedestrian", "person", "stride", "stroll", "walk", "walking"]
             },
             {
               "codepoint": "U+1F6B6 U+200D U+2642 U+FE0F",
               "name": "man walking",
-              "keywords": [
-                "amble",
-                "gait",
-                "hike",
-                "man",
-                "pace",
-                "pedestrian",
-                "stride",
-                "stroll",
-                "walk",
-                "walking"
-              ]
+              "keywords": ["amble", "gait", "hike", "man", "pace", "pedestrian", "stride", "stroll", "walk", "walking"]
             },
             {
               "codepoint": "U+1F6B6 U+200D U+2640 U+FE0F",
               "name": "woman walking",
-              "keywords": [
-                "amble",
-                "gait",
-                "hike",
-                "man",
-                "pace",
-                "pedestrian",
-                "stride",
-                "stroll",
-                "walk",
-                "walking",
-                "woman"
-              ]
+              "keywords": ["amble", "gait", "hike", "man", "pace", "pedestrian", "stride", "stroll", "walk", "walking", "woman"]
             },
             {
               "codepoint": "U+1F6B6 U+200D U+27A1 U+FE0F",
               "name": "person walking: facing right",
-              "keywords": [
-                "amble",
-                "facing",
-                "gait",
-                "hike",
-                "man",
-                "pace",
-                "pedestrian",
-                "person",
-                "right",
-                "stride",
-                "stroll",
-                "walk",
-                "walking"
-              ]
+              "keywords": ["amble", "facing", "gait", "hike", "man", "pace", "pedestrian", "person", "right", "stride", "stroll", "walk", "walking"]
             },
             {
               "codepoint": "U+1F6B6 U+200D U+2640 U+FE0F U+200D U+27A1 U+FE0F",
               "name": "woman walking: facing right",
-              "keywords": [
-                "amble",
-                "facing",
-                "gait",
-                "hike",
-                "man",
-                "pace",
-                "pedestrian",
-                "right",
-                "stride",
-                "stroll",
-                "walk",
-                "walking",
-                "woman"
-              ]
+              "keywords": ["amble", "facing", "gait", "hike", "man", "pace", "pedestrian", "right", "stride", "stroll", "walk", "walking", "woman"]
             },
             {
               "codepoint": "U+1F6B6 U+200D U+2642 U+FE0F U+200D U+27A1 U+FE0F",
               "name": "man walking: facing right",
-              "keywords": [
-                "amble",
-                "facing",
-                "gait",
-                "hike",
-                "man",
-                "pace",
-                "pedestrian",
-                "right",
-                "stride",
-                "stroll",
-                "walk",
-                "walking"
-              ]
+              "keywords": ["amble", "facing", "gait", "hike", "man", "pace", "pedestrian", "right", "stride", "stroll", "walk", "walking"]
             },
             {
               "codepoint": "U+1F9CD",
@@ -5541,116 +2256,47 @@
             {
               "codepoint": "U+1F9CE U+200D U+27A1 U+FE0F",
               "name": "person kneeling: facing right",
-              "keywords": [
-                "facing",
-                "kneel",
-                "kneeling",
-                "knees",
-                "person",
-                "right"
-              ]
+              "keywords": ["facing", "kneel", "kneeling", "knees", "person", "right"]
             },
             {
               "codepoint": "U+1F9CE U+200D U+2640 U+FE0F U+200D U+27A1 U+FE0F",
               "name": "woman kneeling: facing right",
-              "keywords": [
-                "facing",
-                "kneel",
-                "kneeling",
-                "knees",
-                "right",
-                "woman"
-              ]
+              "keywords": ["facing", "kneel", "kneeling", "knees", "right", "woman"]
             },
             {
               "codepoint": "U+1F9CE U+200D U+2642 U+FE0F U+200D U+27A1 U+FE0F",
               "name": "man kneeling: facing right",
-              "keywords": [
-                "facing",
-                "kneel",
-                "kneeling",
-                "knees",
-                "man",
-                "right"
-              ]
+              "keywords": ["facing", "kneel", "kneeling", "knees", "man", "right"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9AF",
               "name": "person with white cane",
-              "keywords": [
-                "accessibility",
-                "blind",
-                "cane",
-                "person",
-                "probing",
-                "white"
-              ]
+              "keywords": ["accessibility", "blind", "cane", "person", "probing", "white"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9AF U+200D U+27A1 U+FE0F",
               "name": "person with white cane: facing right",
-              "keywords": [
-                "accessibility",
-                "blind",
-                "cane",
-                "facing",
-                "person",
-                "probing",
-                "right",
-                "white"
-              ]
+              "keywords": ["accessibility", "blind", "cane", "facing", "person", "probing", "right", "white"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9AF",
               "name": "man with white cane",
-              "keywords": [
-                "accessibility",
-                "blind",
-                "cane",
-                "man",
-                "probing",
-                "white"
-              ]
+              "keywords": ["accessibility", "blind", "cane", "man", "probing", "white"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9AF U+200D U+27A1 U+FE0F",
               "name": "man with white cane: facing right",
-              "keywords": [
-                "accessibility",
-                "blind",
-                "cane",
-                "facing",
-                "man",
-                "probing",
-                "right",
-                "white"
-              ]
+              "keywords": ["accessibility", "blind", "cane", "facing", "man", "probing", "right", "white"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9AF",
               "name": "woman with white cane",
-              "keywords": [
-                "accessibility",
-                "blind",
-                "cane",
-                "probing",
-                "white",
-                "woman"
-              ]
+              "keywords": ["accessibility", "blind", "cane", "probing", "white", "woman"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9AF U+200D U+27A1 U+FE0F",
               "name": "woman with white cane: facing right",
-              "keywords": [
-                "accessibility",
-                "blind",
-                "cane",
-                "facing",
-                "probing",
-                "right",
-                "white",
-                "woman"
-              ]
+              "keywords": ["accessibility", "blind", "cane", "facing", "probing", "right", "white", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9BC",
@@ -5660,14 +2306,7 @@
             {
               "codepoint": "U+1F9D1 U+200D U+1F9BC U+200D U+27A1 U+FE0F",
               "name": "person in motorized wheelchair: facing right",
-              "keywords": [
-                "accessibility",
-                "facing",
-                "motorized",
-                "person",
-                "right",
-                "wheelchair"
-              ]
+              "keywords": ["accessibility", "facing", "motorized", "person", "right", "wheelchair"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9BC",
@@ -5677,14 +2316,7 @@
             {
               "codepoint": "U+1F468 U+200D U+1F9BC U+200D U+27A1 U+FE0F",
               "name": "man in motorized wheelchair: facing right",
-              "keywords": [
-                "accessibility",
-                "facing",
-                "man",
-                "motorized",
-                "right",
-                "wheelchair"
-              ]
+              "keywords": ["accessibility", "facing", "man", "motorized", "right", "wheelchair"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9BC",
@@ -5694,14 +2326,7 @@
             {
               "codepoint": "U+1F469 U+200D U+1F9BC U+200D U+27A1 U+FE0F",
               "name": "woman in motorized wheelchair: facing right",
-              "keywords": [
-                "accessibility",
-                "facing",
-                "motorized",
-                "right",
-                "wheelchair",
-                "woman"
-              ]
+              "keywords": ["accessibility", "facing", "motorized", "right", "wheelchair", "woman"]
             },
             {
               "codepoint": "U+1F9D1 U+200D U+1F9BD",
@@ -5711,14 +2336,7 @@
             {
               "codepoint": "U+1F9D1 U+200D U+1F9BD U+200D U+27A1 U+FE0F",
               "name": "person in manual wheelchair: facing right",
-              "keywords": [
-                "accessibility",
-                "facing",
-                "manual",
-                "person",
-                "right",
-                "wheelchair"
-              ]
+              "keywords": ["accessibility", "facing", "manual", "person", "right", "wheelchair"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F9BD",
@@ -5728,14 +2346,7 @@
             {
               "codepoint": "U+1F468 U+200D U+1F9BD U+200D U+27A1 U+FE0F",
               "name": "man in manual wheelchair: facing right",
-              "keywords": [
-                "accessibility",
-                "facing",
-                "man",
-                "manual",
-                "right",
-                "wheelchair"
-              ]
+              "keywords": ["accessibility", "facing", "man", "manual", "right", "wheelchair"]
             },
             {
               "codepoint": "U+1F469 U+200D U+1F9BD",
@@ -5745,158 +2356,47 @@
             {
               "codepoint": "U+1F469 U+200D U+1F9BD U+200D U+27A1 U+FE0F",
               "name": "woman in manual wheelchair: facing right",
-              "keywords": [
-                "accessibility",
-                "facing",
-                "manual",
-                "right",
-                "wheelchair",
-                "woman"
-              ]
+              "keywords": ["accessibility", "facing", "manual", "right", "wheelchair", "woman"]
             },
             {
               "codepoint": "U+1F3C3",
               "name": "person running",
-              "keywords": [
-                "fast",
-                "hurry",
-                "marathon",
-                "move",
-                "person",
-                "quick",
-                "race",
-                "racing",
-                "run",
-                "rush",
-                "speed"
-              ]
+              "keywords": ["fast", "hurry", "marathon", "move", "person", "quick", "race", "racing", "run", "rush", "speed"]
             },
             {
               "codepoint": "U+1F3C3 U+200D U+2642 U+FE0F",
               "name": "man running",
-              "keywords": [
-                "fast",
-                "hurry",
-                "man",
-                "marathon",
-                "move",
-                "quick",
-                "race",
-                "racing",
-                "run",
-                "rush",
-                "speed"
-              ]
+              "keywords": ["fast", "hurry", "man", "marathon", "move", "quick", "race", "racing", "run", "rush", "speed"]
             },
             {
               "codepoint": "U+1F3C3 U+200D U+2640 U+FE0F",
               "name": "woman running",
-              "keywords": [
-                "fast",
-                "hurry",
-                "marathon",
-                "move",
-                "quick",
-                "race",
-                "racing",
-                "run",
-                "rush",
-                "speed",
-                "woman"
-              ]
+              "keywords": ["fast", "hurry", "marathon", "move", "quick", "race", "racing", "run", "rush", "speed", "woman"]
             },
             {
               "codepoint": "U+1F3C3 U+200D U+27A1 U+FE0F",
               "name": "person running: facing right",
-              "keywords": [
-                "facing",
-                "fast",
-                "hurry",
-                "marathon",
-                "move",
-                "person",
-                "quick",
-                "race",
-                "racing",
-                "right",
-                "run",
-                "rush",
-                "speed"
-              ]
+              "keywords": ["facing", "fast", "hurry", "marathon", "move", "person", "quick", "race", "racing", "right", "run", "rush", "speed"]
             },
             {
               "codepoint": "U+1F3C3 U+200D U+2640 U+FE0F U+200D U+27A1 U+FE0F",
               "name": "woman running: facing right",
-              "keywords": [
-                "facing",
-                "fast",
-                "hurry",
-                "marathon",
-                "move",
-                "quick",
-                "race",
-                "racing",
-                "right",
-                "run",
-                "rush",
-                "speed",
-                "woman"
-              ]
+              "keywords": ["facing", "fast", "hurry", "marathon", "move", "quick", "race", "racing", "right", "run", "rush", "speed", "woman"]
             },
             {
               "codepoint": "U+1F3C3 U+200D U+2642 U+FE0F U+200D U+27A1 U+FE0F",
               "name": "man running: facing right",
-              "keywords": [
-                "facing",
-                "fast",
-                "hurry",
-                "man",
-                "marathon",
-                "move",
-                "quick",
-                "race",
-                "racing",
-                "right",
-                "run",
-                "rush",
-                "speed"
-              ]
+              "keywords": ["facing", "fast", "hurry", "man", "marathon", "move", "quick", "race", "racing", "right", "run", "rush", "speed"]
             },
             {
               "codepoint": "U+1F483",
               "name": "woman dancing",
-              "keywords": [
-                "dance",
-                "dancer",
-                "dancing",
-                "elegant",
-                "festive",
-                "flair",
-                "flamenco",
-                "groove",
-                "let’s",
-                "salsa",
-                "tango",
-                "woman"
-              ]
+              "keywords": ["dance", "dancer", "dancing", "elegant", "festive", "flair", "flamenco", "groove", "let’s", "salsa", "tango", "woman"]
             },
             {
               "codepoint": "U+1F57A",
               "name": "man dancing",
-              "keywords": [
-                "dance",
-                "dancer",
-                "dancing",
-                "elegant",
-                "festive",
-                "flair",
-                "flamenco",
-                "groove",
-                "let’s",
-                "man",
-                "salsa",
-                "tango"
-              ]
+              "keywords": ["dance", "dancer", "dancing", "elegant", "festive", "flair", "flamenco", "groove", "let’s", "man", "salsa", "tango"]
             },
             {
               "codepoint": "U+1F574",
@@ -5906,160 +2406,47 @@
             {
               "codepoint": "U+1F46F",
               "name": "people with bunny ears",
-              "keywords": [
-                "bestie",
-                "bff",
-                "bunny",
-                "counterpart",
-                "dancer",
-                "double",
-                "ear",
-                "identical",
-                "pair",
-                "party",
-                "partying",
-                "people",
-                "soulmate",
-                "twin",
-                "twinsies"
-              ]
+              "keywords": ["bestie", "bff", "bunny", "counterpart", "dancer", "double", "ear", "identical", "pair", "party", "partying", "people", "soulmate", "twin", "twinsies"]
             },
             {
               "codepoint": "U+1F46F U+200D U+2642 U+FE0F",
               "name": "men with bunny ears",
-              "keywords": [
-                "bestie",
-                "bff",
-                "bunny",
-                "counterpart",
-                "dancer",
-                "double",
-                "ear",
-                "identical",
-                "men",
-                "pair",
-                "party",
-                "partying",
-                "people",
-                "soulmate",
-                "twin",
-                "twinsies"
-              ]
+              "keywords": ["bestie", "bff", "bunny", "counterpart", "dancer", "double", "ear", "identical", "men", "pair", "party", "partying", "people", "soulmate", "twin", "twinsies"]
             },
             {
               "codepoint": "U+1F46F U+200D U+2640 U+FE0F",
               "name": "women with bunny ears",
-              "keywords": [
-                "bestie",
-                "bff",
-                "bunny",
-                "counterpart",
-                "dancer",
-                "double",
-                "ear",
-                "identical",
-                "pair",
-                "party",
-                "partying",
-                "people",
-                "soulmate",
-                "twin",
-                "twinsies",
-                "women"
-              ]
+              "keywords": ["bestie", "bff", "bunny", "counterpart", "dancer", "double", "ear", "identical", "pair", "party", "partying", "people", "soulmate", "twin", "twinsies", "women"]
             },
             {
               "codepoint": "U+1F9D6",
               "name": "person in steamy room",
-              "keywords": [
-                "day",
-                "luxurious",
-                "pamper",
-                "person",
-                "relax",
-                "room",
-                "sauna",
-                "spa",
-                "steam",
-                "steambath",
-                "unwind"
-              ]
+              "keywords": ["day", "luxurious", "pamper", "person", "relax", "room", "sauna", "spa", "steam", "steambath", "unwind"]
             },
             {
               "codepoint": "U+1F9D6 U+200D U+2642 U+FE0F",
               "name": "man in steamy room",
-              "keywords": [
-                "day",
-                "luxurious",
-                "man",
-                "pamper",
-                "relax",
-                "room",
-                "sauna",
-                "spa",
-                "steam",
-                "steambath",
-                "unwind"
-              ]
+              "keywords": ["day", "luxurious", "man", "pamper", "relax", "room", "sauna", "spa", "steam", "steambath", "unwind"]
             },
             {
               "codepoint": "U+1F9D6 U+200D U+2640 U+FE0F",
               "name": "woman in steamy room",
-              "keywords": [
-                "day",
-                "luxurious",
-                "pamper",
-                "relax",
-                "room",
-                "sauna",
-                "spa",
-                "steam",
-                "steambath",
-                "unwind",
-                "woman"
-              ]
+              "keywords": ["day", "luxurious", "pamper", "relax", "room", "sauna", "spa", "steam", "steambath", "unwind", "woman"]
             },
             {
               "codepoint": "U+1F9D7",
               "name": "person climbing",
-              "keywords": [
-                "climb",
-                "climber",
-                "climbing",
-                "mountain",
-                "person",
-                "rock",
-                "scale",
-                "up"
-              ]
+              "keywords": ["climb", "climber", "climbing", "mountain", "person", "rock", "scale", "up"]
             },
             {
               "codepoint": "U+1F9D7 U+200D U+2642 U+FE0F",
               "name": "man climbing",
-              "keywords": [
-                "climb",
-                "climber",
-                "climbing",
-                "man",
-                "mountain",
-                "rock",
-                "scale",
-                "up"
-              ]
+              "keywords": ["climb", "climber", "climbing", "man", "mountain", "rock", "scale", "up"]
             },
             {
               "codepoint": "U+1F9D7 U+200D U+2640 U+FE0F",
               "name": "woman climbing",
-              "keywords": [
-                "climb",
-                "climber",
-                "climbing",
-                "mountain",
-                "rock",
-                "scale",
-                "up",
-                "woman"
-              ]
+              "keywords": ["climb", "climber", "climbing", "mountain", "rock", "scale", "up", "woman"]
             }
           ]
         },
@@ -6074,14 +2461,7 @@
             {
               "codepoint": "U+1F3C7",
               "name": "horse racing",
-              "keywords": [
-                "horse",
-                "jockey",
-                "racehorse",
-                "racing",
-                "riding",
-                "sport"
-              ]
+              "keywords": ["horse", "jockey", "racehorse", "racing", "riding", "sport"]
             },
             {
               "codepoint": "U+26F7",
@@ -6096,620 +2476,197 @@
             {
               "codepoint": "U+1F3CC",
               "name": "person golfing",
-              "keywords": [
-                "ball",
-                "birdie",
-                "caddy",
-                "driving",
-                "golf",
-                "golfing",
-                "green",
-                "person",
-                "pga",
-                "putt",
-                "range",
-                "tee"
-              ]
+              "keywords": ["ball", "birdie", "caddy", "driving", "golf", "golfing", "green", "person", "pga", "putt", "range", "tee"]
             },
             {
               "codepoint": "U+1F3CC U+FE0F U+200D U+2642 U+FE0F",
               "name": "man golfing",
-              "keywords": [
-                "ball",
-                "birdie",
-                "caddy",
-                "driving",
-                "golf",
-                "golfing",
-                "green",
-                "man",
-                "pga",
-                "putt",
-                "range",
-                "tee"
-              ]
+              "keywords": ["ball", "birdie", "caddy", "driving", "golf", "golfing", "green", "man", "pga", "putt", "range", "tee"]
             },
             {
               "codepoint": "U+1F3CC U+FE0F U+200D U+2640 U+FE0F",
               "name": "woman golfing",
-              "keywords": [
-                "ball",
-                "birdie",
-                "caddy",
-                "driving",
-                "golf",
-                "golfing",
-                "green",
-                "pga",
-                "putt",
-                "range",
-                "tee",
-                "woman"
-              ]
+              "keywords": ["ball", "birdie", "caddy", "driving", "golf", "golfing", "green", "pga", "putt", "range", "tee", "woman"]
             },
             {
               "codepoint": "U+1F3C4",
               "name": "person surfing",
-              "keywords": [
-                "beach",
-                "ocean",
-                "person",
-                "sport",
-                "surf",
-                "surfer",
-                "surfing",
-                "swell",
-                "waves"
-              ]
+              "keywords": ["beach", "ocean", "person", "sport", "surf", "surfer", "surfing", "swell", "waves"]
             },
             {
               "codepoint": "U+1F3C4 U+200D U+2642 U+FE0F",
               "name": "man surfing",
-              "keywords": [
-                "beach",
-                "man",
-                "ocean",
-                "sport",
-                "surf",
-                "surfer",
-                "surfing",
-                "swell",
-                "waves"
-              ]
+              "keywords": ["beach", "man", "ocean", "sport", "surf", "surfer", "surfing", "swell", "waves"]
             },
             {
               "codepoint": "U+1F3C4 U+200D U+2640 U+FE0F",
               "name": "woman surfing",
-              "keywords": [
-                "beach",
-                "ocean",
-                "person",
-                "sport",
-                "surf",
-                "surfer",
-                "surfing",
-                "swell",
-                "waves"
-              ]
+              "keywords": ["beach", "ocean", "person", "sport", "surf", "surfer", "surfing", "swell", "waves"]
             },
             {
               "codepoint": "U+1F6A3",
               "name": "person rowing boat",
-              "keywords": [
-                "boat",
-                "canoe",
-                "cruise",
-                "fishing",
-                "lake",
-                "oar",
-                "paddle",
-                "person",
-                "raft",
-                "river",
-                "row",
-                "rowboat",
-                "rowing"
-              ]
+              "keywords": ["boat", "canoe", "cruise", "fishing", "lake", "oar", "paddle", "person", "raft", "river", "row", "rowboat", "rowing"]
             },
             {
               "codepoint": "U+1F6A3 U+200D U+2642 U+FE0F",
               "name": "man rowing boat",
-              "keywords": [
-                "boat",
-                "canoe",
-                "cruise",
-                "fishing",
-                "lake",
-                "man",
-                "oar",
-                "paddle",
-                "raft",
-                "river",
-                "row",
-                "rowboat",
-                "rowing"
-              ]
+              "keywords": ["boat", "canoe", "cruise", "fishing", "lake", "man", "oar", "paddle", "raft", "river", "row", "rowboat", "rowing"]
             },
             {
               "codepoint": "U+1F6A3 U+200D U+2640 U+FE0F",
               "name": "woman rowing boat",
-              "keywords": [
-                "boat",
-                "canoe",
-                "cruise",
-                "fishing",
-                "lake",
-                "oar",
-                "paddle",
-                "raft",
-                "river",
-                "row",
-                "rowboat",
-                "rowing",
-                "woman"
-              ]
+              "keywords": ["boat", "canoe", "cruise", "fishing", "lake", "oar", "paddle", "raft", "river", "row", "rowboat", "rowing", "woman"]
             },
             {
               "codepoint": "U+1F3CA",
               "name": "person swimming",
-              "keywords": [
-                "freestyle",
-                "person",
-                "sport",
-                "swim",
-                "swimmer",
-                "swimming",
-                "triathlon"
-              ]
+              "keywords": ["freestyle", "person", "sport", "swim", "swimmer", "swimming", "triathlon"]
             },
             {
               "codepoint": "U+1F3CA U+200D U+2642 U+FE0F",
               "name": "man swimming",
-              "keywords": [
-                "freestyle",
-                "man",
-                "sport",
-                "swim",
-                "swimmer",
-                "swimming",
-                "triathlon"
-              ]
+              "keywords": ["freestyle", "man", "sport", "swim", "swimmer", "swimming", "triathlon"]
             },
             {
               "codepoint": "U+1F3CA U+200D U+2640 U+FE0F",
               "name": "woman swimming",
-              "keywords": [
-                "freestyle",
-                "man",
-                "sport",
-                "swim",
-                "swimmer",
-                "swimming",
-                "triathlon"
-              ]
+              "keywords": ["freestyle", "man", "sport", "swim", "swimmer", "swimming", "triathlon"]
             },
             {
               "codepoint": "U+26F9",
               "name": "person bouncing ball",
-              "keywords": [
-                "athletic",
-                "ball",
-                "basketball",
-                "bouncing",
-                "championship",
-                "dribble",
-                "net",
-                "person",
-                "player",
-                "throw"
-              ]
+              "keywords": ["athletic", "ball", "basketball", "bouncing", "championship", "dribble", "net", "person", "player", "throw"]
             },
             {
               "codepoint": "U+26F9 U+FE0F U+200D U+2642 U+FE0F",
               "name": "man bouncing ball",
-              "keywords": [
-                "athletic",
-                "ball",
-                "basketball",
-                "bouncing",
-                "championship",
-                "dribble",
-                "man",
-                "net",
-                "player",
-                "throw"
-              ]
+              "keywords": ["athletic", "ball", "basketball", "bouncing", "championship", "dribble", "man", "net", "player", "throw"]
             },
             {
               "codepoint": "U+26F9 U+FE0F U+200D U+2640 U+FE0F",
               "name": "woman bouncing ball",
-              "keywords": [
-                "athletic",
-                "ball",
-                "basketball",
-                "bouncing",
-                "championship",
-                "dribble",
-                "net",
-                "player",
-                "throw",
-                "woman"
-              ]
+              "keywords": ["athletic", "ball", "basketball", "bouncing", "championship", "dribble", "net", "player", "throw", "woman"]
             },
             {
               "codepoint": "U+1F3CB",
               "name": "person lifting weights",
-              "keywords": [
-                "barbell",
-                "bodybuilder",
-                "deadlift",
-                "lifter",
-                "lifting",
-                "person",
-                "powerlifting",
-                "weight",
-                "weightlifter",
-                "weights",
-                "workout"
-              ]
+              "keywords": ["barbell", "bodybuilder", "deadlift", "lifter", "lifting", "person", "powerlifting", "weight", "weightlifter", "weights", "workout"]
             },
             {
               "codepoint": "U+1F3CB U+FE0F U+200D U+2642 U+FE0F",
               "name": "man lifting weights",
-              "keywords": [
-                "barbell",
-                "bodybuilder",
-                "deadlift",
-                "lifter",
-                "lifting",
-                "man",
-                "powerlifting",
-                "weight",
-                "weightlifter",
-                "weights",
-                "workout"
-              ]
+              "keywords": ["barbell", "bodybuilder", "deadlift", "lifter", "lifting", "man", "powerlifting", "weight", "weightlifter", "weights", "workout"]
             },
             {
               "codepoint": "U+1F3CB U+FE0F U+200D U+2640 U+FE0F",
               "name": "woman lifting weights",
-              "keywords": [
-                "barbell",
-                "bodybuilder",
-                "deadlift",
-                "lifter",
-                "lifting",
-                "powerlifting",
-                "weight",
-                "weightlifter",
-                "weights",
-                "woman",
-                "workout"
-              ]
+              "keywords": ["barbell", "bodybuilder", "deadlift", "lifter", "lifting", "powerlifting", "weight", "weightlifter", "weights", "woman", "workout"]
             },
             {
               "codepoint": "U+1F6B4",
               "name": "person biking",
-              "keywords": [
-                "bicycle",
-                "bicyclist",
-                "bike",
-                "biking",
-                "cycle",
-                "cyclist",
-                "person",
-                "riding",
-                "sport"
-              ]
+              "keywords": ["bicycle", "bicyclist", "bike", "biking", "cycle", "cyclist", "person", "riding", "sport"]
             },
             {
               "codepoint": "U+1F6B4 U+200D U+2642 U+FE0F",
               "name": "man biking",
-              "keywords": [
-                "bicycle",
-                "bicyclist",
-                "bike",
-                "biking",
-                "cycle",
-                "cyclist",
-                "man",
-                "riding",
-                "sport"
-              ]
+              "keywords": ["bicycle", "bicyclist", "bike", "biking", "cycle", "cyclist", "man", "riding", "sport"]
             },
             {
               "codepoint": "U+1F6B4 U+200D U+2640 U+FE0F",
               "name": "woman biking",
-              "keywords": [
-                "bicycle",
-                "bicyclist",
-                "bike",
-                "biking",
-                "cycle",
-                "cyclist",
-                "riding",
-                "sport",
-                "woman"
-              ]
+              "keywords": ["bicycle", "bicyclist", "bike", "biking", "cycle", "cyclist", "riding", "sport", "woman"]
             },
             {
               "codepoint": "U+1F6B5",
               "name": "person mountain biking",
-              "keywords": [
-                "bicycle",
-                "bicyclist",
-                "bike",
-                "biking",
-                "cycle",
-                "cyclist",
-                "mountain",
-                "person",
-                "riding",
-                "sport"
-              ]
+              "keywords": ["bicycle", "bicyclist", "bike", "biking", "cycle", "cyclist", "mountain", "person", "riding", "sport"]
             },
             {
               "codepoint": "U+1F6B5 U+200D U+2642 U+FE0F",
               "name": "man mountain biking",
-              "keywords": [
-                "bicycle",
-                "bicyclist",
-                "bike",
-                "biking",
-                "cycle",
-                "cyclist",
-                "man",
-                "mountain",
-                "riding",
-                "sport"
-              ]
+              "keywords": ["bicycle", "bicyclist", "bike", "biking", "cycle", "cyclist", "man", "mountain", "riding", "sport"]
             },
             {
               "codepoint": "U+1F6B5 U+200D U+2640 U+FE0F",
               "name": "woman mountain biking",
-              "keywords": [
-                "bicycle",
-                "bicyclist",
-                "bike",
-                "biking",
-                "cycle",
-                "cyclist",
-                "mountain",
-                "riding",
-                "sport",
-                "woman"
-              ]
+              "keywords": ["bicycle", "bicyclist", "bike", "biking", "cycle", "cyclist", "mountain", "riding", "sport", "woman"]
             },
             {
               "codepoint": "U+1F938",
               "name": "person cartwheeling",
-              "keywords": [
-                "active",
-                "cartwheel",
-                "cartwheeling",
-                "excited",
-                "flip",
-                "gymnastics",
-                "happy",
-                "person",
-                "somersault"
-              ]
+              "keywords": ["active", "cartwheel", "cartwheeling", "excited", "flip", "gymnastics", "happy", "person", "somersault"]
             },
             {
               "codepoint": "U+1F938 U+200D U+2642 U+FE0F",
               "name": "man cartwheeling",
-              "keywords": [
-                "active",
-                "cartwheel",
-                "cartwheeling",
-                "excited",
-                "flip",
-                "gymnastics",
-                "happy",
-                "man",
-                "somersault"
-              ]
+              "keywords": ["active", "cartwheel", "cartwheeling", "excited", "flip", "gymnastics", "happy", "man", "somersault"]
             },
             {
               "codepoint": "U+1F938 U+200D U+2640 U+FE0F",
               "name": "woman cartwheeling",
-              "keywords": [
-                "active",
-                "cartwheel",
-                "cartwheeling",
-                "excited",
-                "flip",
-                "gymnastics",
-                "happy",
-                "somersault",
-                "woman"
-              ]
+              "keywords": ["active", "cartwheel", "cartwheeling", "excited", "flip", "gymnastics", "happy", "somersault", "woman"]
             },
             {
               "codepoint": "U+1F93C",
               "name": "people wrestling",
-              "keywords": [
-                "combat",
-                "duel",
-                "grapple",
-                "people",
-                "ring",
-                "tournament",
-                "wrestle",
-                "wrestling"
-              ]
+              "keywords": ["combat", "duel", "grapple", "people", "ring", "tournament", "wrestle", "wrestling"]
             },
             {
               "codepoint": "U+1F93C U+200D U+2642 U+FE0F",
               "name": "men wrestling",
-              "keywords": [
-                "combat",
-                "duel",
-                "grapple",
-                "men",
-                "ring",
-                "tournament",
-                "wrestle",
-                "wrestling"
-              ]
+              "keywords": ["combat", "duel", "grapple", "men", "ring", "tournament", "wrestle", "wrestling"]
             },
             {
               "codepoint": "U+1F93C U+200D U+2640 U+FE0F",
               "name": "women wrestling",
-              "keywords": [
-                "combat",
-                "duel",
-                "grapple",
-                "ring",
-                "tournament",
-                "women",
-                "wrestle",
-                "wrestling"
-              ]
+              "keywords": ["combat", "duel", "grapple", "ring", "tournament", "women", "wrestle", "wrestling"]
             },
             {
               "codepoint": "U+1F93D",
               "name": "person playing water polo",
-              "keywords": [
-                "person",
-                "playing",
-                "polo",
-                "sport",
-                "swimming",
-                "water",
-                "waterpolo"
-              ]
+              "keywords": ["person", "playing", "polo", "sport", "swimming", "water", "waterpolo"]
             },
             {
               "codepoint": "U+1F93D U+200D U+2642 U+FE0F",
               "name": "man playing water polo",
-              "keywords": [
-                "man",
-                "playing",
-                "polo",
-                "sport",
-                "swimming",
-                "water",
-                "waterpolo"
-              ]
+              "keywords": ["man", "playing", "polo", "sport", "swimming", "water", "waterpolo"]
             },
             {
               "codepoint": "U+1F93D U+200D U+2640 U+FE0F",
               "name": "woman playing water polo",
-              "keywords": [
-                "playing",
-                "polo",
-                "sport",
-                "swimming",
-                "water",
-                "waterpolo",
-                "woman"
-              ]
+              "keywords": ["playing", "polo", "sport", "swimming", "water", "waterpolo", "woman"]
             },
             {
               "codepoint": "U+1F93E",
               "name": "person playing handball",
-              "keywords": [
-                "athletics",
-                "ball",
-                "catch",
-                "chuck",
-                "handball",
-                "hurl",
-                "lob",
-                "person",
-                "pitch",
-                "playing",
-                "sport",
-                "throw",
-                "toss"
-              ]
+              "keywords": ["athletics", "ball", "catch", "chuck", "handball", "hurl", "lob", "person", "pitch", "playing", "sport", "throw", "toss"]
             },
             {
               "codepoint": "U+1F93E U+200D U+2642 U+FE0F",
               "name": "man playing handball",
-              "keywords": [
-                "athletics",
-                "ball",
-                "catch",
-                "chuck",
-                "handball",
-                "hurl",
-                "lob",
-                "man",
-                "pitch",
-                "playing",
-                "sport",
-                "throw",
-                "toss"
-              ]
+              "keywords": ["athletics", "ball", "catch", "chuck", "handball", "hurl", "lob", "man", "pitch", "playing", "sport", "throw", "toss"]
             },
             {
               "codepoint": "U+1F93E U+200D U+2640 U+FE0F",
               "name": "woman playing handball",
-              "keywords": [
-                "athletics",
-                "ball",
-                "catch",
-                "chuck",
-                "handball",
-                "hurl",
-                "lob",
-                "pitch",
-                "playing",
-                "sport",
-                "throw",
-                "toss",
-                "woman"
-              ]
+              "keywords": ["athletics", "ball", "catch", "chuck", "handball", "hurl", "lob", "pitch", "playing", "sport", "throw", "toss", "woman"]
             },
             {
               "codepoint": "U+1F939",
               "name": "person juggling",
-              "keywords": [
-                "act",
-                "balance",
-                "balancing",
-                "handle",
-                "juggle",
-                "juggling",
-                "manage",
-                "multitask",
-                "person",
-                "skill"
-              ]
+              "keywords": ["act", "balance", "balancing", "handle", "juggle", "juggling", "manage", "multitask", "person", "skill"]
             },
             {
               "codepoint": "U+1F939 U+200D U+2642 U+FE0F",
               "name": "man juggling",
-              "keywords": [
-                "act",
-                "balance",
-                "balancing",
-                "handle",
-                "juggle",
-                "juggling",
-                "man",
-                "manage",
-                "multitask",
-                "skill"
-              ]
+              "keywords": ["act", "balance", "balancing", "handle", "juggle", "juggling", "man", "manage", "multitask", "skill"]
             },
             {
               "codepoint": "U+1F939 U+200D U+2640 U+FE0F",
               "name": "woman juggling",
-              "keywords": [
-                "act",
-                "balance",
-                "balancing",
-                "handle",
-                "juggle",
-                "juggling",
-                "manage",
-                "multitask",
-                "skill",
-                "woman"
-              ]
+              "keywords": ["act", "balance", "balancing", "handle", "juggle", "juggling", "manage", "multitask", "skill", "woman"]
             }
           ]
         },
@@ -6719,59 +2676,17 @@
             {
               "codepoint": "U+1F9D8",
               "name": "person in lotus position",
-              "keywords": [
-                "cross",
-                "legged",
-                "legs",
-                "lotus",
-                "meditation",
-                "peace",
-                "person",
-                "position",
-                "relax",
-                "serenity",
-                "yoga",
-                "yogi",
-                "zen"
-              ]
+              "keywords": ["cross", "legged", "legs", "lotus", "meditation", "peace", "person", "position", "relax", "serenity", "yoga", "yogi", "zen"]
             },
             {
               "codepoint": "U+1F9D8 U+200D U+2642 U+FE0F",
               "name": "man in lotus position",
-              "keywords": [
-                "cross",
-                "legged",
-                "legs",
-                "lotus",
-                "man",
-                "meditation",
-                "peace",
-                "position",
-                "relax",
-                "serenity",
-                "yoga",
-                "yogi",
-                "zen"
-              ]
+              "keywords": ["cross", "legged", "legs", "lotus", "man", "meditation", "peace", "position", "relax", "serenity", "yoga", "yogi", "zen"]
             },
             {
               "codepoint": "U+1F9D8 U+200D U+2640 U+FE0F",
               "name": "woman in lotus position",
-              "keywords": [
-                "cross",
-                "legged",
-                "legs",
-                "lotus",
-                "meditation",
-                "peace",
-                "position",
-                "relax",
-                "serenity",
-                "woman",
-                "yoga",
-                "yogi",
-                "zen"
-              ]
+              "keywords": ["cross", "legged", "legs", "lotus", "meditation", "peace", "position", "relax", "serenity", "woman", "yoga", "yogi", "zen"]
             },
             {
               "codepoint": "U+1F6C0",
@@ -6781,19 +2696,7 @@
             {
               "codepoint": "U+1F6CC",
               "name": "person in bed",
-              "keywords": [
-                "bed",
-                "bedtime",
-                "good",
-                "goodnight",
-                "hotel",
-                "nap",
-                "night",
-                "person",
-                "sleep",
-                "tired",
-                "zzz"
-              ]
+              "keywords": ["bed", "bedtime", "good", "goodnight", "hotel", "nap", "night", "person", "sleep", "tired", "zzz"]
             }
           ]
         },
@@ -6803,239 +2706,62 @@
             {
               "codepoint": "U+1F9D1 U+200D U+1F91D U+200D U+1F9D1",
               "name": "people holding hands",
-              "keywords": [
-                "bae",
-                "bestie",
-                "bff",
-                "couple",
-                "dating",
-                "flirt",
-                "friends",
-                "hand",
-                "hold",
-                "people",
-                "twins"
-              ]
+              "keywords": ["bae", "bestie", "bff", "couple", "dating", "flirt", "friends", "hand", "hold", "people", "twins"]
             },
             {
               "codepoint": "U+1F46D",
               "name": "women holding hands",
-              "keywords": [
-                "bae",
-                "bestie",
-                "bff",
-                "couple",
-                "dating",
-                "flirt",
-                "friends",
-                "girls",
-                "hand",
-                "hold",
-                "sisters",
-                "twins",
-                "women"
-              ]
+              "keywords": ["bae", "bestie", "bff", "couple", "dating", "flirt", "friends", "girls", "hand", "hold", "sisters", "twins", "women"]
             },
             {
               "codepoint": "U+1F46B",
               "name": "woman and man holding hands",
-              "keywords": [
-                "bae",
-                "bestie",
-                "bff",
-                "couple",
-                "dating",
-                "flirt",
-                "friends",
-                "hand",
-                "hold",
-                "man",
-                "twins",
-                "woman"
-              ]
+              "keywords": ["bae", "bestie", "bff", "couple", "dating", "flirt", "friends", "hand", "hold", "man", "twins", "woman"]
             },
             {
               "codepoint": "U+1F46C",
               "name": "men holding hands",
-              "keywords": [
-                "bae",
-                "bestie",
-                "bff",
-                "boys",
-                "brothers",
-                "couple",
-                "dating",
-                "flirt",
-                "friends",
-                "hand",
-                "hold",
-                "men",
-                "twins"
-              ]
+              "keywords": ["bae", "bestie", "bff", "boys", "brothers", "couple", "dating", "flirt", "friends", "hand", "hold", "men", "twins"]
             },
             {
               "codepoint": "U+1F48F",
               "name": "kiss",
-              "keywords": [
-                "anniversary",
-                "babe",
-                "bae",
-                "couple",
-                "date",
-                "dating",
-                "heart",
-                "kiss",
-                "love",
-                "mwah",
-                "person",
-                "romance",
-                "together",
-                "xoxo"
-              ]
+              "keywords": ["anniversary", "babe", "bae", "couple", "date", "dating", "heart", "kiss", "love", "mwah", "person", "romance", "together", "xoxo"]
             },
             {
               "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F468",
               "name": "kiss: woman, man",
-              "keywords": [
-                "anniversary",
-                "babe",
-                "bae",
-                "couple",
-                "date",
-                "dating",
-                "heart",
-                "kiss",
-                "love",
-                "man",
-                "mwah",
-                "person",
-                "romance",
-                "together",
-                "woman",
-                "xoxo"
-              ]
+              "keywords": ["anniversary", "babe", "bae", "couple", "date", "dating", "heart", "kiss", "love", "man", "mwah", "person", "romance", "together", "woman", "xoxo"]
             },
             {
               "codepoint": "U+1F468 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F468",
               "name": "kiss: man, man",
-              "keywords": [
-                "anniversary",
-                "babe",
-                "bae",
-                "couple",
-                "date",
-                "dating",
-                "heart",
-                "kiss",
-                "love",
-                "man",
-                "mwah",
-                "person",
-                "romance",
-                "together",
-                "xoxo"
-              ]
+              "keywords": ["anniversary", "babe", "bae", "couple", "date", "dating", "heart", "kiss", "love", "man", "mwah", "person", "romance", "together", "xoxo"]
             },
             {
               "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F48B U+200D U+1F469",
               "name": "kiss: woman, woman",
-              "keywords": [
-                "anniversary",
-                "babe",
-                "bae",
-                "couple",
-                "date",
-                "dating",
-                "heart",
-                "kiss",
-                "love",
-                "mwah",
-                "person",
-                "romance",
-                "together",
-                "woman",
-                "xoxo"
-              ]
+              "keywords": ["anniversary", "babe", "bae", "couple", "date", "dating", "heart", "kiss", "love", "mwah", "person", "romance", "together", "woman", "xoxo"]
             },
             {
               "codepoint": "U+1F491",
               "name": "couple with heart",
-              "keywords": [
-                "anniversary",
-                "babe",
-                "bae",
-                "couple",
-                "dating",
-                "heart",
-                "kiss",
-                "love",
-                "person",
-                "relationship",
-                "romance",
-                "together",
-                "you"
-              ]
+              "keywords": ["anniversary", "babe", "bae", "couple", "dating", "heart", "kiss", "love", "person", "relationship", "romance", "together", "you"]
             },
             {
               "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F468",
               "name": "couple with heart: woman, man",
-              "keywords": [
-                "anniversary",
-                "babe",
-                "bae",
-                "couple",
-                "dating",
-                "heart",
-                "kiss",
-                "love",
-                "man",
-                "person",
-                "relationship",
-                "romance",
-                "together",
-                "woman",
-                "you"
-              ]
+              "keywords": ["anniversary", "babe", "bae", "couple", "dating", "heart", "kiss", "love", "man", "person", "relationship", "romance", "together", "woman", "you"]
             },
             {
               "codepoint": "U+1F468 U+200D U+2764 U+FE0F U+200D U+1F468",
               "name": "couple with heart: man, man",
-              "keywords": [
-                "anniversary",
-                "babe",
-                "bae",
-                "couple",
-                "dating",
-                "heart",
-                "kiss",
-                "love",
-                "man",
-                "person",
-                "relationship",
-                "romance",
-                "together",
-                "you"
-              ]
+              "keywords": ["anniversary", "babe", "bae", "couple", "dating", "heart", "kiss", "love", "man", "person", "relationship", "romance", "together", "you"]
             },
             {
               "codepoint": "U+1F469 U+200D U+2764 U+FE0F U+200D U+1F469",
               "name": "couple with heart: woman, woman",
-              "keywords": [
-                "anniversary",
-                "babe",
-                "bae",
-                "couple",
-                "dating",
-                "heart",
-                "kiss",
-                "love",
-                "person",
-                "relationship",
-                "romance",
-                "together",
-                "woman",
-                "you"
-              ]
+              "keywords": ["anniversary", "babe", "bae", "couple", "dating", "heart", "kiss", "love", "person", "relationship", "romance", "together", "woman", "you"]
             },
             {
               "codepoint": "U+1F468 U+200D U+1F469 U+200D U+1F466",
@@ -7180,33 +2906,12 @@
             {
               "codepoint": "U+1F465",
               "name": "busts in silhouette",
-              "keywords": [
-                "bff",
-                "bust",
-                "busts",
-                "everyone",
-                "friend",
-                "friends",
-                "people",
-                "silhouette"
-              ]
+              "keywords": ["bff", "bust", "busts", "everyone", "friend", "friends", "people", "silhouette"]
             },
             {
               "codepoint": "U+1FAC2",
               "name": "people hugging",
-              "keywords": [
-                "comfort",
-                "embrace",
-                "farewell",
-                "friendship",
-                "goodbye",
-                "hello",
-                "hug",
-                "hugging",
-                "love",
-                "people",
-                "thanks"
-              ]
+              "keywords": ["comfort", "embrace", "farewell", "friendship", "goodbye", "hello", "hug", "hugging", "love", "people", "thanks"]
             },
             {
               "codepoint": "U+1F46A",
@@ -7236,31 +2941,12 @@
             {
               "codepoint": "U+1F463",
               "name": "footprints",
-              "keywords": [
-                "barefoot",
-                "clothing",
-                "footprint",
-                "footprints",
-                "omw",
-                "print",
-                "walk"
-              ]
+              "keywords": ["barefoot", "clothing", "footprint", "footprints", "omw", "print", "walk"]
             },
             {
               "codepoint": "U+1FAC6",
               "name": "fingerprint",
-              "keywords": [
-                "clue",
-                "crime",
-                "detective",
-                "fingerprint",
-                "forensics",
-                "identity",
-                "mystery",
-                "print",
-                "safety",
-                "trace"
-              ]
+              "keywords": ["clue", "crime", "detective", "fingerprint", "forensics", "identity", "mystery", "print", "safety", "trace"]
             }
           ]
         }
@@ -7290,14 +2976,7 @@
             {
               "codepoint": "U+1F9B2",
               "name": "bald",
-              "keywords": [
-                "bald",
-                "chemotherapy",
-                "hair",
-                "hairless",
-                "no",
-                "shaven"
-              ]
+              "keywords": ["bald", "chemotherapy", "hair", "hairless", "no", "shaven"]
             }
           ]
         }
@@ -7332,15 +3011,7 @@
             {
               "codepoint": "U+1F436",
               "name": "dog face",
-              "keywords": [
-                "adorbs",
-                "animal",
-                "dog",
-                "face",
-                "pet",
-                "puppies",
-                "puppy"
-              ]
+              "keywords": ["adorbs", "animal", "dog", "face", "pet", "puppies", "puppy"]
             },
             {
               "codepoint": "U+1F415",
@@ -7355,13 +3026,7 @@
             {
               "codepoint": "U+1F415 U+200D U+1F9BA",
               "name": "service dog",
-              "keywords": [
-                "accessibility",
-                "animal",
-                "assistance",
-                "dog",
-                "service"
-              ]
+              "keywords": ["accessibility", "animal", "assistance", "dog", "service"]
             },
             {
               "codepoint": "U+1F429",
@@ -7396,33 +3061,12 @@
             {
               "codepoint": "U+1F408 U+200D U+2B1B",
               "name": "black cat",
-              "keywords": [
-                "animal",
-                "black",
-                "cat",
-                "feline",
-                "halloween",
-                "meow",
-                "unlucky"
-              ]
+              "keywords": ["animal", "black", "cat", "feline", "halloween", "meow", "unlucky"]
             },
             {
               "codepoint": "U+1F981",
               "name": "lion",
-              "keywords": [
-                "alpha",
-                "animal",
-                "face",
-                "Leo",
-                "lion",
-                "mane",
-                "order",
-                "rawr",
-                "roar",
-                "safari",
-                "strong",
-                "zodiac"
-              ]
+              "keywords": ["alpha", "animal", "face", "Leo", "lion", "mane", "order", "rawr", "roar", "safari", "strong", "zodiac"]
             },
             {
               "codepoint": "U+1F42F",
@@ -7442,53 +3086,22 @@
             {
               "codepoint": "U+1F434",
               "name": "horse face",
-              "keywords": [
-                "animal",
-                "dressage",
-                "equine",
-                "face",
-                "farm",
-                "horse",
-                "horses"
-              ]
+              "keywords": ["animal", "dressage", "equine", "face", "farm", "horse", "horses"]
             },
             {
               "codepoint": "U+1FACE",
               "name": "moose",
-              "keywords": [
-                "alces",
-                "animal",
-                "antlers",
-                "elk",
-                "mammal",
-                "moose"
-              ]
+              "keywords": ["alces", "animal", "antlers", "elk", "mammal", "moose"]
             },
             {
               "codepoint": "U+1FACF",
               "name": "donkey",
-              "keywords": [
-                "animal",
-                "ass",
-                "burro",
-                "donkey",
-                "hinny",
-                "mammal",
-                "mule",
-                "stubborn"
-              ]
+              "keywords": ["animal", "ass", "burro", "donkey", "hinny", "mammal", "mule", "stubborn"]
             },
             {
               "codepoint": "U+1F40E",
               "name": "horse",
-              "keywords": [
-                "animal",
-                "equestrian",
-                "farm",
-                "horse",
-                "racehorse",
-                "racing"
-              ]
+              "keywords": ["animal", "equestrian", "farm", "horse", "racehorse", "racing"]
             },
             {
               "codepoint": "U+1F984",
@@ -7518,15 +3131,7 @@
             {
               "codepoint": "U+1F402",
               "name": "ox",
-              "keywords": [
-                "animal",
-                "animals",
-                "bull",
-                "farm",
-                "ox",
-                "Taurus",
-                "zodiac"
-              ]
+              "keywords": ["animal", "animals", "bull", "farm", "ox", "Taurus", "zodiac"]
             },
             {
               "codepoint": "U+1F403",
@@ -7556,93 +3161,37 @@
             {
               "codepoint": "U+1F43D",
               "name": "pig nose",
-              "keywords": [
-                "animal",
-                "face",
-                "farm",
-                "nose",
-                "pig",
-                "smell",
-                "snout"
-              ]
+              "keywords": ["animal", "face", "farm", "nose", "pig", "smell", "snout"]
             },
             {
               "codepoint": "U+1F40F",
               "name": "ram",
-              "keywords": [
-                "animal",
-                "Aries",
-                "horns",
-                "male",
-                "ram",
-                "sheep",
-                "zodiac",
-                "zoo"
-              ]
+              "keywords": ["animal", "Aries", "horns", "male", "ram", "sheep", "zodiac", "zoo"]
             },
             {
               "codepoint": "U+1F411",
               "name": "ewe",
-              "keywords": [
-                "animal",
-                "baa",
-                "ewe",
-                "farm",
-                "female",
-                "fluffy",
-                "lamb",
-                "sheep",
-                "wool"
-              ]
+              "keywords": ["animal", "baa", "ewe", "farm", "female", "fluffy", "lamb", "sheep", "wool"]
             },
             {
               "codepoint": "U+1F410",
               "name": "goat",
-              "keywords": [
-                "animal",
-                "Capricorn",
-                "farm",
-                "goat",
-                "milk",
-                "zodiac"
-              ]
+              "keywords": ["animal", "Capricorn", "farm", "goat", "milk", "zodiac"]
             },
             {
               "codepoint": "U+1F42A",
               "name": "camel",
-              "keywords": [
-                "animal",
-                "camel",
-                "desert",
-                "dromedary",
-                "hump",
-                "one"
-              ]
+              "keywords": ["animal", "camel", "desert", "dromedary", "hump", "one"]
             },
             {
               "codepoint": "U+1F42B",
               "name": "two-hump camel",
-              "keywords": [
-                "animal",
-                "bactrian",
-                "camel",
-                "desert",
-                "hump",
-                "two",
-                "two-hump"
-              ]
+              "keywords": ["animal", "bactrian", "camel", "desert", "hump", "two", "two-hump"]
             },
             {
               "codepoint": "U+1F999",
               "name": "llama",
-              "keywords": [
-                "alpaca",
-                "animal",
-                "guanaco",
-                "llama",
-                "vicuña",
-                "wool"
-              ]
+              "keywords": ["alpaca", "animal", "guanaco", "llama", "vicuña", "wool"]
             },
             {
               "codepoint": "U+1F992",
@@ -7657,14 +3206,7 @@
             {
               "codepoint": "U+1F9A3",
               "name": "mammoth",
-              "keywords": [
-                "animal",
-                "extinction",
-                "large",
-                "mammoth",
-                "tusk",
-                "wooly"
-              ]
+              "keywords": ["animal", "extinction", "large", "mammoth", "tusk", "wooly"]
             },
             {
               "codepoint": "U+1F98F",
@@ -7729,14 +3271,7 @@
             {
               "codepoint": "U+1F43B",
               "name": "bear",
-              "keywords": [
-                "animal",
-                "bear",
-                "face",
-                "grizzly",
-                "growl",
-                "honey"
-              ]
+              "keywords": ["animal", "bear", "face", "grizzly", "growl", "honey"]
             },
             {
               "codepoint": "U+1F43B U+200D U+2744 U+FE0F",
@@ -7746,16 +3281,7 @@
             {
               "codepoint": "U+1F428",
               "name": "koala",
-              "keywords": [
-                "animal",
-                "australia",
-                "bear",
-                "down",
-                "face",
-                "koala",
-                "marsupial",
-                "under"
-              ]
+              "keywords": ["animal", "australia", "bear", "down", "face", "koala", "marsupial", "under"]
             },
             {
               "codepoint": "U+1F43C",
@@ -7825,15 +3351,7 @@
             {
               "codepoint": "U+1F425",
               "name": "front-facing baby chick",
-              "keywords": [
-                "animal",
-                "baby",
-                "bird",
-                "chick",
-                "front-facing",
-                "newborn",
-                "ornithology"
-              ]
+              "keywords": ["animal", "baby", "bird", "chick", "front-facing", "newborn", "ornithology"]
             },
             {
               "codepoint": "U+1F426",
@@ -7843,13 +3361,7 @@
             {
               "codepoint": "U+1F427",
               "name": "penguin",
-              "keywords": [
-                "animal",
-                "antarctica",
-                "bird",
-                "ornithology",
-                "penguin"
-              ]
+              "keywords": ["animal", "antarctica", "bird", "ornithology", "penguin"]
             },
             {
               "codepoint": "U+1F54A",
@@ -7869,15 +3381,7 @@
             {
               "codepoint": "U+1F9A2",
               "name": "swan",
-              "keywords": [
-                "animal",
-                "bird",
-                "cygnet",
-                "duckling",
-                "ornithology",
-                "swan",
-                "ugly"
-              ]
+              "keywords": ["animal", "bird", "cygnet", "duckling", "ornithology", "swan", "ugly"]
             },
             {
               "codepoint": "U+1F989",
@@ -7887,14 +3391,7 @@
             {
               "codepoint": "U+1F9A4",
               "name": "dodo",
-              "keywords": [
-                "animal",
-                "bird",
-                "dodo",
-                "extinction",
-                "large",
-                "ornithology"
-              ]
+              "keywords": ["animal", "bird", "dodo", "extinction", "large", "ornithology"]
             },
             {
               "codepoint": "U+1FAB6",
@@ -7904,113 +3401,37 @@
             {
               "codepoint": "U+1F9A9",
               "name": "flamingo",
-              "keywords": [
-                "animal",
-                "bird",
-                "flamboyant",
-                "flamingo",
-                "ornithology",
-                "tropical"
-              ]
+              "keywords": ["animal", "bird", "flamboyant", "flamingo", "ornithology", "tropical"]
             },
             {
               "codepoint": "U+1F99A",
               "name": "peacock",
-              "keywords": [
-                "animal",
-                "bird",
-                "colorful",
-                "ornithology",
-                "ostentatious",
-                "peacock",
-                "peahen",
-                "pretty",
-                "proud"
-              ]
+              "keywords": ["animal", "bird", "colorful", "ornithology", "ostentatious", "peacock", "peahen", "pretty", "proud"]
             },
             {
               "codepoint": "U+1F99C",
               "name": "parrot",
-              "keywords": [
-                "animal",
-                "bird",
-                "ornithology",
-                "parrot",
-                "pirate",
-                "talk"
-              ]
+              "keywords": ["animal", "bird", "ornithology", "parrot", "pirate", "talk"]
             },
             {
               "codepoint": "U+1FABD",
               "name": "wing",
-              "keywords": [
-                "angelic",
-                "ascend",
-                "aviation",
-                "bird",
-                "fly",
-                "flying",
-                "heavenly",
-                "mythology",
-                "soar",
-                "wing"
-              ]
+              "keywords": ["angelic", "ascend", "aviation", "bird", "fly", "flying", "heavenly", "mythology", "soar", "wing"]
             },
             {
               "codepoint": "U+1F426 U+200D U+2B1B",
               "name": "black bird",
-              "keywords": [
-                "animal",
-                "beak",
-                "bird",
-                "black",
-                "caw",
-                "corvid",
-                "crow",
-                "ornithology",
-                "raven",
-                "rook"
-              ]
+              "keywords": ["animal", "beak", "bird", "black", "caw", "corvid", "crow", "ornithology", "raven", "rook"]
             },
             {
               "codepoint": "U+1FABF",
               "name": "goose",
-              "keywords": [
-                "animal",
-                "bird",
-                "duck",
-                "flock",
-                "fowl",
-                "gaggle",
-                "gander",
-                "geese",
-                "goose",
-                "honk",
-                "ornithology",
-                "silly"
-              ]
+              "keywords": ["animal", "bird", "duck", "flock", "fowl", "gaggle", "gander", "geese", "goose", "honk", "ornithology", "silly"]
             },
             {
               "codepoint": "U+1F426 U+200D U+1F525",
               "name": "phoenix",
-              "keywords": [
-                "ascend",
-                "ascension",
-                "emerge",
-                "fantasy",
-                "firebird",
-                "glory",
-                "immortal",
-                "phoenix",
-                "rebirth",
-                "reincarnation",
-                "reinvent",
-                "renewal",
-                "revival",
-                "revive",
-                "rise",
-                "transform"
-              ]
+              "keywords": ["ascend", "ascension", "emerge", "fantasy", "firebird", "glory", "immortal", "phoenix", "rebirth", "reincarnation", "reinvent", "renewal", "revival", "revive", "rise", "transform"]
             }
           ]
         },
@@ -8045,49 +3466,22 @@
             {
               "codepoint": "U+1F40D",
               "name": "snake",
-              "keywords": [
-                "animal",
-                "bearer",
-                "Ophiuchus",
-                "serpent",
-                "snake",
-                "zodiac"
-              ]
+              "keywords": ["animal", "bearer", "Ophiuchus", "serpent", "snake", "zodiac"]
             },
             {
               "codepoint": "U+1F432",
               "name": "dragon face",
-              "keywords": [
-                "animal",
-                "dragon",
-                "face",
-                "fairy",
-                "fairytale",
-                "tale"
-              ]
+              "keywords": ["animal", "dragon", "face", "fairy", "fairytale", "tale"]
             },
             {
               "codepoint": "U+1F409",
               "name": "dragon",
-              "keywords": [
-                "animal",
-                "dragon",
-                "fairy",
-                "fairytale",
-                "knights",
-                "tale"
-              ]
+              "keywords": ["animal", "dragon", "fairy", "fairytale", "knights", "tale"]
             },
             {
               "codepoint": "U+1F995",
               "name": "sauropod",
-              "keywords": [
-                "brachiosaurus",
-                "brontosaurus",
-                "dinosaur",
-                "diplodocus",
-                "sauropod"
-              ]
+              "keywords": ["brachiosaurus", "brontosaurus", "dinosaur", "diplodocus", "sauropod"]
             },
             {
               "codepoint": "U+1F996",
@@ -8102,14 +3496,7 @@
             {
               "codepoint": "U+1F433",
               "name": "spouting whale",
-              "keywords": [
-                "animal",
-                "beach",
-                "face",
-                "ocean",
-                "spouting",
-                "whale"
-              ]
+              "keywords": ["animal", "beach", "face", "ocean", "spouting", "whale"]
             },
             {
               "codepoint": "U+1F40B",
@@ -8129,15 +3516,7 @@
             {
               "codepoint": "U+1F41F",
               "name": "fish",
-              "keywords": [
-                "animal",
-                "dinner",
-                "fish",
-                "fishes",
-                "fishing",
-                "Pisces",
-                "zodiac"
-              ]
+              "keywords": ["animal", "dinner", "fish", "fishes", "fishing", "Pisces", "zodiac"]
             },
             {
               "codepoint": "U+1F420",
@@ -8172,23 +3551,7 @@
             {
               "codepoint": "U+1FABC",
               "name": "jellyfish",
-              "keywords": [
-                "animal",
-                "aquarium",
-                "burn",
-                "invertebrate",
-                "jelly",
-                "jellyfish",
-                "life",
-                "marine",
-                "ocean",
-                "ouch",
-                "plankton",
-                "sea",
-                "sting",
-                "stinger",
-                "tentacles"
-              ]
+              "keywords": ["animal", "aquarium", "burn", "invertebrate", "jelly", "jellyfish", "life", "marine", "ocean", "ouch", "plankton", "sea", "sting", "stinger", "tentacles"]
             },
             {
               "codepoint": "U+1F980",
@@ -8223,14 +3586,7 @@
             {
               "codepoint": "U+1F40C",
               "name": "snail",
-              "keywords": [
-                "animal",
-                "escargot",
-                "garden",
-                "nature",
-                "slug",
-                "snail"
-              ]
+              "keywords": ["animal", "escargot", "garden", "nature", "slug", "snail"]
             },
             {
               "codepoint": "U+1F98B",
@@ -8250,16 +3606,7 @@
             {
               "codepoint": "U+1F41D",
               "name": "honeybee",
-              "keywords": [
-                "animal",
-                "bee",
-                "bumblebee",
-                "honey",
-                "honeybee",
-                "insect",
-                "nature",
-                "spring"
-              ]
+              "keywords": ["animal", "bee", "bumblebee", "honey", "honeybee", "insect", "nature", "spring"]
             },
             {
               "codepoint": "U+1FAB2",
@@ -8269,28 +3616,12 @@
             {
               "codepoint": "U+1F41E",
               "name": "lady beetle",
-              "keywords": [
-                "animal",
-                "beetle",
-                "garden",
-                "insect",
-                "lady",
-                "ladybird",
-                "ladybug",
-                "nature"
-              ]
+              "keywords": ["animal", "beetle", "garden", "insect", "lady", "ladybird", "ladybug", "nature"]
             },
             {
               "codepoint": "U+1F997",
               "name": "cricket",
-              "keywords": [
-                "animal",
-                "bug",
-                "cricket",
-                "grasshopper",
-                "insect",
-                "Orthoptera"
-              ]
+              "keywords": ["animal", "bug", "cricket", "grasshopper", "insect", "Orthoptera"]
             },
             {
               "codepoint": "U+1FAB3",
@@ -8315,29 +3646,12 @@
             {
               "codepoint": "U+1F99F",
               "name": "mosquito",
-              "keywords": [
-                "bite",
-                "disease",
-                "fever",
-                "insect",
-                "malaria",
-                "mosquito",
-                "pest",
-                "virus"
-              ]
+              "keywords": ["bite", "disease", "fever", "insect", "malaria", "mosquito", "pest", "virus"]
             },
             {
               "codepoint": "U+1FAB0",
               "name": "fly",
-              "keywords": [
-                "animal",
-                "disease",
-                "fly",
-                "insect",
-                "maggot",
-                "pest",
-                "rotting"
-              ]
+              "keywords": ["animal", "disease", "fly", "insect", "maggot", "pest", "rotting"]
             },
             {
               "codepoint": "U+1FAB1",
@@ -8357,28 +3671,12 @@
             {
               "codepoint": "U+1F490",
               "name": "bouquet",
-              "keywords": [
-                "anniversary",
-                "birthday",
-                "bouquet",
-                "date",
-                "flower",
-                "love",
-                "plant",
-                "romance"
-              ]
+              "keywords": ["anniversary", "birthday", "bouquet", "date", "flower", "love", "plant", "romance"]
             },
             {
               "codepoint": "U+1F338",
               "name": "cherry blossom",
-              "keywords": [
-                "blossom",
-                "cherry",
-                "flower",
-                "plant",
-                "spring",
-                "springtime"
-              ]
+              "keywords": ["blossom", "cherry", "flower", "plant", "spring", "springtime"]
             },
             {
               "codepoint": "U+1F4AE",
@@ -8388,17 +3686,7 @@
             {
               "codepoint": "U+1FAB7",
               "name": "lotus",
-              "keywords": [
-                "beauty",
-                "Buddhism",
-                "calm",
-                "flower",
-                "Hinduism",
-                "lotus",
-                "peace",
-                "purity",
-                "serenity"
-              ]
+              "keywords": ["beauty", "Buddhism", "calm", "flower", "Hinduism", "lotus", "peace", "purity", "serenity"]
             },
             {
               "codepoint": "U+1F3F5",
@@ -8408,16 +3696,7 @@
             {
               "codepoint": "U+1F339",
               "name": "rose",
-              "keywords": [
-                "beauty",
-                "elegant",
-                "flower",
-                "love",
-                "plant",
-                "red",
-                "rose",
-                "valentine"
-              ]
+              "keywords": ["beauty", "elegant", "flower", "love", "plant", "red", "rose", "valentine"]
             },
             {
               "codepoint": "U+1F940",
@@ -8437,13 +3716,7 @@
             {
               "codepoint": "U+1F33C",
               "name": "blossom",
-              "keywords": [
-                "blossom",
-                "buttercup",
-                "dandelion",
-                "flower",
-                "plant"
-              ]
+              "keywords": ["blossom", "buttercup", "dandelion", "flower", "plant"]
             },
             {
               "codepoint": "U+1F337",
@@ -8453,22 +3726,7 @@
             {
               "codepoint": "U+1FABB",
               "name": "hyacinth",
-              "keywords": [
-                "bloom",
-                "bluebonnet",
-                "flower",
-                "hyacinth",
-                "indigo",
-                "lavender",
-                "lilac",
-                "lupine",
-                "plant",
-                "purple",
-                "shrub",
-                "snapdragon",
-                "spring",
-                "violet"
-              ]
+              "keywords": ["bloom", "bluebonnet", "flower", "hyacinth", "indigo", "lavender", "lilac", "lupine", "plant", "purple", "shrub", "snapdragon", "spring", "violet"]
             }
           ]
         },
@@ -8483,15 +3741,7 @@
             {
               "codepoint": "U+1FAB4",
               "name": "potted plant",
-              "keywords": [
-                "decor",
-                "grow",
-                "house",
-                "nurturing",
-                "plant",
-                "pot",
-                "potted"
-              ]
+              "keywords": ["decor", "grow", "house", "nurturing", "plant", "pot", "potted"]
             },
             {
               "codepoint": "U+1F332",
@@ -8501,14 +3751,7 @@
             {
               "codepoint": "U+1F333",
               "name": "deciduous tree",
-              "keywords": [
-                "deciduous",
-                "forest",
-                "green",
-                "habitat",
-                "shedding",
-                "tree"
-              ]
+              "keywords": ["deciduous", "forest", "green", "habitat", "shedding", "tree"]
             },
             {
               "codepoint": "U+1F334",
@@ -8538,16 +3781,7 @@
             {
               "codepoint": "U+1F340",
               "name": "four leaf clover",
-              "keywords": [
-                "4",
-                "clover",
-                "four",
-                "four-leaf",
-                "irish",
-                "leaf",
-                "lucky",
-                "plant"
-              ]
+              "keywords": ["4", "clover", "four", "four-leaf", "irish", "leaf", "lucky", "plant"]
             },
             {
               "codepoint": "U+1F341",
@@ -8582,18 +3816,7 @@
             {
               "codepoint": "U+1FABE",
               "name": "leafless tree",
-              "keywords": [
-                "bare",
-                "barren",
-                "branches",
-                "dead",
-                "drought",
-                "leafless",
-                "tree",
-                "trunk",
-                "winter",
-                "wood"
-              ]
+              "keywords": ["bare", "barren", "branches", "dead", "drought", "leafless", "tree", "trunk", "winter", "wood"]
             }
           ]
         }
@@ -8623,15 +3846,7 @@
             {
               "codepoint": "U+1F34A",
               "name": "tangerine",
-              "keywords": [
-                "c",
-                "citrus",
-                "fruit",
-                "nectarine",
-                "orange",
-                "tangerine",
-                "vitamin"
-              ]
+              "keywords": ["c", "citrus", "fruit", "nectarine", "orange", "tangerine", "vitamin"]
             },
             {
               "codepoint": "U+1F34B",
@@ -8641,24 +3856,7 @@
             {
               "codepoint": "U+1F34B U+200D U+1F7E9",
               "name": "lime",
-              "keywords": [
-                "acidity",
-                "citrus",
-                "cocktail",
-                "fruit",
-                "garnish",
-                "key",
-                "lime",
-                "margarita",
-                "mojito",
-                "refreshing",
-                "salsa",
-                "sour",
-                "tangy",
-                "tequila",
-                "tropical",
-                "zest"
-              ]
+              "keywords": ["acidity", "citrus", "cocktail", "fruit", "garnish", "key", "lime", "margarita", "mojito", "refreshing", "salsa", "sour", "tangy", "tequila", "tropical", "zest"]
             },
             {
               "codepoint": "U+1F34C",
@@ -8678,15 +3876,7 @@
             {
               "codepoint": "U+1F34E",
               "name": "red apple",
-              "keywords": [
-                "apple",
-                "diet",
-                "food",
-                "fruit",
-                "health",
-                "red",
-                "ripe"
-              ]
+              "keywords": ["apple", "diet", "food", "fruit", "health", "red", "ripe"]
             },
             {
               "codepoint": "U+1F34F",
@@ -8716,16 +3906,7 @@
             {
               "codepoint": "U+1FAD0",
               "name": "blueberries",
-              "keywords": [
-                "berries",
-                "berry",
-                "bilberry",
-                "blue",
-                "blueberries",
-                "blueberry",
-                "food",
-                "fruit"
-              ]
+              "keywords": ["berries", "berry", "bilberry", "blue", "blueberries", "blueberry", "food", "fruit"]
             },
             {
               "codepoint": "U+1F95D",
@@ -8795,17 +3976,7 @@
             {
               "codepoint": "U+1F96C",
               "name": "leafy green",
-              "keywords": [
-                "bok",
-                "burgers",
-                "cabbage",
-                "choy",
-                "green",
-                "kale",
-                "leafy",
-                "lettuce",
-                "salad"
-              ]
+              "keywords": ["bok", "burgers", "cabbage", "choy", "green", "kale", "leafy", "lettuce", "salad"]
             },
             {
               "codepoint": "U+1F966",
@@ -8840,67 +4011,22 @@
             {
               "codepoint": "U+1FADA",
               "name": "ginger root",
-              "keywords": [
-                "beer",
-                "ginger",
-                "health",
-                "herb",
-                "natural",
-                "root",
-                "spice"
-              ]
+              "keywords": ["beer", "ginger", "health", "herb", "natural", "root", "spice"]
             },
             {
               "codepoint": "U+1FADB",
               "name": "pea pod",
-              "keywords": [
-                "beans",
-                "beanstalk",
-                "edamame",
-                "legume",
-                "pea",
-                "pod",
-                "soybean",
-                "vegetable",
-                "veggie"
-              ]
+              "keywords": ["beans", "beanstalk", "edamame", "legume", "pea", "pod", "soybean", "vegetable", "veggie"]
             },
             {
               "codepoint": "U+1F344 U+200D U+1F7EB",
               "name": "brown mushroom",
-              "keywords": [
-                "food",
-                "fungi",
-                "fungus",
-                "mushroom",
-                "nature",
-                "pizza",
-                "portobello",
-                "shiitake",
-                "shroom",
-                "spore",
-                "sprout",
-                "toppings",
-                "truffle",
-                "vegetable",
-                "vegetarian",
-                "veggie"
-              ]
+              "keywords": ["food", "fungi", "fungus", "mushroom", "nature", "pizza", "portobello", "shiitake", "shroom", "spore", "sprout", "toppings", "truffle", "vegetable", "vegetarian", "veggie"]
             },
             {
               "codepoint": "U+1FADC",
               "name": "root vegetable",
-              "keywords": [
-                "beet",
-                "food",
-                "garden",
-                "radish",
-                "root",
-                "salad",
-                "turnip",
-                "vegetable",
-                "vegetarian"
-              ]
+              "keywords": ["beet", "food", "garden", "radish", "root", "salad", "turnip", "vegetable", "vegetarian"]
             }
           ]
         },
@@ -8910,29 +4036,12 @@
             {
               "codepoint": "U+1F35E",
               "name": "bread",
-              "keywords": [
-                "bread",
-                "carbs",
-                "food",
-                "grain",
-                "loaf",
-                "restaurant",
-                "toast",
-                "wheat"
-              ]
+              "keywords": ["bread", "carbs", "food", "grain", "loaf", "restaurant", "toast", "wheat"]
             },
             {
               "codepoint": "U+1F950",
               "name": "croissant",
-              "keywords": [
-                "bread",
-                "breakfast",
-                "crescent",
-                "croissant",
-                "food",
-                "french",
-                "roll"
-              ]
+              "keywords": ["bread", "breakfast", "crescent", "croissant", "food", "french", "roll"]
             },
             {
               "codepoint": "U+1F956",
@@ -8942,16 +4051,7 @@
             {
               "codepoint": "U+1FAD3",
               "name": "flatbread",
-              "keywords": [
-                "arepa",
-                "bread",
-                "flatbread",
-                "food",
-                "gordita",
-                "lavash",
-                "naan",
-                "pita"
-              ]
+              "keywords": ["arepa", "bread", "flatbread", "food", "gordita", "lavash", "naan", "pita"]
             },
             {
               "codepoint": "U+1F968",
@@ -8966,14 +4066,7 @@
             {
               "codepoint": "U+1F95E",
               "name": "pancakes",
-              "keywords": [
-                "breakfast",
-                "crêpe",
-                "food",
-                "hotcake",
-                "pancake",
-                "pancakes"
-              ]
+              "keywords": ["breakfast", "crêpe", "food", "hotcake", "pancake", "pancakes"]
             },
             {
               "codepoint": "U+1F9C7",
@@ -8993,28 +4086,12 @@
             {
               "codepoint": "U+1F357",
               "name": "poultry leg",
-              "keywords": [
-                "bone",
-                "chicken",
-                "drumstick",
-                "hungry",
-                "leg",
-                "poultry",
-                "turkey"
-              ]
+              "keywords": ["bone", "chicken", "drumstick", "hungry", "leg", "poultry", "turkey"]
             },
             {
               "codepoint": "U+1F969",
               "name": "cut of meat",
-              "keywords": [
-                "chop",
-                "cut",
-                "lambchop",
-                "meat",
-                "porkchop",
-                "red",
-                "steak"
-              ]
+              "keywords": ["chop", "cut", "lambchop", "meat", "porkchop", "red", "steak"]
             },
             {
               "codepoint": "U+1F953",
@@ -9024,14 +4101,7 @@
             {
               "codepoint": "U+1F354",
               "name": "hamburger",
-              "keywords": [
-                "burger",
-                "eat",
-                "fast",
-                "food",
-                "hamburger",
-                "hungry"
-              ]
+              "keywords": ["burger", "eat", "fast", "food", "hamburger", "hungry"]
             },
             {
               "codepoint": "U+1F35F",
@@ -9041,14 +4111,7 @@
             {
               "codepoint": "U+1F355",
               "name": "pizza",
-              "keywords": [
-                "cheese",
-                "food",
-                "hungry",
-                "pepperoni",
-                "pizza",
-                "slice"
-              ]
+              "keywords": ["cheese", "food", "hungry", "pepperoni", "pizza", "slice"]
             },
             {
               "codepoint": "U+1F32D",
@@ -9078,14 +4141,7 @@
             {
               "codepoint": "U+1F959",
               "name": "stuffed flatbread",
-              "keywords": [
-                "falafel",
-                "flatbread",
-                "food",
-                "gyro",
-                "kebab",
-                "stuffed"
-              ]
+              "keywords": ["falafel", "flatbread", "food", "gyro", "kebab", "stuffed"]
             },
             {
               "codepoint": "U+1F9C6",
@@ -9100,20 +4156,7 @@
             {
               "codepoint": "U+1F373",
               "name": "cooking",
-              "keywords": [
-                "breakfast",
-                "cooking",
-                "easy",
-                "egg",
-                "fry",
-                "frying",
-                "over",
-                "pan",
-                "restaurant",
-                "side",
-                "sunny",
-                "up"
-              ]
+              "keywords": ["breakfast", "cooking", "easy", "egg", "fry", "frying", "over", "pan", "restaurant", "side", "sunny", "up"]
             },
             {
               "codepoint": "U+1F958",
@@ -9128,28 +4171,12 @@
             {
               "codepoint": "U+1FAD5",
               "name": "fondue",
-              "keywords": [
-                "cheese",
-                "chocolate",
-                "fondue",
-                "food",
-                "melted",
-                "pot",
-                "ski"
-              ]
+              "keywords": ["cheese", "chocolate", "fondue", "food", "melted", "pot", "ski"]
             },
             {
               "codepoint": "U+1F963",
               "name": "bowl with spoon",
-              "keywords": [
-                "bowl",
-                "breakfast",
-                "cereal",
-                "congee",
-                "oatmeal",
-                "porridge",
-                "spoon"
-              ]
+              "keywords": ["bowl", "breakfast", "cereal", "congee", "oatmeal", "porridge", "spoon"]
             },
             {
               "codepoint": "U+1F957",
@@ -9169,16 +4196,7 @@
             {
               "codepoint": "U+1F9C2",
               "name": "salt",
-              "keywords": [
-                "condiment",
-                "flavor",
-                "mad",
-                "salt",
-                "salty",
-                "shaker",
-                "taste",
-                "upset"
-              ]
+              "keywords": ["condiment", "flavor", "mad", "salt", "salty", "shaker", "taste", "upset"]
             },
             {
               "codepoint": "U+1F96B",
@@ -9218,27 +4236,12 @@
             {
               "codepoint": "U+1F35C",
               "name": "steaming bowl",
-              "keywords": [
-                "bowl",
-                "chopsticks",
-                "food",
-                "noodle",
-                "pho",
-                "ramen",
-                "soup",
-                "steaming"
-              ]
+              "keywords": ["bowl", "chopsticks", "food", "noodle", "pho", "ramen", "soup", "steaming"]
             },
             {
               "codepoint": "U+1F35D",
               "name": "spaghetti",
-              "keywords": [
-                "food",
-                "meatballs",
-                "pasta",
-                "restaurant",
-                "spaghetti"
-              ]
+              "keywords": ["food", "meatballs", "pasta", "restaurant", "spaghetti"]
             },
             {
               "codepoint": "U+1F360",
@@ -9248,15 +4251,7 @@
             {
               "codepoint": "U+1F362",
               "name": "oden",
-              "keywords": [
-                "food",
-                "kebab",
-                "oden",
-                "restaurant",
-                "seafood",
-                "skewer",
-                "stick"
-              ]
+              "keywords": ["food", "kebab", "oden", "restaurant", "seafood", "skewer", "stick"]
             },
             {
               "codepoint": "U+1F363",
@@ -9271,14 +4266,7 @@
             {
               "codepoint": "U+1F365",
               "name": "fish cake with swirl",
-              "keywords": [
-                "cake",
-                "fish",
-                "food",
-                "pastry",
-                "restaurant",
-                "swirl"
-              ]
+              "keywords": ["cake", "fish", "food", "pastry", "restaurant", "swirl"]
             },
             {
               "codepoint": "U+1F96E",
@@ -9288,26 +4276,12 @@
             {
               "codepoint": "U+1F361",
               "name": "dango",
-              "keywords": [
-                "dango",
-                "dessert",
-                "Japanese",
-                "skewer",
-                "stick",
-                "sweet"
-              ]
+              "keywords": ["dango", "dessert", "Japanese", "skewer", "stick", "sweet"]
             },
             {
               "codepoint": "U+1F95F",
               "name": "dumpling",
-              "keywords": [
-                "dumpling",
-                "empanada",
-                "gyōza",
-                "jiaozi",
-                "pierogi",
-                "potsticker"
-              ]
+              "keywords": ["dumpling", "empanada", "gyōza", "jiaozi", "pierogi", "potsticker"]
             },
             {
               "codepoint": "U+1F960",
@@ -9317,15 +4291,7 @@
             {
               "codepoint": "U+1F961",
               "name": "takeout box",
-              "keywords": [
-                "box",
-                "chopsticks",
-                "delivery",
-                "food",
-                "oyster",
-                "pail",
-                "takeout"
-              ]
+              "keywords": ["box", "chopsticks", "delivery", "food", "oyster", "pail", "takeout"]
             }
           ]
         },
@@ -9335,17 +4301,7 @@
             {
               "codepoint": "U+1F366",
               "name": "soft ice cream",
-              "keywords": [
-                "cream",
-                "dessert",
-                "food",
-                "ice",
-                "icecream",
-                "restaurant",
-                "serve",
-                "soft",
-                "sweet"
-              ]
+              "keywords": ["cream", "dessert", "food", "ice", "icecream", "restaurant", "serve", "soft", "sweet"]
             },
             {
               "codepoint": "U+1F367",
@@ -9355,26 +4311,12 @@
             {
               "codepoint": "U+1F368",
               "name": "ice cream",
-              "keywords": [
-                "cream",
-                "dessert",
-                "food",
-                "ice",
-                "restaurant",
-                "sweet"
-              ]
+              "keywords": ["cream", "dessert", "food", "ice", "restaurant", "sweet"]
             },
             {
               "codepoint": "U+1F369",
               "name": "doughnut",
-              "keywords": [
-                "breakfast",
-                "dessert",
-                "donut",
-                "doughnut",
-                "food",
-                "sweet"
-              ]
+              "keywords": ["breakfast", "dessert", "donut", "doughnut", "food", "sweet"]
             },
             {
               "codepoint": "U+1F36A",
@@ -9384,94 +4326,37 @@
             {
               "codepoint": "U+1F382",
               "name": "birthday cake",
-              "keywords": [
-                "bday",
-                "birthday",
-                "cake",
-                "celebration",
-                "dessert",
-                "happy",
-                "pastry",
-                "sweet"
-              ]
+              "keywords": ["bday", "birthday", "cake", "celebration", "dessert", "happy", "pastry", "sweet"]
             },
             {
               "codepoint": "U+1F370",
               "name": "shortcake",
-              "keywords": [
-                "cake",
-                "dessert",
-                "pastry",
-                "shortcake",
-                "slice",
-                "sweet"
-              ]
+              "keywords": ["cake", "dessert", "pastry", "shortcake", "slice", "sweet"]
             },
             {
               "codepoint": "U+1F9C1",
               "name": "cupcake",
-              "keywords": [
-                "bakery",
-                "cupcake",
-                "dessert",
-                "sprinkles",
-                "sugar",
-                "sweet",
-                "treat"
-              ]
+              "keywords": ["bakery", "cupcake", "dessert", "sprinkles", "sugar", "sweet", "treat"]
             },
             {
               "codepoint": "U+1F967",
               "name": "pie",
-              "keywords": [
-                "apple",
-                "filling",
-                "fruit",
-                "meat",
-                "pastry",
-                "pie",
-                "pumpkin",
-                "slice"
-              ]
+              "keywords": ["apple", "filling", "fruit", "meat", "pastry", "pie", "pumpkin", "slice"]
             },
             {
               "codepoint": "U+1F36B",
               "name": "chocolate bar",
-              "keywords": [
-                "bar",
-                "candy",
-                "chocolate",
-                "dessert",
-                "halloween",
-                "sweet",
-                "tooth"
-              ]
+              "keywords": ["bar", "candy", "chocolate", "dessert", "halloween", "sweet", "tooth"]
             },
             {
               "codepoint": "U+1F36C",
               "name": "candy",
-              "keywords": [
-                "candy",
-                "cavities",
-                "dessert",
-                "halloween",
-                "restaurant",
-                "sweet",
-                "tooth",
-                "wrapper"
-              ]
+              "keywords": ["candy", "cavities", "dessert", "halloween", "restaurant", "sweet", "tooth", "wrapper"]
             },
             {
               "codepoint": "U+1F36D",
               "name": "lollipop",
-              "keywords": [
-                "candy",
-                "dessert",
-                "food",
-                "lollipop",
-                "restaurant",
-                "sweet"
-              ]
+              "keywords": ["candy", "dessert", "food", "lollipop", "restaurant", "sweet"]
             },
             {
               "codepoint": "U+1F36E",
@@ -9481,16 +4366,7 @@
             {
               "codepoint": "U+1F36F",
               "name": "honey pot",
-              "keywords": [
-                "barrel",
-                "bear",
-                "food",
-                "honey",
-                "honeypot",
-                "jar",
-                "pot",
-                "sweet"
-              ]
+              "keywords": ["barrel", "bear", "food", "honey", "honeypot", "jar", "pot", "sweet"]
             }
           ]
         },
@@ -9500,17 +4376,7 @@
             {
               "codepoint": "U+1F37C",
               "name": "baby bottle",
-              "keywords": [
-                "babies",
-                "baby",
-                "birth",
-                "born",
-                "bottle",
-                "drink",
-                "infant",
-                "milk",
-                "newborn"
-              ]
+              "keywords": ["babies", "baby", "birth", "born", "bottle", "drink", "infant", "milk", "newborn"]
             },
             {
               "codepoint": "U+1F95B",
@@ -9520,18 +4386,7 @@
             {
               "codepoint": "U+2615",
               "name": "hot beverage",
-              "keywords": [
-                "beverage",
-                "cafe",
-                "caffeine",
-                "chai",
-                "coffee",
-                "drink",
-                "hot",
-                "morning",
-                "steaming",
-                "tea"
-              ]
+              "keywords": ["beverage", "cafe", "caffeine", "chai", "coffee", "drink", "hot", "morning", "steaming", "tea"]
             },
             {
               "codepoint": "U+1FAD6",
@@ -9541,28 +4396,12 @@
             {
               "codepoint": "U+1F375",
               "name": "teacup without handle",
-              "keywords": [
-                "beverage",
-                "cup",
-                "drink",
-                "handle",
-                "oolong",
-                "tea",
-                "teacup"
-              ]
+              "keywords": ["beverage", "cup", "drink", "handle", "oolong", "tea", "teacup"]
             },
             {
               "codepoint": "U+1F376",
               "name": "sake",
-              "keywords": [
-                "bar",
-                "beverage",
-                "bottle",
-                "cup",
-                "drink",
-                "restaurant",
-                "sake"
-              ]
+              "keywords": ["bar", "beverage", "bottle", "cup", "drink", "restaurant", "sake"]
             },
             {
               "codepoint": "U+1F37E",
@@ -9572,149 +4411,47 @@
             {
               "codepoint": "U+1F377",
               "name": "wine glass",
-              "keywords": [
-                "alcohol",
-                "bar",
-                "beverage",
-                "booze",
-                "club",
-                "drink",
-                "drinking",
-                "drinks",
-                "glass",
-                "restaurant",
-                "wine"
-              ]
+              "keywords": ["alcohol", "bar", "beverage", "booze", "club", "drink", "drinking", "drinks", "glass", "restaurant", "wine"]
             },
             {
               "codepoint": "U+1F378",
               "name": "cocktail glass",
-              "keywords": [
-                "alcohol",
-                "bar",
-                "booze",
-                "club",
-                "cocktail",
-                "drink",
-                "drinking",
-                "drinks",
-                "glass",
-                "mad",
-                "martini",
-                "men"
-              ]
+              "keywords": ["alcohol", "bar", "booze", "club", "cocktail", "drink", "drinking", "drinks", "glass", "mad", "martini", "men"]
             },
             {
               "codepoint": "U+1F379",
               "name": "tropical drink",
-              "keywords": [
-                "alcohol",
-                "bar",
-                "booze",
-                "club",
-                "cocktail",
-                "drink",
-                "drinking",
-                "drinks",
-                "drunk",
-                "mai",
-                "party",
-                "tai",
-                "tropical",
-                "tropics"
-              ]
+              "keywords": ["alcohol", "bar", "booze", "club", "cocktail", "drink", "drinking", "drinks", "drunk", "mai", "party", "tai", "tropical", "tropics"]
             },
             {
               "codepoint": "U+1F37A",
               "name": "beer mug",
-              "keywords": [
-                "alcohol",
-                "ale",
-                "bar",
-                "beer",
-                "booze",
-                "drink",
-                "drinking",
-                "drinks",
-                "mug",
-                "octoberfest",
-                "oktoberfest",
-                "pint",
-                "stein",
-                "summer"
-              ]
+              "keywords": ["alcohol", "ale", "bar", "beer", "booze", "drink", "drinking", "drinks", "mug", "octoberfest", "oktoberfest", "pint", "stein", "summer"]
             },
             {
               "codepoint": "U+1F37B",
               "name": "clinking beer mugs",
-              "keywords": [
-                "alcohol",
-                "bar",
-                "beer",
-                "booze",
-                "bottoms",
-                "cheers",
-                "clink",
-                "clinking",
-                "drinking",
-                "drinks",
-                "mugs"
-              ]
+              "keywords": ["alcohol", "bar", "beer", "booze", "bottoms", "cheers", "clink", "clinking", "drinking", "drinks", "mugs"]
             },
             {
               "codepoint": "U+1F942",
               "name": "clinking glasses",
-              "keywords": [
-                "celebrate",
-                "clink",
-                "clinking",
-                "drink",
-                "glass",
-                "glasses"
-              ]
+              "keywords": ["celebrate", "clink", "clinking", "drink", "glass", "glasses"]
             },
             {
               "codepoint": "U+1F943",
               "name": "tumbler glass",
-              "keywords": [
-                "glass",
-                "liquor",
-                "scotch",
-                "shot",
-                "tumbler",
-                "whiskey",
-                "whisky"
-              ]
+              "keywords": ["glass", "liquor", "scotch", "shot", "tumbler", "whiskey", "whisky"]
             },
             {
               "codepoint": "U+1FAD7",
               "name": "pouring liquid",
-              "keywords": [
-                "accident",
-                "drink",
-                "empty",
-                "glass",
-                "liquid",
-                "oops",
-                "pour",
-                "pouring",
-                "spill",
-                "water"
-              ]
+              "keywords": ["accident", "drink", "empty", "glass", "liquid", "oops", "pour", "pouring", "spill", "water"]
             },
             {
               "codepoint": "U+1F964",
               "name": "cup with straw",
-              "keywords": [
-                "cup",
-                "drink",
-                "juice",
-                "malt",
-                "soda",
-                "soft",
-                "straw",
-                "water"
-              ]
+              "keywords": ["cup", "drink", "juice", "malt", "soda", "soft", "straw", "water"]
             },
             {
               "codepoint": "U+1F9CB",
@@ -9754,24 +4491,7 @@
             {
               "codepoint": "U+1F374",
               "name": "fork and knife",
-              "keywords": [
-                "breakfast",
-                "breaky",
-                "cooking",
-                "cutlery",
-                "delicious",
-                "dinner",
-                "eat",
-                "feed",
-                "food",
-                "fork",
-                "hungry",
-                "knife",
-                "lunch",
-                "restaurant",
-                "yum",
-                "yummy"
-              ]
+              "keywords": ["breakfast", "breaky", "cooking", "cutlery", "delicious", "dinner", "eat", "feed", "food", "fork", "hungry", "knife", "lunch", "restaurant", "yum", "yummy"]
             },
             {
               "codepoint": "U+1F944",
@@ -9781,42 +4501,17 @@
             {
               "codepoint": "U+1F52A",
               "name": "kitchen knife",
-              "keywords": [
-                "chef",
-                "cooking",
-                "hocho",
-                "kitchen",
-                "knife",
-                "tool",
-                "weapon"
-              ]
+              "keywords": ["chef", "cooking", "hocho", "kitchen", "knife", "tool", "weapon"]
             },
             {
               "codepoint": "U+1FAD9",
               "name": "jar",
-              "keywords": [
-                "condiment",
-                "container",
-                "empty",
-                "jar",
-                "nothing",
-                "sauce",
-                "store"
-              ]
+              "keywords": ["condiment", "container", "empty", "jar", "nothing", "sauce", "store"]
             },
             {
               "codepoint": "U+1F3FA",
               "name": "amphora",
-              "keywords": [
-                "amphora",
-                "Aquarius",
-                "cooking",
-                "drink",
-                "jug",
-                "tool",
-                "weapon",
-                "zodiac"
-              ]
+              "keywords": ["amphora", "Aquarius", "cooking", "drink", "jug", "tool", "weapon", "zodiac"]
             }
           ]
         }
@@ -9831,15 +4526,7 @@
             {
               "codepoint": "U+1F30D",
               "name": "globe showing Europe-Africa",
-              "keywords": [
-                "Africa",
-                "earth",
-                "Europe",
-                "Europe-Africa",
-                "globe",
-                "showing",
-                "world"
-              ]
+              "keywords": ["Africa", "earth", "Europe", "Europe-Africa", "globe", "showing", "world"]
             },
             {
               "codepoint": "U+1F30E",
@@ -9849,28 +4536,12 @@
             {
               "codepoint": "U+1F30F",
               "name": "globe showing Asia-Australia",
-              "keywords": [
-                "Asia",
-                "Asia-Australia",
-                "Australia",
-                "earth",
-                "globe",
-                "showing",
-                "world"
-              ]
+              "keywords": ["Asia", "Asia-Australia", "Australia", "earth", "globe", "showing", "world"]
             },
             {
               "codepoint": "U+1F310",
               "name": "globe with meridians",
-              "keywords": [
-                "earth",
-                "globe",
-                "internet",
-                "meridians",
-                "web",
-                "world",
-                "worldwide"
-              ]
+              "keywords": ["earth", "globe", "internet", "meridians", "web", "world", "worldwide"]
             },
             {
               "codepoint": "U+1F5FA",
@@ -9885,13 +4556,7 @@
             {
               "codepoint": "U+1F9ED",
               "name": "compass",
-              "keywords": [
-                "compass",
-                "direction",
-                "magnetic",
-                "navigation",
-                "orienteering"
-              ]
+              "keywords": ["compass", "direction", "magnetic", "navigation", "orienteering"]
             }
           ]
         },
@@ -9971,14 +4636,7 @@
             {
               "codepoint": "U+1FAA8",
               "name": "rock",
-              "keywords": [
-                "boulder",
-                "heavy",
-                "rock",
-                "solid",
-                "stone",
-                "tough"
-              ]
+              "keywords": ["boulder", "heavy", "rock", "solid", "stone", "tough"]
             },
             {
               "codepoint": "U+1FAB5",
@@ -9988,14 +4646,7 @@
             {
               "codepoint": "U+1F6D6",
               "name": "hut",
-              "keywords": [
-                "home",
-                "house",
-                "hut",
-                "roundhouse",
-                "shelter",
-                "yurt"
-              ]
+              "keywords": ["home", "house", "hut", "roundhouse", "shelter", "yurt"]
             },
             {
               "codepoint": "U+1F3D8",
@@ -10010,37 +4661,12 @@
             {
               "codepoint": "U+1F3E0",
               "name": "house",
-              "keywords": [
-                "building",
-                "country",
-                "heart",
-                "home",
-                "house",
-                "ranch",
-                "settle",
-                "simple",
-                "suburban",
-                "suburbia",
-                "where"
-              ]
+              "keywords": ["building", "country", "heart", "home", "house", "ranch", "settle", "simple", "suburban", "suburbia", "where"]
             },
             {
               "codepoint": "U+1F3E1",
               "name": "house with garden",
-              "keywords": [
-                "building",
-                "country",
-                "garden",
-                "heart",
-                "home",
-                "house",
-                "ranch",
-                "settle",
-                "simple",
-                "suburban",
-                "suburbia",
-                "where"
-              ]
+              "keywords": ["building", "country", "garden", "heart", "home", "house", "ranch", "settle", "simple", "suburban", "suburbia", "where"]
             },
             {
               "codepoint": "U+1F3E2",
@@ -10110,13 +4736,7 @@
             {
               "codepoint": "U+1F492",
               "name": "wedding",
-              "keywords": [
-                "chapel",
-                "hitched",
-                "nuptials",
-                "romance",
-                "wedding"
-              ]
+              "keywords": ["chapel", "hitched", "nuptials", "romance", "wedding"]
             },
             {
               "codepoint": "U+1F5FC",
@@ -10126,16 +4746,7 @@
             {
               "codepoint": "U+1F5FD",
               "name": "Statue of Liberty",
-              "keywords": [
-                "liberty",
-                "Liberty",
-                "new",
-                "ny",
-                "nyc",
-                "statue",
-                "Statue",
-                "york"
-              ]
+              "keywords": ["liberty", "Liberty", "new", "ny", "nyc", "statue", "Statue", "york"]
             }
           ]
         },
@@ -10145,14 +4756,7 @@
             {
               "codepoint": "U+26EA",
               "name": "church",
-              "keywords": [
-                "bless",
-                "chapel",
-                "Christian",
-                "church",
-                "cross",
-                "religion"
-              ]
+              "keywords": ["bless", "chapel", "Christian", "church", "cross", "religion"]
             },
             {
               "codepoint": "U+1F54C",
@@ -10167,14 +4771,7 @@
             {
               "codepoint": "U+1F54D",
               "name": "synagogue",
-              "keywords": [
-                "Jew",
-                "Jewish",
-                "judaism",
-                "religion",
-                "synagogue",
-                "temple"
-              ]
+              "keywords": ["Jew", "Jewish", "judaism", "religion", "synagogue", "temple"]
             },
             {
               "codepoint": "U+26E9",
@@ -10184,14 +4781,7 @@
             {
               "codepoint": "U+1F54B",
               "name": "kaaba",
-              "keywords": [
-                "hajj",
-                "islam",
-                "kaaba",
-                "Muslim",
-                "religion",
-                "umrah"
-              ]
+              "keywords": ["hajj", "islam", "kaaba", "Muslim", "religion", "umrah"]
             }
           ]
         },
@@ -10236,17 +4826,7 @@
             {
               "codepoint": "U+1F306",
               "name": "cityscape at dusk",
-              "keywords": [
-                "at",
-                "building",
-                "city",
-                "cityscape",
-                "dusk",
-                "evening",
-                "landscape",
-                "sun",
-                "sunset"
-              ]
+              "keywords": ["at", "building", "city", "cityscape", "dusk", "evening", "landscape", "sun", "sunset"]
             },
             {
               "codepoint": "U+1F307",
@@ -10271,16 +4851,7 @@
             {
               "codepoint": "U+1F6DD",
               "name": "playground slide",
-              "keywords": [
-                "amusement",
-                "park",
-                "play",
-                "playground",
-                "playing",
-                "slide",
-                "sliding",
-                "theme"
-              ]
+              "keywords": ["amusement", "park", "play", "playground", "playing", "slide", "sliding", "theme"]
             },
             {
               "codepoint": "U+1F3A1",
@@ -10310,54 +4881,22 @@
             {
               "codepoint": "U+1F682",
               "name": "locomotive",
-              "keywords": [
-                "caboose",
-                "engine",
-                "locomotive",
-                "railway",
-                "steam",
-                "train",
-                "trains",
-                "travel"
-              ]
+              "keywords": ["caboose", "engine", "locomotive", "railway", "steam", "train", "trains", "travel"]
             },
             {
               "codepoint": "U+1F683",
               "name": "railway car",
-              "keywords": [
-                "car",
-                "electric",
-                "railway",
-                "train",
-                "tram",
-                "travel",
-                "trolleybus"
-              ]
+              "keywords": ["car", "electric", "railway", "train", "tram", "travel", "trolleybus"]
             },
             {
               "codepoint": "U+1F684",
               "name": "high-speed train",
-              "keywords": [
-                "high-speed",
-                "railway",
-                "shinkansen",
-                "speed",
-                "train"
-              ]
+              "keywords": ["high-speed", "railway", "shinkansen", "speed", "train"]
             },
             {
               "codepoint": "U+1F685",
               "name": "bullet train",
-              "keywords": [
-                "bullet",
-                "high-speed",
-                "nose",
-                "railway",
-                "shinkansen",
-                "speed",
-                "train",
-                "travel"
-              ]
+              "keywords": ["bullet", "high-speed", "nose", "railway", "shinkansen", "speed", "train", "travel"]
             },
             {
               "codepoint": "U+1F686",
@@ -10442,29 +4981,12 @@
             {
               "codepoint": "U+1F695",
               "name": "taxi",
-              "keywords": [
-                "cab",
-                "cabbie",
-                "car",
-                "drive",
-                "taxi",
-                "vehicle",
-                "yellow"
-              ]
+              "keywords": ["cab", "cabbie", "car", "drive", "taxi", "vehicle", "yellow"]
             },
             {
               "codepoint": "U+1F696",
               "name": "oncoming taxi",
-              "keywords": [
-                "cab",
-                "cabbie",
-                "cars",
-                "drove",
-                "hail",
-                "oncoming",
-                "taxi",
-                "yellow"
-              ]
+              "keywords": ["cab", "cabbie", "cars", "drove", "hail", "oncoming", "taxi", "yellow"]
             },
             {
               "codepoint": "U+1F697",
@@ -10474,40 +4996,17 @@
             {
               "codepoint": "U+1F698",
               "name": "oncoming automobile",
-              "keywords": [
-                "automobile",
-                "car",
-                "cars",
-                "drove",
-                "oncoming",
-                "vehicle"
-              ]
+              "keywords": ["automobile", "car", "cars", "drove", "oncoming", "vehicle"]
             },
             {
               "codepoint": "U+1F699",
               "name": "sport utility vehicle",
-              "keywords": [
-                "car",
-                "drive",
-                "recreational",
-                "sport",
-                "sportutility",
-                "utility",
-                "vehicle"
-              ]
+              "keywords": ["car", "drive", "recreational", "sport", "sportutility", "utility", "vehicle"]
             },
             {
               "codepoint": "U+1F6FB",
               "name": "pickup truck",
-              "keywords": [
-                "automobile",
-                "car",
-                "flatbed",
-                "pick-up",
-                "pickup",
-                "transportation",
-                "truck"
-              ]
+              "keywords": ["automobile", "car", "flatbed", "pick-up", "pickup", "transportation", "truck"]
             },
             {
               "codepoint": "U+1F69A",
@@ -10517,16 +5016,7 @@
             {
               "codepoint": "U+1F69B",
               "name": "articulated lorry",
-              "keywords": [
-                "articulated",
-                "car",
-                "drive",
-                "lorry",
-                "move",
-                "semi",
-                "truck",
-                "vehicle"
-              ]
+              "keywords": ["articulated", "car", "drive", "lorry", "move", "semi", "truck", "vehicle"]
             },
             {
               "codepoint": "U+1F69C",
@@ -10566,18 +5056,7 @@
             {
               "codepoint": "U+1F6B2",
               "name": "bicycle",
-              "keywords": [
-                "bicycle",
-                "bike",
-                "class",
-                "cycle",
-                "cycling",
-                "cyclist",
-                "gang",
-                "ride",
-                "spin",
-                "spinning"
-              ]
+              "keywords": ["bicycle", "bike", "class", "cycle", "cycling", "cyclist", "gang", "ride", "spin", "spinning"]
             },
             {
               "codepoint": "U+1F6F4",
@@ -10617,15 +5096,7 @@
             {
               "codepoint": "U+26FD",
               "name": "fuel pump",
-              "keywords": [
-                "diesel",
-                "fuel",
-                "fuelpump",
-                "gas",
-                "gasoline",
-                "pump",
-                "station"
-              ]
+              "keywords": ["diesel", "fuel", "fuelpump", "gas", "gasoline", "pump", "station"]
             },
             {
               "codepoint": "U+1F6DE",
@@ -10635,44 +5106,17 @@
             {
               "codepoint": "U+1F6A8",
               "name": "police car light",
-              "keywords": [
-                "alarm",
-                "alert",
-                "beacon",
-                "car",
-                "emergency",
-                "light",
-                "police",
-                "revolving",
-                "siren"
-              ]
+              "keywords": ["alarm", "alert", "beacon", "car", "emergency", "light", "police", "revolving", "siren"]
             },
             {
               "codepoint": "U+1F6A5",
               "name": "horizontal traffic light",
-              "keywords": [
-                "horizontal",
-                "intersection",
-                "light",
-                "signal",
-                "stop",
-                "stoplight",
-                "traffic"
-              ]
+              "keywords": ["horizontal", "intersection", "light", "signal", "stop", "stoplight", "traffic"]
             },
             {
               "codepoint": "U+1F6A6",
               "name": "vertical traffic light",
-              "keywords": [
-                "drove",
-                "intersection",
-                "light",
-                "signal",
-                "stop",
-                "stoplight",
-                "traffic",
-                "vertical"
-              ]
+              "keywords": ["drove", "intersection", "light", "signal", "stop", "stoplight", "traffic", "vertical"]
             },
             {
               "codepoint": "U+1F6D1",
@@ -10697,31 +5141,12 @@
             {
               "codepoint": "U+1F6DF",
               "name": "ring buoy",
-              "keywords": [
-                "buoy",
-                "float",
-                "life",
-                "lifesaver",
-                "preserver",
-                "rescue",
-                "ring",
-                "safety",
-                "save",
-                "saver",
-                "swim"
-              ]
+              "keywords": ["buoy", "float", "life", "lifesaver", "preserver", "rescue", "ring", "safety", "save", "saver", "swim"]
             },
             {
               "codepoint": "U+26F5",
               "name": "sailboat",
-              "keywords": [
-                "boat",
-                "resort",
-                "sailboat",
-                "sailing",
-                "sea",
-                "yacht"
-              ]
+              "keywords": ["boat", "resort", "sailboat", "sailing", "sea", "yacht"]
             },
             {
               "codepoint": "U+1F6F6",
@@ -10731,16 +5156,7 @@
             {
               "codepoint": "U+1F6A4",
               "name": "speedboat",
-              "keywords": [
-                "billionaire",
-                "boat",
-                "lake",
-                "luxury",
-                "millionaire",
-                "speedboat",
-                "summer",
-                "travel"
-              ]
+              "keywords": ["billionaire", "boat", "lake", "luxury", "millionaire", "speedboat", "summer", "travel"]
             },
             {
               "codepoint": "U+1F6F3",
@@ -10770,15 +5186,7 @@
             {
               "codepoint": "U+2708",
               "name": "airplane",
-              "keywords": [
-                "aeroplane",
-                "airplane",
-                "fly",
-                "flying",
-                "jet",
-                "plane",
-                "travel"
-              ]
+              "keywords": ["aeroplane", "airplane", "fly", "flying", "jet", "plane", "travel"]
             },
             {
               "codepoint": "U+1F6E9",
@@ -10788,27 +5196,12 @@
             {
               "codepoint": "U+1F6EB",
               "name": "airplane departure",
-              "keywords": [
-                "aeroplane",
-                "airplane",
-                "check-in",
-                "departure",
-                "departures",
-                "plane"
-              ]
+              "keywords": ["aeroplane", "airplane", "check-in", "departure", "departures", "plane"]
             },
             {
               "codepoint": "U+1F6EC",
               "name": "airplane arrival",
-              "keywords": [
-                "aeroplane",
-                "airplane",
-                "arrival",
-                "arrivals",
-                "arriving",
-                "landing",
-                "plane"
-              ]
+              "keywords": ["aeroplane", "airplane", "arrival", "arrivals", "arriving", "landing", "plane"]
             },
             {
               "codepoint": "U+1FA82",
@@ -10823,13 +5216,7 @@
             {
               "codepoint": "U+1F681",
               "name": "helicopter",
-              "keywords": [
-                "copter",
-                "helicopter",
-                "roflcopter",
-                "travel",
-                "vehicle"
-              ]
+              "keywords": ["copter", "helicopter", "roflcopter", "travel", "vehicle"]
             },
             {
               "codepoint": "U+1F69F",
@@ -10839,26 +5226,12 @@
             {
               "codepoint": "U+1F6A0",
               "name": "mountain cableway",
-              "keywords": [
-                "cable",
-                "cableway",
-                "gondola",
-                "lift",
-                "mountain",
-                "ski"
-              ]
+              "keywords": ["cable", "cableway", "gondola", "lift", "mountain", "ski"]
             },
             {
               "codepoint": "U+1F6A1",
               "name": "aerial tramway",
-              "keywords": [
-                "aerial",
-                "cable",
-                "car",
-                "gondola",
-                "ropeway",
-                "tramway"
-              ]
+              "keywords": ["aerial", "cable", "car", "gondola", "ropeway", "tramway"]
             },
             {
               "codepoint": "U+1F6F0",
@@ -10873,14 +5246,7 @@
             {
               "codepoint": "U+1F6F8",
               "name": "flying saucer",
-              "keywords": [
-                "aliens",
-                "extra",
-                "flying",
-                "saucer",
-                "terrestrial",
-                "UFO"
-              ]
+              "keywords": ["aliens", "extra", "flying", "saucer", "terrestrial", "UFO"]
             }
           ]
         },
@@ -10895,14 +5261,7 @@
             {
               "codepoint": "U+1F9F3",
               "name": "luggage",
-              "keywords": [
-                "bag",
-                "luggage",
-                "packing",
-                "roller",
-                "suitcase",
-                "travel"
-              ]
+              "keywords": ["bag", "luggage", "packing", "roller", "suitcase", "travel"]
             }
           ]
         },
@@ -10917,17 +5276,7 @@
             {
               "codepoint": "U+23F3",
               "name": "hourglass not done",
-              "keywords": [
-                "done",
-                "flowing",
-                "hourglass",
-                "hours",
-                "not",
-                "sand",
-                "timer",
-                "waiting",
-                "yolo"
-              ]
+              "keywords": ["done", "flowing", "hourglass", "hours", "not", "sand", "timer", "waiting", "yolo"]
             },
             {
               "codepoint": "U+231A",
@@ -10937,15 +5286,7 @@
             {
               "codepoint": "U+23F0",
               "name": "alarm clock",
-              "keywords": [
-                "alarm",
-                "clock",
-                "hours",
-                "hrs",
-                "late",
-                "time",
-                "waiting"
-              ]
+              "keywords": ["alarm", "clock", "hours", "hrs", "late", "time", "waiting"]
             },
             {
               "codepoint": "U+23F1",
@@ -10970,16 +5311,7 @@
             {
               "codepoint": "U+1F567",
               "name": "twelve-thirty",
-              "keywords": [
-                "12",
-                "12:30",
-                "30",
-                "clock",
-                "thirty",
-                "time",
-                "twelve",
-                "twelve-thirty"
-              ]
+              "keywords": ["12", "12:30", "30", "clock", "thirty", "time", "twelve", "twelve-thirty"]
             },
             {
               "codepoint": "U+1F550",
@@ -10989,16 +5321,7 @@
             {
               "codepoint": "U+1F55C",
               "name": "one-thirty",
-              "keywords": [
-                "1",
-                "1:30",
-                "30",
-                "clock",
-                "one",
-                "one-thirty",
-                "thirty",
-                "time"
-              ]
+              "keywords": ["1", "1:30", "30", "clock", "one", "one-thirty", "thirty", "time"]
             },
             {
               "codepoint": "U+1F551",
@@ -11008,16 +5331,7 @@
             {
               "codepoint": "U+1F55D",
               "name": "two-thirty",
-              "keywords": [
-                "2",
-                "2:30",
-                "30",
-                "clock",
-                "thirty",
-                "time",
-                "two",
-                "two-thirty"
-              ]
+              "keywords": ["2", "2:30", "30", "clock", "thirty", "time", "two", "two-thirty"]
             },
             {
               "codepoint": "U+1F552",
@@ -11027,16 +5341,7 @@
             {
               "codepoint": "U+1F55E",
               "name": "three-thirty",
-              "keywords": [
-                "3",
-                "3:30",
-                "30",
-                "clock",
-                "thirty",
-                "three",
-                "three-thirty",
-                "time"
-              ]
+              "keywords": ["3", "3:30", "30", "clock", "thirty", "three", "three-thirty", "time"]
             },
             {
               "codepoint": "U+1F553",
@@ -11046,16 +5351,7 @@
             {
               "codepoint": "U+1F55F",
               "name": "four-thirty",
-              "keywords": [
-                "30",
-                "4",
-                "4:30",
-                "clock",
-                "four",
-                "four-thirty",
-                "thirty",
-                "time"
-              ]
+              "keywords": ["30", "4", "4:30", "clock", "four", "four-thirty", "thirty", "time"]
             },
             {
               "codepoint": "U+1F554",
@@ -11065,16 +5361,7 @@
             {
               "codepoint": "U+1F560",
               "name": "five-thirty",
-              "keywords": [
-                "30",
-                "5",
-                "5:30",
-                "clock",
-                "five",
-                "five-thirty",
-                "thirty",
-                "time"
-              ]
+              "keywords": ["30", "5", "5:30", "clock", "five", "five-thirty", "thirty", "time"]
             },
             {
               "codepoint": "U+1F555",
@@ -11084,15 +5371,7 @@
             {
               "codepoint": "U+1F561",
               "name": "six-thirty",
-              "keywords": [
-                "30",
-                "6",
-                "6:30",
-                "clock",
-                "six",
-                "six-thirty",
-                "thirty"
-              ]
+              "keywords": ["30", "6", "6:30", "clock", "six", "six-thirty", "thirty"]
             },
             {
               "codepoint": "U+1F556",
@@ -11102,15 +5381,7 @@
             {
               "codepoint": "U+1F562",
               "name": "seven-thirty",
-              "keywords": [
-                "30",
-                "7",
-                "7:30",
-                "clock",
-                "seven",
-                "seven-thirty",
-                "thirty"
-              ]
+              "keywords": ["30", "7", "7:30", "clock", "seven", "seven-thirty", "thirty"]
             },
             {
               "codepoint": "U+1F557",
@@ -11120,16 +5391,7 @@
             {
               "codepoint": "U+1F563",
               "name": "eight-thirty",
-              "keywords": [
-                "30",
-                "8",
-                "8:30",
-                "clock",
-                "eight",
-                "eight-thirty",
-                "thirty",
-                "time"
-              ]
+              "keywords": ["30", "8", "8:30", "clock", "eight", "eight-thirty", "thirty", "time"]
             },
             {
               "codepoint": "U+1F558",
@@ -11139,16 +5401,7 @@
             {
               "codepoint": "U+1F564",
               "name": "nine-thirty",
-              "keywords": [
-                "30",
-                "9",
-                "9:30",
-                "clock",
-                "nine",
-                "nine-thirty",
-                "thirty",
-                "time"
-              ]
+              "keywords": ["30", "9", "9:30", "clock", "nine", "nine-thirty", "thirty", "time"]
             },
             {
               "codepoint": "U+1F559",
@@ -11158,16 +5411,7 @@
             {
               "codepoint": "U+1F565",
               "name": "ten-thirty",
-              "keywords": [
-                "10",
-                "10:30",
-                "30",
-                "clock",
-                "ten",
-                "ten-thirty",
-                "thirty",
-                "time"
-              ]
+              "keywords": ["10", "10:30", "30", "clock", "ten", "ten-thirty", "thirty", "time"]
             },
             {
               "codepoint": "U+1F55A",
@@ -11177,16 +5421,7 @@
             {
               "codepoint": "U+1F566",
               "name": "eleven-thirty",
-              "keywords": [
-                "11",
-                "11:30",
-                "30",
-                "clock",
-                "eleven",
-                "eleven-thirty",
-                "thirty",
-                "time"
-              ]
+              "keywords": ["11", "11:30", "30", "clock", "eleven", "eleven-thirty", "thirty", "time"]
             }
           ]
         },
@@ -11271,18 +5506,7 @@
             {
               "codepoint": "U+1F31E",
               "name": "sun with face",
-              "keywords": [
-                "beach",
-                "bright",
-                "day",
-                "face",
-                "heat",
-                "shine",
-                "sun",
-                "sunny",
-                "sunshine",
-                "weather"
-              ]
+              "keywords": ["beach", "bright", "day", "face", "heat", "shine", "sun", "sunny", "sunshine", "weather"]
             },
             {
               "codepoint": "U+1FA90",
@@ -11297,16 +5521,7 @@
             {
               "codepoint": "U+1F31F",
               "name": "glowing star",
-              "keywords": [
-                "glittery",
-                "glow",
-                "glowing",
-                "night",
-                "shining",
-                "sparkle",
-                "star",
-                "win"
-              ]
+              "keywords": ["glittery", "glow", "glowing", "night", "shining", "sparkle", "star", "win"]
             },
             {
               "codepoint": "U+1F320",
@@ -11331,13 +5546,7 @@
             {
               "codepoint": "U+26C8",
               "name": "cloud with lightning and rain",
-              "keywords": [
-                "cloud",
-                "lightning",
-                "rain",
-                "thunder",
-                "thunderstorm"
-              ]
+              "keywords": ["cloud", "lightning", "rain", "thunder", "thunderstorm"]
             },
             {
               "codepoint": "U+1F324",
@@ -11387,36 +5596,12 @@
             {
               "codepoint": "U+1F300",
               "name": "cyclone",
-              "keywords": [
-                "cyclone",
-                "dizzy",
-                "hurricane",
-                "twister",
-                "typhoon",
-                "weather"
-              ]
+              "keywords": ["cyclone", "dizzy", "hurricane", "twister", "typhoon", "weather"]
             },
             {
               "codepoint": "U+1F308",
               "name": "rainbow",
-              "keywords": [
-                "gay",
-                "genderqueer",
-                "glbt",
-                "glbtq",
-                "lesbian",
-                "lgbt",
-                "lgbtq",
-                "lgbtqia",
-                "nature",
-                "pride",
-                "queer",
-                "rain",
-                "rainbow",
-                "trans",
-                "transgender",
-                "weather"
-              ]
+              "keywords": ["gay", "genderqueer", "glbt", "glbtq", "lesbian", "lgbt", "lgbtq", "lgbtqia", "nature", "pride", "queer", "rain", "rainbow", "trans", "transgender", "weather"]
             },
             {
               "codepoint": "U+1F302",
@@ -11431,14 +5616,7 @@
             {
               "codepoint": "U+2614",
               "name": "umbrella with rain drops",
-              "keywords": [
-                "clothing",
-                "drop",
-                "drops",
-                "rain",
-                "umbrella",
-                "weather"
-              ]
+              "keywords": ["clothing", "drop", "drops", "rain", "umbrella", "weather"]
             },
             {
               "codepoint": "U+26F1",
@@ -11448,18 +5626,7 @@
             {
               "codepoint": "U+26A1",
               "name": "high voltage",
-              "keywords": [
-                "danger",
-                "electric",
-                "electricity",
-                "high",
-                "lightning",
-                "nature",
-                "thunder",
-                "thunderbolt",
-                "voltage",
-                "zap"
-              ]
+              "keywords": ["danger", "electric", "electricity", "high", "lightning", "nature", "thunder", "thunderbolt", "voltage", "zap"]
             },
             {
               "codepoint": "U+2744",
@@ -11484,45 +5651,17 @@
             {
               "codepoint": "U+1F525",
               "name": "fire",
-              "keywords": [
-                "af",
-                "burn",
-                "fire",
-                "flame",
-                "hot",
-                "lit",
-                "litaf",
-                "tool"
-              ]
+              "keywords": ["af", "burn", "fire", "flame", "hot", "lit", "litaf", "tool"]
             },
             {
               "codepoint": "U+1F4A7",
               "name": "droplet",
-              "keywords": [
-                "cold",
-                "comic",
-                "drop",
-                "droplet",
-                "nature",
-                "sad",
-                "sweat",
-                "tear",
-                "water",
-                "weather"
-              ]
+              "keywords": ["cold", "comic", "drop", "droplet", "nature", "sad", "sweat", "tear", "water", "weather"]
             },
             {
               "codepoint": "U+1F30A",
               "name": "water wave",
-              "keywords": [
-                "nature",
-                "ocean",
-                "surf",
-                "surfer",
-                "surfing",
-                "water",
-                "wave"
-              ]
+              "keywords": ["nature", "ocean", "surf", "surfer", "surfing", "water", "wave"]
             }
           ]
         }
@@ -11537,14 +5676,7 @@
             {
               "codepoint": "U+1F383",
               "name": "jack-o-lantern",
-              "keywords": [
-                "celebration",
-                "halloween",
-                "jack",
-                "jack-o-lantern",
-                "lantern",
-                "pumpkin"
-              ]
+              "keywords": ["celebration", "halloween", "jack", "jack-o-lantern", "lantern", "pumpkin"]
             },
             {
               "codepoint": "U+1F384",
@@ -11554,39 +5686,17 @@
             {
               "codepoint": "U+1F386",
               "name": "fireworks",
-              "keywords": [
-                "boom",
-                "celebration",
-                "entertainment",
-                "fireworks",
-                "yolo"
-              ]
+              "keywords": ["boom", "celebration", "entertainment", "fireworks", "yolo"]
             },
             {
               "codepoint": "U+1F387",
               "name": "sparkler",
-              "keywords": [
-                "boom",
-                "celebration",
-                "fireworks",
-                "sparkle",
-                "sparkler"
-              ]
+              "keywords": ["boom", "celebration", "fireworks", "sparkle", "sparkler"]
             },
             {
               "codepoint": "U+1F9E8",
               "name": "firecracker",
-              "keywords": [
-                "dynamite",
-                "explosive",
-                "fire",
-                "firecracker",
-                "fireworks",
-                "light",
-                "pop",
-                "popping",
-                "spark"
-              ]
+              "keywords": ["dynamite", "explosive", "fire", "firecracker", "fireworks", "light", "pop", "popping", "spark"]
             },
             {
               "codepoint": "U+2728",
@@ -11601,64 +5711,27 @@
             {
               "codepoint": "U+1F389",
               "name": "party popper",
-              "keywords": [
-                "awesome",
-                "birthday",
-                "celebrate",
-                "celebration",
-                "excited",
-                "hooray",
-                "party",
-                "popper",
-                "tada",
-                "woohoo"
-              ]
+              "keywords": ["awesome", "birthday", "celebrate", "celebration", "excited", "hooray", "party", "popper", "tada", "woohoo"]
             },
             {
               "codepoint": "U+1F38A",
               "name": "confetti ball",
-              "keywords": [
-                "ball",
-                "celebrate",
-                "celebration",
-                "confetti",
-                "party",
-                "woohoo"
-              ]
+              "keywords": ["ball", "celebrate", "celebration", "confetti", "party", "woohoo"]
             },
             {
               "codepoint": "U+1F38B",
               "name": "tanabata tree",
-              "keywords": [
-                "banner",
-                "celebration",
-                "Japanese",
-                "tanabata",
-                "tree"
-              ]
+              "keywords": ["banner", "celebration", "Japanese", "tanabata", "tree"]
             },
             {
               "codepoint": "U+1F38D",
               "name": "pine decoration",
-              "keywords": [
-                "bamboo",
-                "celebration",
-                "decoration",
-                "Japanese",
-                "pine",
-                "plant"
-              ]
+              "keywords": ["bamboo", "celebration", "decoration", "Japanese", "pine", "plant"]
             },
             {
               "codepoint": "U+1F38E",
               "name": "Japanese dolls",
-              "keywords": [
-                "celebration",
-                "doll",
-                "dolls",
-                "festival",
-                "Japanese"
-              ]
+              "keywords": ["celebration", "doll", "dolls", "festival", "Japanese"]
             },
             {
               "codepoint": "U+1F38F",
@@ -11678,17 +5751,7 @@
             {
               "codepoint": "U+1F9E7",
               "name": "red envelope",
-              "keywords": [
-                "envelope",
-                "gift",
-                "good",
-                "hóngbāo",
-                "lai",
-                "luck",
-                "money",
-                "red",
-                "see"
-              ]
+              "keywords": ["envelope", "gift", "good", "hóngbāo", "lai", "luck", "money", "red", "see"]
             },
             {
               "codepoint": "U+1F380",
@@ -11698,17 +5761,7 @@
             {
               "codepoint": "U+1F381",
               "name": "wrapped gift",
-              "keywords": [
-                "birthday",
-                "bow",
-                "box",
-                "celebration",
-                "christmas",
-                "gift",
-                "present",
-                "surprise",
-                "wrapped"
-              ]
+              "keywords": ["birthday", "bow", "box", "celebration", "christmas", "gift", "present", "surprise", "wrapped"]
             },
             {
               "codepoint": "U+1F397",
@@ -11738,17 +5791,7 @@
             {
               "codepoint": "U+1F3C6",
               "name": "trophy",
-              "keywords": [
-                "champion",
-                "champs",
-                "prize",
-                "slay",
-                "sport",
-                "trophy",
-                "victory",
-                "win",
-                "winning"
-              ]
+              "keywords": ["champion", "champs", "prize", "slay", "sport", "trophy", "victory", "win", "winning"]
             },
             {
               "codepoint": "U+1F3C5",
@@ -11803,14 +5846,7 @@
             {
               "codepoint": "U+1F3C8",
               "name": "american football",
-              "keywords": [
-                "american",
-                "ball",
-                "bowl",
-                "football",
-                "sport",
-                "super"
-              ]
+              "keywords": ["american", "ball", "bowl", "football", "sport", "super"]
             },
             {
               "codepoint": "U+1F3C9",
@@ -11855,28 +5891,12 @@
             {
               "codepoint": "U+1F3D3",
               "name": "ping pong",
-              "keywords": [
-                "ball",
-                "bat",
-                "game",
-                "paddle",
-                "ping",
-                "pingpong",
-                "pong",
-                "table",
-                "tennis"
-              ]
+              "keywords": ["ball", "bat", "game", "paddle", "ping", "pingpong", "pong", "table", "tennis"]
             },
             {
               "codepoint": "U+1F3F8",
               "name": "badminton",
-              "keywords": [
-                "badminton",
-                "birdie",
-                "game",
-                "racquet",
-                "shuttlecock"
-              ]
+              "keywords": ["badminton", "birdie", "game", "racquet", "shuttlecock"]
             },
             {
               "codepoint": "U+1F94A",
@@ -11886,14 +5906,7 @@
             {
               "codepoint": "U+1F94B",
               "name": "martial arts uniform",
-              "keywords": [
-                "arts",
-                "judo",
-                "karate",
-                "martial",
-                "taekwondo",
-                "uniform"
-              ]
+              "keywords": ["arts", "judo", "karate", "martial", "taekwondo", "uniform"]
             },
             {
               "codepoint": "U+1F945",
@@ -11933,14 +5946,7 @@
             {
               "codepoint": "U+1F6F7",
               "name": "sled",
-              "keywords": [
-                "luge",
-                "sled",
-                "sledge",
-                "sleigh",
-                "snow",
-                "toboggan"
-              ]
+              "keywords": ["luge", "sled", "sledge", "sleigh", "snow", "toboggan"]
             },
             {
               "codepoint": "U+1F94C",
@@ -11955,16 +5961,7 @@
             {
               "codepoint": "U+1F3AF",
               "name": "bullseye",
-              "keywords": [
-                "bull",
-                "bullseye",
-                "dart",
-                "direct",
-                "entertainment",
-                "game",
-                "hit",
-                "target"
-              ]
+              "keywords": ["bull", "bullseye", "dart", "direct", "entertainment", "game", "hit", "target"]
             },
             {
               "codepoint": "U+1FA80",
@@ -11979,44 +5976,17 @@
             {
               "codepoint": "U+1F52B",
               "name": "water pistol",
-              "keywords": [
-                "gun",
-                "handgun",
-                "pistol",
-                "revolver",
-                "tool",
-                "water",
-                "weapon"
-              ]
+              "keywords": ["gun", "handgun", "pistol", "revolver", "tool", "water", "weapon"]
             },
             {
               "codepoint": "U+1F3B1",
               "name": "pool 8 ball",
-              "keywords": [
-                "8",
-                "8ball",
-                "ball",
-                "billiard",
-                "eight",
-                "game",
-                "pool"
-              ]
+              "keywords": ["8", "8ball", "ball", "billiard", "eight", "game", "pool"]
             },
             {
               "codepoint": "U+1F52E",
               "name": "crystal ball",
-              "keywords": [
-                "ball",
-                "crystal",
-                "fairy",
-                "fairytale",
-                "fantasy",
-                "fortune",
-                "future",
-                "magic",
-                "tale",
-                "tool"
-              ]
+              "keywords": ["ball", "crystal", "fairy", "fairytale", "fantasy", "fortune", "future", "magic", "tale", "tool"]
             },
             {
               "codepoint": "U+1FA84",
@@ -12036,15 +6006,7 @@
             {
               "codepoint": "U+1F3B0",
               "name": "slot machine",
-              "keywords": [
-                "casino",
-                "gamble",
-                "gambling",
-                "game",
-                "machine",
-                "slot",
-                "slots"
-              ]
+              "keywords": ["casino", "gamble", "gambling", "game", "machine", "slot", "slots"]
             },
             {
               "codepoint": "U+1F3B2",
@@ -12059,57 +6021,22 @@
             {
               "codepoint": "U+1F9F8",
               "name": "teddy bear",
-              "keywords": [
-                "bear",
-                "plaything",
-                "plush",
-                "stuffed",
-                "teddy",
-                "toy"
-              ]
+              "keywords": ["bear", "plaything", "plush", "stuffed", "teddy", "toy"]
             },
             {
               "codepoint": "U+1FA85",
               "name": "piñata",
-              "keywords": [
-                "candy",
-                "celebrate",
-                "celebration",
-                "cinco",
-                "de",
-                "festive",
-                "mayo",
-                "party",
-                "pinada",
-                "pinata",
-                "piñata"
-              ]
+              "keywords": ["candy", "celebrate", "celebration", "cinco", "de", "festive", "mayo", "party", "pinada", "pinata", "piñata"]
             },
             {
               "codepoint": "U+1FAA9",
               "name": "mirror ball",
-              "keywords": [
-                "ball",
-                "dance",
-                "disco",
-                "glitter",
-                "mirror",
-                "party"
-              ]
+              "keywords": ["ball", "dance", "disco", "glitter", "mirror", "party"]
             },
             {
               "codepoint": "U+1FA86",
               "name": "nesting dolls",
-              "keywords": [
-                "babooshka",
-                "baboushka",
-                "babushka",
-                "doll",
-                "dolls",
-                "matryoshka",
-                "nesting",
-                "russia"
-              ]
+              "keywords": ["babooshka", "baboushka", "babushka", "doll", "dolls", "matryoshka", "nesting", "russia"]
             },
             {
               "codepoint": "U+2660",
@@ -12149,14 +6076,7 @@
             {
               "codepoint": "U+1F3B4",
               "name": "flower playing cards",
-              "keywords": [
-                "card",
-                "cards",
-                "flower",
-                "game",
-                "Japanese",
-                "playing"
-              ]
+              "keywords": ["card", "cards", "flower", "game", "Japanese", "playing"]
             }
           ]
         },
@@ -12166,47 +6086,17 @@
             {
               "codepoint": "U+1F3AD",
               "name": "performing arts",
-              "keywords": [
-                "actor",
-                "actress",
-                "art",
-                "arts",
-                "entertainment",
-                "mask",
-                "performing",
-                "theater",
-                "theatre",
-                "thespian"
-              ]
+              "keywords": ["actor", "actress", "art", "arts", "entertainment", "mask", "performing", "theater", "theatre", "thespian"]
             },
             {
               "codepoint": "U+1F5BC",
               "name": "framed picture",
-              "keywords": [
-                "art",
-                "frame",
-                "framed",
-                "museum",
-                "painting",
-                "picture"
-              ]
+              "keywords": ["art", "frame", "framed", "museum", "painting", "picture"]
             },
             {
               "codepoint": "U+1F3A8",
               "name": "artist palette",
-              "keywords": [
-                "art",
-                "artist",
-                "artsy",
-                "arty",
-                "colorful",
-                "creative",
-                "entertainment",
-                "museum",
-                "painter",
-                "painting",
-                "palette"
-              ]
+              "keywords": ["art", "artist", "artsy", "arty", "colorful", "creative", "entertainment", "museum", "painter", "painting", "palette"]
             },
             {
               "codepoint": "U+1F9F5",
@@ -12216,16 +6106,7 @@
             {
               "codepoint": "U+1FAA1",
               "name": "sewing needle",
-              "keywords": [
-                "embroidery",
-                "needle",
-                "sew",
-                "sewing",
-                "stitches",
-                "sutures",
-                "tailoring",
-                "thread"
-              ]
+              "keywords": ["embroidery", "needle", "sew", "sewing", "stitches", "sutures", "tailoring", "thread"]
             },
             {
               "codepoint": "U+1F9F6",
@@ -12235,15 +6116,7 @@
             {
               "codepoint": "U+1FAA2",
               "name": "knot",
-              "keywords": [
-                "cord",
-                "knot",
-                "rope",
-                "tangled",
-                "tie",
-                "twine",
-                "twist"
-              ]
+              "keywords": ["cord", "knot", "rope", "tangled", "tie", "twine", "twist"]
             }
           ]
         }
@@ -12258,13 +6131,7 @@
             {
               "codepoint": "U+1F453",
               "name": "glasses",
-              "keywords": [
-                "clothing",
-                "eye",
-                "eyeglasses",
-                "eyewear",
-                "glasses"
-              ]
+              "keywords": ["clothing", "eye", "eyeglasses", "eyewear", "glasses"]
             },
             {
               "codepoint": "U+1F576",
@@ -12274,30 +6141,12 @@
             {
               "codepoint": "U+1F97D",
               "name": "goggles",
-              "keywords": [
-                "dive",
-                "eye",
-                "goggles",
-                "protection",
-                "scuba",
-                "swimming",
-                "welding"
-              ]
+              "keywords": ["dive", "eye", "goggles", "protection", "scuba", "swimming", "welding"]
             },
             {
               "codepoint": "U+1F97C",
               "name": "lab coat",
-              "keywords": [
-                "clothes",
-                "coat",
-                "doctor",
-                "dr",
-                "experiment",
-                "jacket",
-                "lab",
-                "scientist",
-                "white"
-              ]
+              "keywords": ["clothes", "coat", "doctor", "dr", "experiment", "jacket", "lab", "scientist", "white"]
             },
             {
               "codepoint": "U+1F9BA",
@@ -12307,48 +6156,17 @@
             {
               "codepoint": "U+1F454",
               "name": "necktie",
-              "keywords": [
-                "clothing",
-                "employed",
-                "necktie",
-                "serious",
-                "shirt",
-                "tie"
-              ]
+              "keywords": ["clothing", "employed", "necktie", "serious", "shirt", "tie"]
             },
             {
               "codepoint": "U+1F455",
               "name": "t-shirt",
-              "keywords": [
-                "blue",
-                "casual",
-                "clothes",
-                "clothing",
-                "collar",
-                "dressed",
-                "shirt",
-                "shopping",
-                "t-shirt",
-                "tshirt",
-                "weekend"
-              ]
+              "keywords": ["blue", "casual", "clothes", "clothing", "collar", "dressed", "shirt", "shopping", "t-shirt", "tshirt", "weekend"]
             },
             {
               "codepoint": "U+1F456",
               "name": "jeans",
-              "keywords": [
-                "blue",
-                "casual",
-                "clothes",
-                "clothing",
-                "denim",
-                "dressed",
-                "jeans",
-                "pants",
-                "shopping",
-                "trousers",
-                "weekend"
-              ]
+              "keywords": ["blue", "casual", "clothes", "clothing", "denim", "dressed", "jeans", "pants", "shopping", "trousers", "weekend"]
             },
             {
               "codepoint": "U+1F9E3",
@@ -12373,14 +6191,7 @@
             {
               "codepoint": "U+1F457",
               "name": "dress",
-              "keywords": [
-                "clothes",
-                "clothing",
-                "dress",
-                "dressed",
-                "fancy",
-                "shopping"
-              ]
+              "keywords": ["clothes", "clothing", "dress", "dressed", "fancy", "shopping"]
             },
             {
               "codepoint": "U+1F458",
@@ -12400,116 +6211,42 @@
             {
               "codepoint": "U+1FA72",
               "name": "briefs",
-              "keywords": [
-                "bathing",
-                "briefs",
-                "one-piece",
-                "suit",
-                "swimsuit",
-                "underwear"
-              ]
+              "keywords": ["bathing", "briefs", "one-piece", "suit", "swimsuit", "underwear"]
             },
             {
               "codepoint": "U+1FA73",
               "name": "shorts",
-              "keywords": [
-                "bathing",
-                "pants",
-                "shorts",
-                "suit",
-                "swimsuit",
-                "underwear"
-              ]
+              "keywords": ["bathing", "pants", "shorts", "suit", "swimsuit", "underwear"]
             },
             {
               "codepoint": "U+1F459",
               "name": "bikini",
-              "keywords": [
-                "bathing",
-                "beach",
-                "bikini",
-                "clothing",
-                "pool",
-                "suit",
-                "swim"
-              ]
+              "keywords": ["bathing", "beach", "bikini", "clothing", "pool", "suit", "swim"]
             },
             {
               "codepoint": "U+1F45A",
               "name": "woman’s clothes",
-              "keywords": [
-                "blouse",
-                "clothes",
-                "clothing",
-                "collar",
-                "dress",
-                "dressed",
-                "lady",
-                "shirt",
-                "shopping",
-                "woman",
-                "woman’s"
-              ]
+              "keywords": ["blouse", "clothes", "clothing", "collar", "dress", "dressed", "lady", "shirt", "shopping", "woman", "woman’s"]
             },
             {
               "codepoint": "U+1FAAD",
               "name": "folding hand fan",
-              "keywords": [
-                "clack",
-                "clap",
-                "cool",
-                "cooling",
-                "dance",
-                "fan",
-                "flirt",
-                "flutter",
-                "folding",
-                "hand",
-                "hot",
-                "shy"
-              ]
+              "keywords": ["clack", "clap", "cool", "cooling", "dance", "fan", "flirt", "flutter", "folding", "hand", "hot", "shy"]
             },
             {
               "codepoint": "U+1F45B",
               "name": "purse",
-              "keywords": [
-                "clothes",
-                "clothing",
-                "coin",
-                "dress",
-                "fancy",
-                "handbag",
-                "purse",
-                "shopping"
-              ]
+              "keywords": ["clothes", "clothing", "coin", "dress", "fancy", "handbag", "purse", "shopping"]
             },
             {
               "codepoint": "U+1F45C",
               "name": "handbag",
-              "keywords": [
-                "bag",
-                "clothes",
-                "clothing",
-                "dress",
-                "handbag",
-                "lady",
-                "purse",
-                "shopping"
-              ]
+              "keywords": ["bag", "clothes", "clothing", "dress", "handbag", "lady", "purse", "shopping"]
             },
             {
               "codepoint": "U+1F45D",
               "name": "clutch bag",
-              "keywords": [
-                "bag",
-                "clothes",
-                "clothing",
-                "clutch",
-                "dress",
-                "handbag",
-                "pouch",
-                "purse"
-              ]
+              "keywords": ["bag", "clothes", "clothing", "clutch", "dress", "handbag", "pouch", "purse"]
             },
             {
               "codepoint": "U+1F6CD",
@@ -12519,109 +6256,37 @@
             {
               "codepoint": "U+1F392",
               "name": "backpack",
-              "keywords": [
-                "backpack",
-                "backpacking",
-                "bag",
-                "bookbag",
-                "education",
-                "rucksack",
-                "satchel",
-                "school"
-              ]
+              "keywords": ["backpack", "backpacking", "bag", "bookbag", "education", "rucksack", "satchel", "school"]
             },
             {
               "codepoint": "U+1FA74",
               "name": "thong sandal",
-              "keywords": [
-                "beach",
-                "flip",
-                "flop",
-                "sandal",
-                "sandals",
-                "shoe",
-                "thong",
-                "thongs",
-                "zōri"
-              ]
+              "keywords": ["beach", "flip", "flop", "sandal", "sandals", "shoe", "thong", "thongs", "zōri"]
             },
             {
               "codepoint": "U+1F45E",
               "name": "man’s shoe",
-              "keywords": [
-                "brown",
-                "clothes",
-                "clothing",
-                "feet",
-                "foot",
-                "kick",
-                "man",
-                "man’s",
-                "shoe",
-                "shoes",
-                "shopping"
-              ]
+              "keywords": ["brown", "clothes", "clothing", "feet", "foot", "kick", "man", "man’s", "shoe", "shoes", "shopping"]
             },
             {
               "codepoint": "U+1F45F",
               "name": "running shoe",
-              "keywords": [
-                "athletic",
-                "clothes",
-                "clothing",
-                "fast",
-                "kick",
-                "running",
-                "shoe",
-                "shoes",
-                "shopping",
-                "sneaker",
-                "tennis"
-              ]
+              "keywords": ["athletic", "clothes", "clothing", "fast", "kick", "running", "shoe", "shoes", "shopping", "sneaker", "tennis"]
             },
             {
               "codepoint": "U+1F97E",
               "name": "hiking boot",
-              "keywords": [
-                "backpacking",
-                "boot",
-                "brown",
-                "camping",
-                "hiking",
-                "outdoors",
-                "shoe"
-              ]
+              "keywords": ["backpacking", "boot", "brown", "camping", "hiking", "outdoors", "shoe"]
             },
             {
               "codepoint": "U+1F97F",
               "name": "flat shoe",
-              "keywords": [
-                "ballet",
-                "comfy",
-                "flat",
-                "flats",
-                "shoe",
-                "slip-on",
-                "slipper"
-              ]
+              "keywords": ["ballet", "comfy", "flat", "flats", "shoe", "slip-on", "slipper"]
             },
             {
               "codepoint": "U+1F460",
               "name": "high-heeled shoe",
-              "keywords": [
-                "clothes",
-                "clothing",
-                "dress",
-                "fashion",
-                "heel",
-                "heels",
-                "high-heeled",
-                "shoe",
-                "shoes",
-                "shopping",
-                "stiletto",
-                "woman"
-              ]
+              "keywords": ["clothes", "clothing", "dress", "fashion", "heel", "heels", "high-heeled", "shoe", "shoes", "shopping", "stiletto", "woman"]
             },
             {
               "codepoint": "U+1F461",
@@ -12636,17 +6301,7 @@
             {
               "codepoint": "U+1F462",
               "name": "woman’s boot",
-              "keywords": [
-                "boot",
-                "clothes",
-                "clothing",
-                "dress",
-                "shoe",
-                "shoes",
-                "shopping",
-                "woman",
-                "woman’s"
-              ]
+              "keywords": ["boot", "clothes", "clothing", "dress", "shoe", "shoes", "shopping", "woman", "woman’s"]
             },
             {
               "codepoint": "U+1FAAE",
@@ -12656,58 +6311,22 @@
             {
               "codepoint": "U+1F451",
               "name": "crown",
-              "keywords": [
-                "clothing",
-                "crown",
-                "family",
-                "king",
-                "medieval",
-                "queen",
-                "royal",
-                "royalty",
-                "win"
-              ]
+              "keywords": ["clothing", "crown", "family", "king", "medieval", "queen", "royal", "royalty", "win"]
             },
             {
               "codepoint": "U+1F452",
               "name": "woman’s hat",
-              "keywords": [
-                "clothes",
-                "clothing",
-                "garden",
-                "hat",
-                "hats",
-                "party",
-                "woman",
-                "woman’s"
-              ]
+              "keywords": ["clothes", "clothing", "garden", "hat", "hats", "party", "woman", "woman’s"]
             },
             {
               "codepoint": "U+1F3A9",
               "name": "top hat",
-              "keywords": [
-                "clothes",
-                "clothing",
-                "fancy",
-                "formal",
-                "hat",
-                "magic",
-                "top",
-                "tophat"
-              ]
+              "keywords": ["clothes", "clothing", "fancy", "formal", "hat", "magic", "top", "tophat"]
             },
             {
               "codepoint": "U+1F393",
               "name": "graduation cap",
-              "keywords": [
-                "cap",
-                "celebration",
-                "clothing",
-                "education",
-                "graduation",
-                "hat",
-                "scholar"
-              ]
+              "keywords": ["cap", "celebration", "clothing", "education", "graduation", "hat", "scholar"]
             },
             {
               "codepoint": "U+1F9E2",
@@ -12717,38 +6336,17 @@
             {
               "codepoint": "U+1FA96",
               "name": "military helmet",
-              "keywords": [
-                "army",
-                "helmet",
-                "military",
-                "soldier",
-                "war",
-                "warrior"
-              ]
+              "keywords": ["army", "helmet", "military", "soldier", "war", "warrior"]
             },
             {
               "codepoint": "U+26D1",
               "name": "rescue worker’s helmet",
-              "keywords": [
-                "aid",
-                "cross",
-                "face",
-                "hat",
-                "helmet",
-                "rescue",
-                "worker’s"
-              ]
+              "keywords": ["aid", "cross", "face", "hat", "helmet", "rescue", "worker’s"]
             },
             {
               "codepoint": "U+1F4FF",
               "name": "prayer beads",
-              "keywords": [
-                "beads",
-                "clothing",
-                "necklace",
-                "prayer",
-                "religion"
-              ]
+              "keywords": ["beads", "clothing", "necklace", "prayer", "religion"]
             },
             {
               "codepoint": "U+1F484",
@@ -12758,31 +6356,12 @@
             {
               "codepoint": "U+1F48D",
               "name": "ring",
-              "keywords": [
-                "diamond",
-                "engaged",
-                "engagement",
-                "married",
-                "ring",
-                "romance",
-                "shiny",
-                "sparkling",
-                "wedding"
-              ]
+              "keywords": ["diamond", "engaged", "engagement", "married", "ring", "romance", "shiny", "sparkling", "wedding"]
             },
             {
               "codepoint": "U+1F48E",
               "name": "gem stone",
-              "keywords": [
-                "diamond",
-                "engagement",
-                "gem",
-                "jewel",
-                "money",
-                "romance",
-                "stone",
-                "wedding"
-              ]
+              "keywords": ["diamond", "engagement", "gem", "jewel", "money", "romance", "stone", "wedding"]
             }
           ]
         },
@@ -12792,14 +6371,7 @@
             {
               "codepoint": "U+1F507",
               "name": "muted speaker",
-              "keywords": [
-                "mute",
-                "muted",
-                "quiet",
-                "silent",
-                "sound",
-                "speaker"
-              ]
+              "keywords": ["mute", "muted", "quiet", "silent", "sound", "speaker"]
             },
             {
               "codepoint": "U+1F508",
@@ -12814,26 +6386,12 @@
             {
               "codepoint": "U+1F50A",
               "name": "speaker high volume",
-              "keywords": [
-                "high",
-                "loud",
-                "music",
-                "sound",
-                "speaker",
-                "volume"
-              ]
+              "keywords": ["high", "loud", "music", "sound", "speaker", "volume"]
             },
             {
               "codepoint": "U+1F4E2",
               "name": "loudspeaker",
-              "keywords": [
-                "address",
-                "communication",
-                "loud",
-                "loudspeaker",
-                "public",
-                "sound"
-              ]
+              "keywords": ["address", "communication", "loud", "loudspeaker", "public", "sound"]
             },
             {
               "codepoint": "U+1F4E3",
@@ -12853,18 +6411,7 @@
             {
               "codepoint": "U+1F515",
               "name": "bell with slash",
-              "keywords": [
-                "bell",
-                "forbidden",
-                "mute",
-                "no",
-                "not",
-                "prohibited",
-                "quiet",
-                "silent",
-                "slash",
-                "sound"
-              ]
+              "keywords": ["bell", "forbidden", "mute", "no", "not", "prohibited", "quiet", "silent", "slash", "sound"]
             }
           ]
         },
@@ -12904,14 +6451,7 @@
             {
               "codepoint": "U+1F3A4",
               "name": "microphone",
-              "keywords": [
-                "karaoke",
-                "mic",
-                "microphone",
-                "music",
-                "sing",
-                "sound"
-              ]
+              "keywords": ["karaoke", "mic", "microphone", "music", "sing", "sound"]
             },
             {
               "codepoint": "U+1F3A7",
@@ -12936,15 +6476,7 @@
             {
               "codepoint": "U+1FA97",
               "name": "accordion",
-              "keywords": [
-                "accordion",
-                "box",
-                "concertina",
-                "instrument",
-                "music",
-                "squeeze",
-                "squeezebox"
-              ]
+              "keywords": ["accordion", "box", "concertina", "instrument", "music", "squeeze", "squeezebox"]
             },
             {
               "codepoint": "U+1F3B8",
@@ -12954,13 +6486,7 @@
             {
               "codepoint": "U+1F3B9",
               "name": "musical keyboard",
-              "keywords": [
-                "instrument",
-                "keyboard",
-                "music",
-                "musical",
-                "piano"
-              ]
+              "keywords": ["instrument", "keyboard", "music", "musical", "piano"]
             },
             {
               "codepoint": "U+1F3BA",
@@ -12985,60 +6511,22 @@
             {
               "codepoint": "U+1FA98",
               "name": "long drum",
-              "keywords": [
-                "beat",
-                "conga",
-                "drum",
-                "instrument",
-                "long",
-                "rhythm"
-              ]
+              "keywords": ["beat", "conga", "drum", "instrument", "long", "rhythm"]
             },
             {
               "codepoint": "U+1FA87",
               "name": "maracas",
-              "keywords": [
-                "cha",
-                "dance",
-                "instrument",
-                "maracas",
-                "music",
-                "party",
-                "percussion",
-                "rattle",
-                "shake",
-                "shaker"
-              ]
+              "keywords": ["cha", "dance", "instrument", "maracas", "music", "party", "percussion", "rattle", "shake", "shaker"]
             },
             {
               "codepoint": "U+1FA88",
               "name": "flute",
-              "keywords": [
-                "band",
-                "fife",
-                "flautist",
-                "flute",
-                "instrument",
-                "marching",
-                "music",
-                "orchestra",
-                "piccolo",
-                "pipe",
-                "recorder",
-                "woodwind"
-              ]
+              "keywords": ["band", "fife", "flautist", "flute", "instrument", "marching", "music", "orchestra", "piccolo", "pipe", "recorder", "woodwind"]
             },
             {
               "codepoint": "U+1FA89",
               "name": "harp",
-              "keywords": [
-                "cupid",
-                "harp",
-                "instrument",
-                "love",
-                "music",
-                "orchestra"
-              ]
+              "keywords": ["cupid", "harp", "instrument", "love", "music", "orchestra"]
             }
           ]
         },
@@ -13048,28 +6536,12 @@
             {
               "codepoint": "U+1F4F1",
               "name": "mobile phone",
-              "keywords": [
-                "cell",
-                "communication",
-                "mobile",
-                "phone",
-                "telephone"
-              ]
+              "keywords": ["cell", "communication", "mobile", "phone", "telephone"]
             },
             {
               "codepoint": "U+1F4F2",
               "name": "mobile phone with arrow",
-              "keywords": [
-                "arrow",
-                "build",
-                "call",
-                "cell",
-                "communication",
-                "mobile",
-                "phone",
-                "receive",
-                "telephone"
-              ]
+              "keywords": ["arrow", "build", "call", "cell", "communication", "mobile", "phone", "receive", "telephone"]
             },
             {
               "codepoint": "U+260E",
@@ -13079,13 +6551,7 @@
             {
               "codepoint": "U+1F4DE",
               "name": "telephone receiver",
-              "keywords": [
-                "communication",
-                "phone",
-                "receiver",
-                "telephone",
-                "voip"
-              ]
+              "keywords": ["communication", "phone", "receiver", "telephone", "voip"]
             },
             {
               "codepoint": "U+1F4DF",
@@ -13110,14 +6576,7 @@
             {
               "codepoint": "U+1FAAB",
               "name": "low battery",
-              "keywords": [
-                "battery",
-                "drained",
-                "electronic",
-                "energy",
-                "low",
-                "power"
-              ]
+              "keywords": ["battery", "drained", "electronic", "energy", "low", "power"]
             },
             {
               "codepoint": "U+1F50C",
@@ -13167,26 +6626,12 @@
             {
               "codepoint": "U+1F4BF",
               "name": "optical disk",
-              "keywords": [
-                "blu-ray",
-                "CD",
-                "computer",
-                "disk",
-                "dvd",
-                "optical"
-              ]
+              "keywords": ["blu-ray", "CD", "computer", "disk", "dvd", "optical"]
             },
             {
               "codepoint": "U+1F4C0",
               "name": "dvd",
-              "keywords": [
-                "Blu-ray",
-                "cd",
-                "computer",
-                "disk",
-                "DVD",
-                "optical"
-              ]
+              "keywords": ["Blu-ray", "cd", "computer", "disk", "DVD", "optical"]
             },
             {
               "codepoint": "U+1F9EE",
@@ -13201,15 +6646,7 @@
             {
               "codepoint": "U+1F3A5",
               "name": "movie camera",
-              "keywords": [
-                "bollywood",
-                "camera",
-                "cinema",
-                "film",
-                "hollywood",
-                "movie",
-                "record"
-              ]
+              "keywords": ["bollywood", "camera", "cinema", "film", "hollywood", "movie", "record"]
             },
             {
               "codepoint": "U+1F39E",
@@ -13234,15 +6671,7 @@
             {
               "codepoint": "U+1F4F7",
               "name": "camera",
-              "keywords": [
-                "camera",
-                "photo",
-                "selfie",
-                "snap",
-                "tbt",
-                "trip",
-                "video"
-              ]
+              "keywords": ["camera", "photo", "selfie", "snap", "tbt", "trip", "video"]
             },
             {
               "codepoint": "U+1F4F8",
@@ -13257,46 +6686,17 @@
             {
               "codepoint": "U+1F4FC",
               "name": "videocassette",
-              "keywords": [
-                "old",
-                "school",
-                "tape",
-                "vcr",
-                "vhs",
-                "video",
-                "videocassette"
-              ]
+              "keywords": ["old", "school", "tape", "vcr", "vhs", "video", "videocassette"]
             },
             {
               "codepoint": "U+1F50D",
               "name": "magnifying glass tilted left",
-              "keywords": [
-                "glass",
-                "lab",
-                "left",
-                "left-pointing",
-                "magnifying",
-                "science",
-                "search",
-                "tilted",
-                "tool"
-              ]
+              "keywords": ["glass", "lab", "left", "left-pointing", "magnifying", "science", "search", "tilted", "tool"]
             },
             {
               "codepoint": "U+1F50E",
               "name": "magnifying glass tilted right",
-              "keywords": [
-                "contact",
-                "glass",
-                "lab",
-                "magnifying",
-                "right",
-                "right-pointing",
-                "science",
-                "search",
-                "tilted",
-                "tool"
-              ]
+              "keywords": ["contact", "glass", "lab", "magnifying", "right", "right-pointing", "science", "search", "tilted", "tool"]
             },
             {
               "codepoint": "U+1F56F",
@@ -13316,14 +6716,7 @@
             {
               "codepoint": "U+1F3EE",
               "name": "red paper lantern",
-              "keywords": [
-                "bar",
-                "lantern",
-                "light",
-                "paper",
-                "red",
-                "restaurant"
-              ]
+              "keywords": ["bar", "lantern", "light", "paper", "red", "restaurant"]
             },
             {
               "codepoint": "U+1FA94",
@@ -13338,16 +6731,7 @@
             {
               "codepoint": "U+1F4D4",
               "name": "notebook with decorative cover",
-              "keywords": [
-                "book",
-                "cover",
-                "decorated",
-                "decorative",
-                "education",
-                "notebook",
-                "school",
-                "writing"
-              ]
+              "keywords": ["book", "cover", "decorated", "decorative", "education", "notebook", "school", "writing"]
             },
             {
               "codepoint": "U+1F4D5",
@@ -13357,68 +6741,27 @@
             {
               "codepoint": "U+1F4D6",
               "name": "open book",
-              "keywords": [
-                "book",
-                "education",
-                "fantasy",
-                "knowledge",
-                "library",
-                "novels",
-                "open",
-                "reading"
-              ]
+              "keywords": ["book", "education", "fantasy", "knowledge", "library", "novels", "open", "reading"]
             },
             {
               "codepoint": "U+1F4D7",
               "name": "green book",
-              "keywords": [
-                "book",
-                "education",
-                "fantasy",
-                "green",
-                "library",
-                "reading"
-              ]
+              "keywords": ["book", "education", "fantasy", "green", "library", "reading"]
             },
             {
               "codepoint": "U+1F4D8",
               "name": "blue book",
-              "keywords": [
-                "blue",
-                "book",
-                "education",
-                "fantasy",
-                "library",
-                "reading"
-              ]
+              "keywords": ["blue", "book", "education", "fantasy", "library", "reading"]
             },
             {
               "codepoint": "U+1F4D9",
               "name": "orange book",
-              "keywords": [
-                "book",
-                "education",
-                "fantasy",
-                "library",
-                "orange",
-                "reading"
-              ]
+              "keywords": ["book", "education", "fantasy", "library", "orange", "reading"]
             },
             {
               "codepoint": "U+1F4DA",
               "name": "books",
-              "keywords": [
-                "book",
-                "books",
-                "education",
-                "fantasy",
-                "knowledge",
-                "library",
-                "novels",
-                "reading",
-                "school",
-                "study"
-              ]
+              "keywords": ["book", "books", "education", "fantasy", "knowledge", "library", "novels", "reading", "school", "study"]
             },
             {
               "codepoint": "U+1F4D3",
@@ -13478,157 +6821,52 @@
             {
               "codepoint": "U+1F4B0",
               "name": "money bag",
-              "keywords": [
-                "bag",
-                "bank",
-                "bet",
-                "billion",
-                "cash",
-                "cost",
-                "dollar",
-                "gold",
-                "million",
-                "money",
-                "moneybag",
-                "paid",
-                "paying",
-                "pot",
-                "rich",
-                "win"
-              ]
+              "keywords": ["bag", "bank", "bet", "billion", "cash", "cost", "dollar", "gold", "million", "money", "moneybag", "paid", "paying", "pot", "rich", "win"]
             },
             {
               "codepoint": "U+1FA99",
               "name": "coin",
-              "keywords": [
-                "coin",
-                "dollar",
-                "euro",
-                "gold",
-                "metal",
-                "money",
-                "rich",
-                "silver",
-                "treasure"
-              ]
+              "keywords": ["coin", "dollar", "euro", "gold", "metal", "money", "rich", "silver", "treasure"]
             },
             {
               "codepoint": "U+1F4B4",
               "name": "yen banknote",
-              "keywords": [
-                "bank",
-                "banknote",
-                "bill",
-                "currency",
-                "money",
-                "note",
-                "yen"
-              ]
+              "keywords": ["bank", "banknote", "bill", "currency", "money", "note", "yen"]
             },
             {
               "codepoint": "U+1F4B5",
               "name": "dollar banknote",
-              "keywords": [
-                "bank",
-                "banknote",
-                "bill",
-                "currency",
-                "dollar",
-                "money",
-                "note"
-              ]
+              "keywords": ["bank", "banknote", "bill", "currency", "dollar", "money", "note"]
             },
             {
               "codepoint": "U+1F4B6",
               "name": "euro banknote",
-              "keywords": [
-                "100",
-                "bank",
-                "banknote",
-                "bill",
-                "currency",
-                "euro",
-                "money",
-                "note",
-                "rich"
-              ]
+              "keywords": ["100", "bank", "banknote", "bill", "currency", "euro", "money", "note", "rich"]
             },
             {
               "codepoint": "U+1F4B7",
               "name": "pound banknote",
-              "keywords": [
-                "bank",
-                "banknote",
-                "bill",
-                "billion",
-                "cash",
-                "currency",
-                "money",
-                "note",
-                "pound",
-                "pounds"
-              ]
+              "keywords": ["bank", "banknote", "bill", "billion", "cash", "currency", "money", "note", "pound", "pounds"]
             },
             {
               "codepoint": "U+1F4B8",
               "name": "money with wings",
-              "keywords": [
-                "bank",
-                "banknote",
-                "bill",
-                "billion",
-                "cash",
-                "dollar",
-                "fly",
-                "million",
-                "money",
-                "note",
-                "pay",
-                "wings"
-              ]
+              "keywords": ["bank", "banknote", "bill", "billion", "cash", "dollar", "fly", "million", "money", "note", "pay", "wings"]
             },
             {
               "codepoint": "U+1F4B3",
               "name": "credit card",
-              "keywords": [
-                "bank",
-                "card",
-                "cash",
-                "charge",
-                "credit",
-                "money",
-                "pay"
-              ]
+              "keywords": ["bank", "card", "cash", "charge", "credit", "money", "pay"]
             },
             {
               "codepoint": "U+1F9FE",
               "name": "receipt",
-              "keywords": [
-                "accounting",
-                "bookkeeping",
-                "evidence",
-                "invoice",
-                "proof",
-                "receipt"
-              ]
+              "keywords": ["accounting", "bookkeeping", "evidence", "invoice", "proof", "receipt"]
             },
             {
               "codepoint": "U+1F4B9",
               "name": "chart increasing with yen",
-              "keywords": [
-                "bank",
-                "chart",
-                "currency",
-                "graph",
-                "growth",
-                "increasing",
-                "market",
-                "money",
-                "rise",
-                "trend",
-                "upward",
-                "yen"
-              ]
+              "keywords": ["bank", "chart", "currency", "graph", "growth", "increasing", "market", "money", "rise", "trend", "upward", "yen"]
             }
           ]
         },
@@ -13648,122 +6886,47 @@
             {
               "codepoint": "U+1F4E8",
               "name": "incoming envelope",
-              "keywords": [
-                "delivering",
-                "e-mail",
-                "email",
-                "envelope",
-                "incoming",
-                "letter",
-                "mail",
-                "receive",
-                "sent"
-              ]
+              "keywords": ["delivering", "e-mail", "email", "envelope", "incoming", "letter", "mail", "receive", "sent"]
             },
             {
               "codepoint": "U+1F4E9",
               "name": "envelope with arrow",
-              "keywords": [
-                "arrow",
-                "communication",
-                "down",
-                "e-mail",
-                "email",
-                "envelope",
-                "letter",
-                "mail",
-                "outgoing",
-                "send",
-                "sent"
-              ]
+              "keywords": ["arrow", "communication", "down", "e-mail", "email", "envelope", "letter", "mail", "outgoing", "send", "sent"]
             },
             {
               "codepoint": "U+1F4E4",
               "name": "outbox tray",
-              "keywords": [
-                "box",
-                "email",
-                "letter",
-                "mail",
-                "outbox",
-                "sent",
-                "tray"
-              ]
+              "keywords": ["box", "email", "letter", "mail", "outbox", "sent", "tray"]
             },
             {
               "codepoint": "U+1F4E5",
               "name": "inbox tray",
-              "keywords": [
-                "box",
-                "email",
-                "inbox",
-                "letter",
-                "mail",
-                "receive",
-                "tray",
-                "zero"
-              ]
+              "keywords": ["box", "email", "inbox", "letter", "mail", "receive", "tray", "zero"]
             },
             {
               "codepoint": "U+1F4E6",
               "name": "package",
-              "keywords": [
-                "box",
-                "communication",
-                "delivery",
-                "package",
-                "parcel",
-                "shipping"
-              ]
+              "keywords": ["box", "communication", "delivery", "package", "parcel", "shipping"]
             },
             {
               "codepoint": "U+1F4EB",
               "name": "closed mailbox with raised flag",
-              "keywords": [
-                "closed",
-                "communication",
-                "flag",
-                "mail",
-                "mailbox",
-                "postbox",
-                "raised"
-              ]
+              "keywords": ["closed", "communication", "flag", "mail", "mailbox", "postbox", "raised"]
             },
             {
               "codepoint": "U+1F4EA",
               "name": "closed mailbox with lowered flag",
-              "keywords": [
-                "closed",
-                "flag",
-                "lowered",
-                "mail",
-                "mailbox",
-                "postbox"
-              ]
+              "keywords": ["closed", "flag", "lowered", "mail", "mailbox", "postbox"]
             },
             {
               "codepoint": "U+1F4EC",
               "name": "open mailbox with raised flag",
-              "keywords": [
-                "flag",
-                "mail",
-                "mailbox",
-                "open",
-                "postbox",
-                "raised"
-              ]
+              "keywords": ["flag", "mail", "mailbox", "open", "postbox", "raised"]
             },
             {
               "codepoint": "U+1F4ED",
               "name": "open mailbox with lowered flag",
-              "keywords": [
-                "flag",
-                "lowered",
-                "mail",
-                "mailbox",
-                "open",
-                "postbox"
-              ]
+              "keywords": ["flag", "lowered", "mail", "mailbox", "open", "postbox"]
             },
             {
               "codepoint": "U+1F4EE",
@@ -13864,31 +7027,12 @@
             {
               "codepoint": "U+1F4C8",
               "name": "chart increasing",
-              "keywords": [
-                "chart",
-                "data",
-                "graph",
-                "growth",
-                "increasing",
-                "right",
-                "trend",
-                "up",
-                "upward"
-              ]
+              "keywords": ["chart", "data", "graph", "growth", "increasing", "right", "trend", "up", "upward"]
             },
             {
               "codepoint": "U+1F4C9",
               "name": "chart decreasing",
-              "keywords": [
-                "chart",
-                "data",
-                "decreasing",
-                "down",
-                "downward",
-                "graph",
-                "negative",
-                "trend"
-              ]
+              "keywords": ["chart", "data", "decreasing", "down", "downward", "graph", "negative", "trend"]
             },
             {
               "codepoint": "U+1F4CA",
@@ -13923,28 +7067,12 @@
             {
               "codepoint": "U+1F4CF",
               "name": "straight ruler",
-              "keywords": [
-                "angle",
-                "edge",
-                "math",
-                "ruler",
-                "straight",
-                "straightedge"
-              ]
+              "keywords": ["angle", "edge", "math", "ruler", "straight", "straightedge"]
             },
             {
               "codepoint": "U+1F4D0",
               "name": "triangular ruler",
-              "keywords": [
-                "angle",
-                "math",
-                "rule",
-                "ruler",
-                "set",
-                "slide",
-                "triangle",
-                "triangular"
-              ]
+              "keywords": ["angle", "math", "rule", "ruler", "set", "slide", "triangle", "triangular"]
             },
             {
               "codepoint": "U+2702",
@@ -14044,14 +7172,7 @@
             {
               "codepoint": "U+1F4A3",
               "name": "bomb",
-              "keywords": [
-                "bomb",
-                "boom",
-                "comic",
-                "dangerous",
-                "explosion",
-                "hot"
-              ]
+              "keywords": ["bomb", "boom", "comic", "dangerous", "explosion", "hot"]
             },
             {
               "codepoint": "U+1FA83",
@@ -14061,16 +7182,7 @@
             {
               "codepoint": "U+1F3F9",
               "name": "bow and arrow",
-              "keywords": [
-                "archer",
-                "archery",
-                "arrow",
-                "bow",
-                "Sagittarius",
-                "tool",
-                "weapon",
-                "zodiac"
-              ]
+              "keywords": ["archer", "archery", "arrow", "bow", "Sagittarius", "tool", "weapon", "zodiac"]
             },
             {
               "codepoint": "U+1F6E1",
@@ -14080,15 +7192,7 @@
             {
               "codepoint": "U+1FA9A",
               "name": "carpentry saw",
-              "keywords": [
-                "carpenter",
-                "carpentry",
-                "cut",
-                "lumber",
-                "saw",
-                "tool",
-                "trim"
-              ]
+              "keywords": ["carpenter", "carpentry", "cut", "lumber", "saw", "tool", "trim"]
             },
             {
               "codepoint": "U+1F527",
@@ -14118,16 +7222,7 @@
             {
               "codepoint": "U+2696",
               "name": "balance scale",
-              "keywords": [
-                "balance",
-                "justice",
-                "Libra",
-                "scale",
-                "scales",
-                "tool",
-                "weight",
-                "zodiac"
-              ]
+              "keywords": ["balance", "justice", "Libra", "scale", "scales", "tool", "weight", "zodiac"]
             },
             {
               "codepoint": "U+1F9AF",
@@ -14142,14 +7237,7 @@
             {
               "codepoint": "U+26D3 U+FE0F U+200D U+1F4A5",
               "name": "broken chain",
-              "keywords": [
-                "break",
-                "breaking",
-                "broken",
-                "chain",
-                "cuffs",
-                "freedom"
-              ]
+              "keywords": ["break", "breaking", "broken", "chain", "cuffs", "freedom"]
             },
             {
               "codepoint": "U+26D3",
@@ -14159,15 +7247,7 @@
             {
               "codepoint": "U+1FA9D",
               "name": "hook",
-              "keywords": [
-                "catch",
-                "crook",
-                "curve",
-                "ensnare",
-                "hook",
-                "point",
-                "selling"
-              ]
+              "keywords": ["catch", "crook", "curve", "ensnare", "hook", "point", "selling"]
             },
             {
               "codepoint": "U+1F9F0",
@@ -14177,16 +7257,7 @@
             {
               "codepoint": "U+1F9F2",
               "name": "magnet",
-              "keywords": [
-                "attraction",
-                "horseshoe",
-                "magnet",
-                "magnetic",
-                "negative",
-                "positive",
-                "shape",
-                "u"
-              ]
+              "keywords": ["attraction", "horseshoe", "magnet", "magnetic", "negative", "positive", "shape", "u"]
             },
             {
               "codepoint": "U+1FA9C",
@@ -14196,17 +7267,7 @@
             {
               "codepoint": "U+1FA8F",
               "name": "shovel",
-              "keywords": [
-                "bury",
-                "dig",
-                "garden",
-                "hole",
-                "plant",
-                "scoop",
-                "shovel",
-                "snow",
-                "spade"
-              ]
+              "keywords": ["bury", "dig", "garden", "hole", "plant", "scoop", "shovel", "snow", "spade"]
             }
           ]
         },
@@ -14221,40 +7282,17 @@
             {
               "codepoint": "U+1F9EA",
               "name": "test tube",
-              "keywords": [
-                "chemist",
-                "chemistry",
-                "experiment",
-                "lab",
-                "science",
-                "test",
-                "tube"
-              ]
+              "keywords": ["chemist", "chemistry", "experiment", "lab", "science", "test", "tube"]
             },
             {
               "codepoint": "U+1F9EB",
               "name": "petri dish",
-              "keywords": [
-                "bacteria",
-                "biologist",
-                "biology",
-                "culture",
-                "dish",
-                "lab",
-                "petri"
-              ]
+              "keywords": ["bacteria", "biologist", "biology", "culture", "dish", "lab", "petri"]
             },
             {
               "codepoint": "U+1F9EC",
               "name": "dna",
-              "keywords": [
-                "biologist",
-                "dna",
-                "evolution",
-                "gene",
-                "genetics",
-                "life"
-              ]
+              "keywords": ["biologist", "dna", "evolution", "gene", "genetics", "life"]
             },
             {
               "codepoint": "U+1F52C",
@@ -14264,25 +7302,12 @@
             {
               "codepoint": "U+1F52D",
               "name": "telescope",
-              "keywords": [
-                "contact",
-                "extraterrestrial",
-                "science",
-                "telescope",
-                "tool"
-              ]
+              "keywords": ["contact", "extraterrestrial", "science", "telescope", "tool"]
             },
             {
               "codepoint": "U+1F4E1",
               "name": "satellite antenna",
-              "keywords": [
-                "aliens",
-                "antenna",
-                "contact",
-                "dish",
-                "satellite",
-                "science"
-              ]
+              "keywords": ["aliens", "antenna", "contact", "dish", "satellite", "science"]
             }
           ]
         },
@@ -14292,44 +7317,17 @@
             {
               "codepoint": "U+1F489",
               "name": "syringe",
-              "keywords": [
-                "doctor",
-                "flu",
-                "medicine",
-                "needle",
-                "shot",
-                "sick",
-                "syringe",
-                "tool",
-                "vaccination"
-              ]
+              "keywords": ["doctor", "flu", "medicine", "needle", "shot", "sick", "syringe", "tool", "vaccination"]
             },
             {
               "codepoint": "U+1FA78",
               "name": "drop of blood",
-              "keywords": [
-                "bleed",
-                "blood",
-                "donation",
-                "drop",
-                "injury",
-                "medicine",
-                "menstruation"
-              ]
+              "keywords": ["bleed", "blood", "donation", "drop", "injury", "medicine", "menstruation"]
             },
             {
               "codepoint": "U+1F48A",
               "name": "pill",
-              "keywords": [
-                "doctor",
-                "drugs",
-                "medicated",
-                "medicine",
-                "pill",
-                "pills",
-                "sick",
-                "vitamin"
-              ]
+              "keywords": ["doctor", "drugs", "medicated", "medicine", "pill", "pills", "sick", "vitamin"]
             },
             {
               "codepoint": "U+1FA79",
@@ -14339,17 +7337,7 @@
             {
               "codepoint": "U+1FA7C",
               "name": "crutch",
-              "keywords": [
-                "aid",
-                "cane",
-                "crutch",
-                "disability",
-                "help",
-                "hurt",
-                "injured",
-                "mobility",
-                "stick"
-              ]
+              "keywords": ["aid", "cane", "crutch", "disability", "help", "hurt", "injured", "mobility", "stick"]
             },
             {
               "codepoint": "U+1FA7A",
@@ -14359,15 +7347,7 @@
             {
               "codepoint": "U+1FA7B",
               "name": "x-ray",
-              "keywords": [
-                "bones",
-                "doctor",
-                "medical",
-                "skeleton",
-                "skull",
-                "x-ray",
-                "xray"
-              ]
+              "keywords": ["bones", "doctor", "medical", "skeleton", "skull", "x-ray", "xray"]
             }
           ]
         },
@@ -14387,26 +7367,12 @@
             {
               "codepoint": "U+1FA9E",
               "name": "mirror",
-              "keywords": [
-                "makeup",
-                "mirror",
-                "reflection",
-                "reflector",
-                "speculum"
-              ]
+              "keywords": ["makeup", "mirror", "reflection", "reflector", "speculum"]
             },
             {
               "codepoint": "U+1FA9F",
               "name": "window",
-              "keywords": [
-                "air",
-                "frame",
-                "fresh",
-                "opening",
-                "transparent",
-                "view",
-                "window"
-              ]
+              "keywords": ["air", "frame", "fresh", "opening", "transparent", "view", "window"]
             },
             {
               "codepoint": "U+1F6CF",
@@ -14431,15 +7397,7 @@
             {
               "codepoint": "U+1FAA0",
               "name": "plunger",
-              "keywords": [
-                "cup",
-                "force",
-                "plumber",
-                "plunger",
-                "poop",
-                "suction",
-                "toilet"
-              ]
+              "keywords": ["cup", "force", "plumber", "plunger", "poop", "suction", "toilet"]
             },
             {
               "codepoint": "U+1F6BF",
@@ -14454,15 +7412,7 @@
             {
               "codepoint": "U+1FAA4",
               "name": "mouse trap",
-              "keywords": [
-                "bait",
-                "cheese",
-                "lure",
-                "mouse",
-                "mousetrap",
-                "snare",
-                "trap"
-              ]
+              "keywords": ["bait", "cheese", "lure", "mouse", "mousetrap", "snare", "trap"]
             },
             {
               "codepoint": "U+1FA92",
@@ -14472,13 +7422,7 @@
             {
               "codepoint": "U+1F9F4",
               "name": "lotion bottle",
-              "keywords": [
-                "bottle",
-                "lotion",
-                "moisturizer",
-                "shampoo",
-                "sunscreen"
-              ]
+              "keywords": ["bottle", "lotion", "moisturizer", "shampoo", "sunscreen"]
             },
             {
               "codepoint": "U+1F9F7",
@@ -14508,43 +7452,17 @@
             {
               "codepoint": "U+1F9FC",
               "name": "soap",
-              "keywords": [
-                "bar",
-                "bathing",
-                "clean",
-                "cleaning",
-                "lather",
-                "soap",
-                "soapdish"
-              ]
+              "keywords": ["bar", "bathing", "clean", "cleaning", "lather", "soap", "soapdish"]
             },
             {
               "codepoint": "U+1FAE7",
               "name": "bubbles",
-              "keywords": [
-                "bubble",
-                "bubbles",
-                "burp",
-                "clean",
-                "floating",
-                "pearl",
-                "soap",
-                "underwater"
-              ]
+              "keywords": ["bubble", "bubbles", "burp", "clean", "floating", "pearl", "soap", "underwater"]
             },
             {
               "codepoint": "U+1FAA5",
               "name": "toothbrush",
-              "keywords": [
-                "bathroom",
-                "brush",
-                "clean",
-                "dental",
-                "hygiene",
-                "teeth",
-                "toiletry",
-                "toothbrush"
-              ]
+              "keywords": ["bathroom", "brush", "clean", "dental", "hygiene", "teeth", "toiletry", "toothbrush"]
             },
             {
               "codepoint": "U+1F9FD",
@@ -14579,17 +7497,7 @@
             {
               "codepoint": "U+1FAA6",
               "name": "headstone",
-              "keywords": [
-                "cemetery",
-                "dead",
-                "grave",
-                "graveyard",
-                "headstone",
-                "memorial",
-                "rip",
-                "tomb",
-                "tombstone"
-              ]
+              "keywords": ["cemetery", "dead", "grave", "graveyard", "headstone", "memorial", "rip", "tomb", "tombstone"]
             },
             {
               "codepoint": "U+26B1",
@@ -14599,71 +7507,27 @@
             {
               "codepoint": "U+1F9FF",
               "name": "nazar amulet",
-              "keywords": [
-                "amulet",
-                "bead",
-                "blue",
-                "charm",
-                "evil-eye",
-                "nazar",
-                "talisman"
-              ]
+              "keywords": ["amulet", "bead", "blue", "charm", "evil-eye", "nazar", "talisman"]
             },
             {
               "codepoint": "U+1FAAC",
               "name": "hamsa",
-              "keywords": [
-                "amulet",
-                "Fatima",
-                "fortune",
-                "guide",
-                "hamsa",
-                "hand",
-                "Mary",
-                "Miriam",
-                "palm",
-                "protect",
-                "protection"
-              ]
+              "keywords": ["amulet", "Fatima", "fortune", "guide", "hamsa", "hand", "Mary", "Miriam", "palm", "protect", "protection"]
             },
             {
               "codepoint": "U+1F5FF",
               "name": "moai",
-              "keywords": [
-                "face",
-                "moai",
-                "moyai",
-                "statue",
-                "stoneface",
-                "travel"
-              ]
+              "keywords": ["face", "moai", "moyai", "statue", "stoneface", "travel"]
             },
             {
               "codepoint": "U+1FAA7",
               "name": "placard",
-              "keywords": [
-                "card",
-                "demonstration",
-                "notice",
-                "picket",
-                "placard",
-                "plaque",
-                "protest",
-                "sign"
-              ]
+              "keywords": ["card", "demonstration", "notice", "picket", "placard", "plaque", "protest", "sign"]
             },
             {
               "codepoint": "U+1FAAA",
               "name": "identification card",
-              "keywords": [
-                "card",
-                "credentials",
-                "document",
-                "ID",
-                "identification",
-                "license",
-                "security"
-              ]
+              "keywords": ["card", "credentials", "document", "ID", "identification", "license", "security"]
             }
           ]
         }
@@ -14678,15 +7542,7 @@
             {
               "codepoint": "U+1F3E7",
               "name": "ATM sign",
-              "keywords": [
-                "ATM",
-                "automated",
-                "bank",
-                "cash",
-                "money",
-                "sign",
-                "teller"
-              ]
+              "keywords": ["ATM", "automated", "bank", "cash", "money", "sign", "teller"]
             },
             {
               "codepoint": "U+1F6AE",
@@ -14706,30 +7562,12 @@
             {
               "codepoint": "U+1F6B9",
               "name": "men’s room",
-              "keywords": [
-                "bathroom",
-                "lavatory",
-                "man",
-                "men’s",
-                "restroom",
-                "room",
-                "toilet",
-                "WC"
-              ]
+              "keywords": ["bathroom", "lavatory", "man", "men’s", "restroom", "room", "toilet", "WC"]
             },
             {
               "codepoint": "U+1F6BA",
               "name": "women’s room",
-              "keywords": [
-                "bathroom",
-                "lavatory",
-                "restroom",
-                "room",
-                "toilet",
-                "WC",
-                "woman",
-                "women’s"
-              ]
+              "keywords": ["bathroom", "lavatory", "restroom", "room", "toilet", "WC", "woman", "women’s"]
             },
             {
               "codepoint": "U+1F6BB",
@@ -14744,15 +7582,7 @@
             {
               "codepoint": "U+1F6BE",
               "name": "water closet",
-              "keywords": [
-                "bathroom",
-                "closet",
-                "lavatory",
-                "restroom",
-                "toilet",
-                "water",
-                "WC"
-              ]
+              "keywords": ["bathroom", "closet", "lavatory", "restroom", "toilet", "water", "WC"]
             },
             {
               "codepoint": "U+1F6C2",
@@ -14767,20 +7597,7 @@
             {
               "codepoint": "U+1F6C4",
               "name": "baggage claim",
-              "keywords": [
-                "arrived",
-                "baggage",
-                "bags",
-                "case",
-                "checked",
-                "claim",
-                "journey",
-                "packing",
-                "plane",
-                "ready",
-                "travel",
-                "trip"
-              ]
+              "keywords": ["arrived", "baggage", "bags", "case", "checked", "claim", "journey", "packing", "plane", "ready", "travel", "trip"]
             },
             {
               "codepoint": "U+1F6C5",
@@ -14800,131 +7617,52 @@
             {
               "codepoint": "U+1F6B8",
               "name": "children crossing",
-              "keywords": [
-                "child",
-                "children",
-                "crossing",
-                "pedestrian",
-                "traffic"
-              ]
+              "keywords": ["child", "children", "crossing", "pedestrian", "traffic"]
             },
             {
               "codepoint": "U+26D4",
               "name": "no entry",
-              "keywords": [
-                "do",
-                "entry",
-                "fail",
-                "forbidden",
-                "no",
-                "not",
-                "pass",
-                "prohibited",
-                "traffic"
-              ]
+              "keywords": ["do", "entry", "fail", "forbidden", "no", "not", "pass", "prohibited", "traffic"]
             },
             {
               "codepoint": "U+1F6AB",
               "name": "prohibited",
-              "keywords": [
-                "entry",
-                "forbidden",
-                "no",
-                "not",
-                "prohibited",
-                "smoke"
-              ]
+              "keywords": ["entry", "forbidden", "no", "not", "prohibited", "smoke"]
             },
             {
               "codepoint": "U+1F6B3",
               "name": "no bicycles",
-              "keywords": [
-                "bicycle",
-                "bicycles",
-                "bike",
-                "forbidden",
-                "no",
-                "not",
-                "prohibited"
-              ]
+              "keywords": ["bicycle", "bicycles", "bike", "forbidden", "no", "not", "prohibited"]
             },
             {
               "codepoint": "U+1F6AD",
               "name": "no smoking",
-              "keywords": [
-                "forbidden",
-                "no",
-                "not",
-                "prohibited",
-                "smoke",
-                "smoking"
-              ]
+              "keywords": ["forbidden", "no", "not", "prohibited", "smoke", "smoking"]
             },
             {
               "codepoint": "U+1F6AF",
               "name": "no littering",
-              "keywords": [
-                "forbidden",
-                "litter",
-                "littering",
-                "no",
-                "not",
-                "prohibited"
-              ]
+              "keywords": ["forbidden", "litter", "littering", "no", "not", "prohibited"]
             },
             {
               "codepoint": "U+1F6B1",
               "name": "non-potable water",
-              "keywords": [
-                "dry",
-                "non-drinking",
-                "non-potable",
-                "prohibited",
-                "water"
-              ]
+              "keywords": ["dry", "non-drinking", "non-potable", "prohibited", "water"]
             },
             {
               "codepoint": "U+1F6B7",
               "name": "no pedestrians",
-              "keywords": [
-                "forbidden",
-                "no",
-                "not",
-                "pedestrian",
-                "pedestrians",
-                "prohibited"
-              ]
+              "keywords": ["forbidden", "no", "not", "pedestrian", "pedestrians", "prohibited"]
             },
             {
               "codepoint": "U+1F4F5",
               "name": "no mobile phones",
-              "keywords": [
-                "cell",
-                "forbidden",
-                "mobile",
-                "no",
-                "not",
-                "phone",
-                "phones",
-                "prohibited",
-                "telephone"
-              ]
+              "keywords": ["cell", "forbidden", "mobile", "no", "not", "phone", "phones", "prohibited", "telephone"]
             },
             {
               "codepoint": "U+1F51E",
               "name": "no one under eighteen",
-              "keywords": [
-                "18",
-                "age",
-                "eighteen",
-                "forbidden",
-                "no",
-                "not",
-                "one",
-                "prohibited",
-                "restriction",
-                "underage"
-              ]
+              "keywords": ["18", "age", "eighteen", "forbidden", "no", "not", "one", "prohibited", "restriction", "underage"]
             },
             {
               "codepoint": "U+2622",
@@ -14949,13 +7687,7 @@
             {
               "codepoint": "U+2197",
               "name": "up-right arrow",
-              "keywords": [
-                "arrow",
-                "direction",
-                "intercardinal",
-                "northeast",
-                "up-right"
-              ]
+              "keywords": ["arrow", "direction", "intercardinal", "northeast", "up-right"]
             },
             {
               "codepoint": "U+27A1",
@@ -14965,13 +7697,7 @@
             {
               "codepoint": "U+2198",
               "name": "down-right arrow",
-              "keywords": [
-                "arrow",
-                "direction",
-                "down-right",
-                "intercardinal",
-                "southeast"
-              ]
+              "keywords": ["arrow", "direction", "down-right", "intercardinal", "southeast"]
             },
             {
               "codepoint": "U+2B07",
@@ -14981,13 +7707,7 @@
             {
               "codepoint": "U+2199",
               "name": "down-left arrow",
-              "keywords": [
-                "arrow",
-                "direction",
-                "down-left",
-                "intercardinal",
-                "southwest"
-              ]
+              "keywords": ["arrow", "direction", "down-left", "intercardinal", "southwest"]
             },
             {
               "codepoint": "U+2B05",
@@ -14997,13 +7717,7 @@
             {
               "codepoint": "U+2196",
               "name": "up-left arrow",
-              "keywords": [
-                "arrow",
-                "direction",
-                "intercardinal",
-                "northwest",
-                "up-left"
-              ]
+              "keywords": ["arrow", "direction", "intercardinal", "northwest", "up-left"]
             },
             {
               "codepoint": "U+2195",
@@ -15038,30 +7752,12 @@
             {
               "codepoint": "U+1F503",
               "name": "clockwise vertical arrows",
-              "keywords": [
-                "arrow",
-                "arrows",
-                "clockwise",
-                "refresh",
-                "reload",
-                "vertical"
-              ]
+              "keywords": ["arrow", "arrows", "clockwise", "refresh", "reload", "vertical"]
             },
             {
               "codepoint": "U+1F504",
               "name": "counterclockwise arrows button",
-              "keywords": [
-                "again",
-                "anticlockwise",
-                "arrow",
-                "arrows",
-                "button",
-                "counterclockwise",
-                "deja",
-                "refresh",
-                "rewindershins",
-                "vu"
-              ]
+              "keywords": ["again", "anticlockwise", "arrow", "arrows", "button", "counterclockwise", "deja", "refresh", "rewindershins", "vu"]
             },
             {
               "codepoint": "U+1F519",
@@ -15111,14 +7807,7 @@
             {
               "codepoint": "U+2721",
               "name": "star of David",
-              "keywords": [
-                "David",
-                "Jew",
-                "Jewish",
-                "judaism",
-                "religion",
-                "star"
-              ]
+              "keywords": ["David", "Jew", "Jewish", "judaism", "religion", "star"]
             },
             {
               "codepoint": "U+2638",
@@ -15128,17 +7817,7 @@
             {
               "codepoint": "U+262F",
               "name": "yin yang",
-              "keywords": [
-                "difficult",
-                "lives",
-                "religion",
-                "tao",
-                "taoist",
-                "total",
-                "yang",
-                "yin",
-                "yinyang"
-              ]
+              "keywords": ["difficult", "lives", "religion", "tao", "taoist", "total", "yang", "yin", "yinyang"]
             },
             {
               "codepoint": "U+271D",
@@ -15153,14 +7832,7 @@
             {
               "codepoint": "U+262A",
               "name": "star and crescent",
-              "keywords": [
-                "crescent",
-                "islam",
-                "Muslim",
-                "ramadan",
-                "religion",
-                "star"
-              ]
+              "keywords": ["crescent", "islam", "Muslim", "ramadan", "religion", "star"]
             },
             {
               "codepoint": "U+262E",
@@ -15170,41 +7842,17 @@
             {
               "codepoint": "U+1F54E",
               "name": "menorah",
-              "keywords": [
-                "candelabrum",
-                "candlestick",
-                "hanukkah",
-                "jewish",
-                "judaism",
-                "menorah",
-                "religion"
-              ]
+              "keywords": ["candelabrum", "candlestick", "hanukkah", "jewish", "judaism", "menorah", "religion"]
             },
             {
               "codepoint": "U+1F52F",
               "name": "dotted six-pointed star",
-              "keywords": [
-                "dotted",
-                "fortune",
-                "jewish",
-                "judaism",
-                "six-pointed",
-                "star"
-              ]
+              "keywords": ["dotted", "fortune", "jewish", "judaism", "six-pointed", "star"]
             },
             {
               "codepoint": "U+1FAAF",
               "name": "khanda",
-              "keywords": [
-                "Deg",
-                "Fateh",
-                "Khalsa",
-                "Khanda",
-                "religion",
-                "Sikh",
-                "Sikhism",
-                "Tegh"
-              ]
+              "keywords": ["Deg", "Fateh", "Khalsa", "Khanda", "religion", "Sikh", "Sikhism", "Tegh"]
             }
           ]
         },
@@ -15244,25 +7892,12 @@
             {
               "codepoint": "U+264E",
               "name": "Libra",
-              "keywords": [
-                "balance",
-                "horoscope",
-                "justice",
-                "Libra",
-                "scales",
-                "zodiac"
-              ]
+              "keywords": ["balance", "horoscope", "justice", "Libra", "scales", "zodiac"]
             },
             {
               "codepoint": "U+264F",
               "name": "Scorpio",
-              "keywords": [
-                "horoscope",
-                "Scorpio",
-                "scorpion",
-                "Scorpius",
-                "zodiac"
-              ]
+              "keywords": ["horoscope", "Scorpio", "scorpion", "Scorpius", "zodiac"]
             },
             {
               "codepoint": "U+2650",
@@ -15307,14 +7942,7 @@
             {
               "codepoint": "U+1F502",
               "name": "repeat single button",
-              "keywords": [
-                "arrow",
-                "button",
-                "clockwise",
-                "once",
-                "repeat",
-                "single"
-              ]
+              "keywords": ["arrow", "button", "clockwise", "once", "repeat", "single"]
             },
             {
               "codepoint": "U+25B6",
@@ -15324,38 +7952,17 @@
             {
               "codepoint": "U+23E9",
               "name": "fast-forward button",
-              "keywords": [
-                "arrow",
-                "button",
-                "double",
-                "fast",
-                "fast-forward",
-                "forward"
-              ]
+              "keywords": ["arrow", "button", "double", "fast", "fast-forward", "forward"]
             },
             {
               "codepoint": "U+23ED",
               "name": "next track button",
-              "keywords": [
-                "arrow",
-                "button",
-                "next",
-                "scene",
-                "track",
-                "triangle"
-              ]
+              "keywords": ["arrow", "button", "next", "scene", "track", "triangle"]
             },
             {
               "codepoint": "U+23EF",
               "name": "play or pause button",
-              "keywords": [
-                "arrow",
-                "button",
-                "pause",
-                "play",
-                "right",
-                "triangle"
-              ]
+              "keywords": ["arrow", "button", "pause", "play", "right", "triangle"]
             },
             {
               "codepoint": "U+25C0",
@@ -15365,27 +7972,12 @@
             {
               "codepoint": "U+23EA",
               "name": "fast reverse button",
-              "keywords": [
-                "arrow",
-                "button",
-                "double",
-                "fast",
-                "reverse",
-                "rewind"
-              ]
+              "keywords": ["arrow", "button", "double", "fast", "reverse", "rewind"]
             },
             {
               "codepoint": "U+23EE",
               "name": "last track button",
-              "keywords": [
-                "arrow",
-                "button",
-                "last",
-                "previous",
-                "scene",
-                "track",
-                "triangle"
-              ]
+              "keywords": ["arrow", "button", "last", "previous", "scene", "track", "triangle"]
             },
             {
               "codepoint": "U+1F53C",
@@ -15445,48 +8037,17 @@
             {
               "codepoint": "U+1F4F6",
               "name": "antenna bars",
-              "keywords": [
-                "antenna",
-                "bar",
-                "bars",
-                "cell",
-                "communication",
-                "mobile",
-                "phone",
-                "signal",
-                "telephone"
-              ]
+              "keywords": ["antenna", "bar", "bars", "cell", "communication", "mobile", "phone", "signal", "telephone"]
             },
             {
               "codepoint": "U+1F6DC",
               "name": "wireless",
-              "keywords": [
-                "broadband",
-                "computer",
-                "connectivity",
-                "hotspot",
-                "internet",
-                "network",
-                "router",
-                "smartphone",
-                "wi-fi",
-                "wifi",
-                "wireless",
-                "wlan"
-              ]
+              "keywords": ["broadband", "computer", "connectivity", "hotspot", "internet", "network", "router", "smartphone", "wi-fi", "wifi", "wireless", "wlan"]
             },
             {
               "codepoint": "U+1F4F3",
               "name": "vibration mode",
-              "keywords": [
-                "cell",
-                "communication",
-                "mobile",
-                "mode",
-                "phone",
-                "telephone",
-                "vibration"
-              ]
+              "keywords": ["cell", "communication", "mobile", "mode", "phone", "telephone", "vibration"]
             },
             {
               "codepoint": "U+1F4F4",
@@ -15521,14 +8082,7 @@
             {
               "codepoint": "U+2716",
               "name": "multiply",
-              "keywords": [
-                "×",
-                "cancel",
-                "multiplication",
-                "multiply",
-                "sign",
-                "x"
-              ]
+              "keywords": ["×", "cancel", "multiplication", "multiply", "sign", "x"]
             },
             {
               "codepoint": "U+2795",
@@ -15548,15 +8102,7 @@
             {
               "codepoint": "U+1F7F0",
               "name": "heavy equals sign",
-              "keywords": [
-                "answer",
-                "equal",
-                "equality",
-                "equals",
-                "heavy",
-                "math",
-                "sign"
-              ]
+              "keywords": ["answer", "equal", "equality", "equals", "heavy", "math", "sign"]
             },
             {
               "codepoint": "U+267E",
@@ -15571,29 +8117,12 @@
             {
               "codepoint": "U+203C",
               "name": "double exclamation mark",
-              "keywords": [
-                "!",
-                "!!",
-                "bangbang",
-                "double",
-                "exclamation",
-                "mark",
-                "punctuation"
-              ]
+              "keywords": ["!", "!!", "bangbang", "double", "exclamation", "mark", "punctuation"]
             },
             {
               "codepoint": "U+2049",
               "name": "exclamation question mark",
-              "keywords": [
-                "!",
-                "!?",
-                "?",
-                "exclamation",
-                "interrobang",
-                "mark",
-                "punctuation",
-                "question"
-              ]
+              "keywords": ["!", "!?", "?", "exclamation", "interrobang", "mark", "punctuation", "question"]
             },
             {
               "codepoint": "U+2753",
@@ -15603,26 +8132,12 @@
             {
               "codepoint": "U+2754",
               "name": "white question mark",
-              "keywords": [
-                "?",
-                "mark",
-                "outlined",
-                "punctuation",
-                "question",
-                "white"
-              ]
+              "keywords": ["?", "mark", "outlined", "punctuation", "question", "white"]
             },
             {
               "codepoint": "U+2755",
               "name": "white exclamation mark",
-              "keywords": [
-                "!",
-                "exclamation",
-                "mark",
-                "outlined",
-                "punctuation",
-                "white"
-              ]
+              "keywords": ["!", "exclamation", "mark", "outlined", "punctuation", "white"]
             },
             {
               "codepoint": "U+2757",
@@ -15647,18 +8162,7 @@
             {
               "codepoint": "U+1F4B2",
               "name": "heavy dollar sign",
-              "keywords": [
-                "billion",
-                "cash",
-                "charge",
-                "currency",
-                "dollar",
-                "heavy",
-                "million",
-                "money",
-                "pay",
-                "sign"
-              ]
+              "keywords": ["billion", "cash", "charge", "currency", "dollar", "heavy", "million", "money", "pay", "sign"]
             }
           ]
         },
@@ -15668,13 +8172,7 @@
             {
               "codepoint": "U+2695",
               "name": "medical symbol",
-              "keywords": [
-                "aesculapius",
-                "medical",
-                "medicine",
-                "staff",
-                "symbol"
-              ]
+              "keywords": ["aesculapius", "medical", "medicine", "staff", "symbol"]
             },
             {
               "codepoint": "U+267B",
@@ -15689,14 +8187,7 @@
             {
               "codepoint": "U+1F531",
               "name": "trident emblem",
-              "keywords": [
-                "anchor",
-                "emblem",
-                "poseidon",
-                "ship",
-                "tool",
-                "trident"
-              ]
+              "keywords": ["anchor", "emblem", "poseidon", "ship", "tool", "trident"]
             },
             {
               "codepoint": "U+1F4DB",
@@ -15706,16 +8197,7 @@
             {
               "codepoint": "U+1F530",
               "name": "Japanese symbol for beginner",
-              "keywords": [
-                "beginner",
-                "chevron",
-                "green",
-                "Japanese",
-                "leaf",
-                "symbol",
-                "tool",
-                "yellow"
-              ]
+              "keywords": ["beginner", "chevron", "green", "Japanese", "leaf", "symbol", "tool", "yellow"]
             },
             {
               "codepoint": "U+2B55",
@@ -15725,74 +8207,27 @@
             {
               "codepoint": "U+2705",
               "name": "check mark button",
-              "keywords": [
-                "✓",
-                "button",
-                "check",
-                "checked",
-                "checkmark",
-                "complete",
-                "completed",
-                "done",
-                "fixed",
-                "mark",
-                "tick"
-              ]
+              "keywords": ["✓", "button", "check", "checked", "checkmark", "complete", "completed", "done", "fixed", "mark", "tick"]
             },
             {
               "codepoint": "U+2611",
               "name": "check box with check",
-              "keywords": [
-                "✓",
-                "ballot",
-                "box",
-                "check",
-                "checked",
-                "done",
-                "off",
-                "tick"
-              ]
+              "keywords": ["✓", "ballot", "box", "check", "checked", "done", "off", "tick"]
             },
             {
               "codepoint": "U+2714",
               "name": "check mark",
-              "keywords": [
-                "✓",
-                "check",
-                "checked",
-                "checkmark",
-                "done",
-                "heavy",
-                "mark",
-                "tick"
-              ]
+              "keywords": ["✓", "check", "checked", "checkmark", "done", "heavy", "mark", "tick"]
             },
             {
               "codepoint": "U+274C",
               "name": "cross mark",
-              "keywords": [
-                "×",
-                "cancel",
-                "cross",
-                "mark",
-                "multiplication",
-                "multiply",
-                "x"
-              ]
+              "keywords": ["×", "cancel", "cross", "mark", "multiplication", "multiply", "x"]
             },
             {
               "codepoint": "U+274E",
               "name": "cross mark button",
-              "keywords": [
-                "×",
-                "button",
-                "cross",
-                "mark",
-                "multiplication",
-                "multiply",
-                "square",
-                "x"
-              ]
+              "keywords": ["×", "button", "cross", "mark", "multiplication", "multiply", "square", "x"]
             },
             {
               "codepoint": "U+27B0",
@@ -15842,17 +8277,7 @@
             {
               "codepoint": "U+1FADF",
               "name": "splatter",
-              "keywords": [
-                "drip",
-                "holi",
-                "ink",
-                "liquid",
-                "mess",
-                "paint",
-                "spill",
-                "splatter",
-                "stain"
-              ]
+              "keywords": ["drip", "holi", "ink", "liquid", "mess", "paint", "spill", "splatter", "stain"]
             }
           ]
         },
@@ -16047,36 +8472,17 @@
             {
               "codepoint": "U+1F202",
               "name": "Japanese “service charge” button",
-              "keywords": [
-                "button",
-                "charge",
-                "Japanese",
-                "katakana",
-                "service"
-              ]
+              "keywords": ["button", "charge", "Japanese", "katakana", "service"]
             },
             {
               "codepoint": "U+1F237",
               "name": "Japanese “monthly amount” button",
-              "keywords": [
-                "amount",
-                "button",
-                "ideograph",
-                "Japanese",
-                "monthly"
-              ]
+              "keywords": ["amount", "button", "ideograph", "Japanese", "monthly"]
             },
             {
               "codepoint": "U+1F236",
               "name": "Japanese “not free of charge” button",
-              "keywords": [
-                "button",
-                "charge",
-                "free",
-                "ideograph",
-                "Japanese",
-                "not"
-              ]
+              "keywords": ["button", "charge", "free", "ideograph", "Japanese", "not"]
             },
             {
               "codepoint": "U+1F22F",
@@ -16116,13 +8522,7 @@
             {
               "codepoint": "U+1F234",
               "name": "Japanese “passing grade” button",
-              "keywords": [
-                "button",
-                "grade",
-                "ideograph",
-                "Japanese",
-                "passing"
-              ]
+              "keywords": ["button", "grade", "ideograph", "Japanese", "passing"]
             },
             {
               "codepoint": "U+1F233",
@@ -16142,13 +8542,7 @@
             {
               "codepoint": "U+1F23A",
               "name": "Japanese “open for business” button",
-              "keywords": [
-                "business",
-                "button",
-                "ideograph",
-                "Japanese",
-                "open"
-              ]
+              "keywords": ["business", "button", "ideograph", "Japanese", "open"]
             },
             {
               "codepoint": "U+1F235",
@@ -16343,18 +8737,7 @@
             {
               "codepoint": "U+1F3C1",
               "name": "chequered flag",
-              "keywords": [
-                "checkered",
-                "chequered",
-                "finish",
-                "flag",
-                "flags",
-                "game",
-                "race",
-                "racing",
-                "sport",
-                "win"
-              ]
+              "keywords": ["checkered", "chequered", "finish", "flag", "flags", "game", "race", "racing", "sport", "win"]
             },
             {
               "codepoint": "U+1F6A9",
@@ -16364,13 +8747,7 @@
             {
               "codepoint": "U+1F38C",
               "name": "crossed flags",
-              "keywords": [
-                "celebration",
-                "cross",
-                "crossed",
-                "flags",
-                "Japanese"
-              ]
+              "keywords": ["celebration", "cross", "crossed", "flags", "Japanese"]
             },
             {
               "codepoint": "U+1F3F4",
@@ -16385,47 +8762,17 @@
             {
               "codepoint": "U+1F3F3 U+FE0F U+200D U+1F308",
               "name": "rainbow flag",
-              "keywords": [
-                "bisexual",
-                "flag",
-                "gay",
-                "genderqueer",
-                "glbt",
-                "glbtq",
-                "lesbian",
-                "lgbt",
-                "lgbtq",
-                "lgbtqia",
-                "pride",
-                "queer",
-                "rainbow",
-                "trans",
-                "transgender"
-              ]
+              "keywords": ["bisexual", "flag", "gay", "genderqueer", "glbt", "glbtq", "lesbian", "lgbt", "lgbtq", "lgbtqia", "pride", "queer", "rainbow", "trans", "transgender"]
             },
             {
               "codepoint": "U+1F3F3 U+FE0F U+200D U+26A7 U+FE0F",
               "name": "transgender flag",
-              "keywords": [
-                "blue",
-                "flag",
-                "light",
-                "pink",
-                "transgender",
-                "white"
-              ]
+              "keywords": ["blue", "flag", "light", "pink", "transgender", "white"]
             },
             {
               "codepoint": "U+1F3F4 U+200D U+2620 U+FE0F",
               "name": "pirate flag",
-              "keywords": [
-                "flag",
-                "Jolly",
-                "pirate",
-                "plunder",
-                "Roger",
-                "treasure"
-              ]
+              "keywords": ["flag", "Jolly", "pirate", "plunder", "Roger", "treasure"]
             }
           ]
         },


### PR DESCRIPTION
This PR updates `assets/unicode-emoji.json` to include 36 new emojis added between Emoji 15.0 and 16.0.

This includes all emojis added in Emoji 15.1 and 16.0, with the exception of skin tone variants.

Additionally:
* The names and keywords for many existing emojis have been updated in accordance with [CLDR v46.1.0](https://github.com/unicode-org/cldr-json/releases/tag/46.1.0)
* Emojis no longer include their own name as a keyword; if this is problematic, it should be relatively easy to add them back
* Subcategory names now use hyphens instead of underscores; if this breaks things it should also be an easy fix